### PR TITLE
PT-FIXES:DOS-4039 Resolve IN through TreeIndex key lookups

### DIFF
--- a/src/foam/dao/index/AndOrderRecord.js
+++ b/src/foam/dao/index/AndOrderRecord.js
@@ -8,7 +8,7 @@ foam.CLASS({
   package: 'foam.dao.index',
   name: 'AndOrderRecord',
 
-  documentation: 'Test record for MDAOAndOrderTest.',
+  documentation: 'Test record for the MDAO index tests in this package.',
 
   properties: [
     { class: 'Long', name: 'id' },

--- a/src/foam/dao/index/TreeIndex.java
+++ b/src/foam/dao/index/TreeIndex.java
@@ -8,12 +8,15 @@ import foam.lang.FObject;
 import foam.lang.Indexer;
 import foam.dao.AbstractDAO;
 import foam.dao.Sink;
+import foam.mlang.ArrayConstant;
+import foam.mlang.Constant;
 import foam.mlang.Expr;
 import foam.mlang.order.Comparator;
 import foam.mlang.predicate.*;
 import foam.mlang.sink.Count;
 import foam.mlang.sink.GroupBy;
 import java.util.Arrays;
+import java.util.List;
 
 public class TreeIndex
   extends AbstractIndex
@@ -145,6 +148,41 @@ public class TreeIndex
         state = ( (TreeNode) state ).lte((TreeNode) state, expr.getArg2().f(expr), indexer_);
         return new Object[] {state, null};
       }
+
+      if ( predicate.getClass().equals(In.class) && expr.getArg1().toString().equals(indexer_.toString()) ) {
+        Object[] keys = inKeys((In) predicate);
+
+        if ( keys != null && worthLookingUp(keys.length, ((TreeNode) state).size) ) {
+          try {
+            TreeNode root = (TreeNode) state;
+            TreeNode out  = TreeNode.getNullNode();
+
+            for ( int i = 0 ; i < keys.length ; i++ ) {
+              TreeNode node = root.get(root, keys[i], indexer_);
+              // get() hands back a node whose value IS the subtree already in
+              // the index, so pointing the new tree at it copies no rows.
+              if ( node != null ) out = out.putKeyTail(out, indexer_, node.key, node.value, tail_);
+            }
+
+            // The predicate is deliberately NOT reported as consumed. The tree
+            // compares keys with the property's comparePropertyToValue, which
+            // casts both sides, while In.f compares them by equals - so the two
+            // disagree on a key like "5" against a Long id. Handing the
+            // predicate back makes this purely a narrowing of the candidate set
+            // and leaves the answer to In.f, which is what a plain scan would
+            // have used. Anything else lets Count (which reads the tree size)
+            // and a row select (which re-tests through ValuePlan) disagree.
+            return new Object[] {out == TreeNode.getNullNode() ? null : out, predicate};
+          } catch ( ClassCastException | NumberFormatException | NullPointerException e ) {
+            // A key the indexer cannot compare against its property - the same
+            // hazard returnKeyForValue() below absorbs. Leaving it to propagate
+            // would be worse than not optimizing: planSelect runs inside
+            // AltIndex's plan auction, which catches Throwable, so this index
+            // would drop out of the auction and the query would quietly return
+            // nothing. Fall through to the scan instead.
+          }
+        }
+      }
     } else if ( predicate instanceof And ) {
       int length = ((And) predicate).getArgs().length;
 
@@ -171,6 +209,64 @@ public class TreeIndex
     if ( p instanceof True ) p = null;
 
     return new Object[] {state, p};
+  }
+
+  /**
+   * Whether k key lookups beat scanning the whole tree.
+   *
+   * An AA tree's height is bounded by 2*log2(n+1), so a lookup walks up to that
+   * many nodes and k of them stop being a bargain once k * height reaches the
+   * row count - an IN listing far more keys than the table holds rows is
+   * cheaper to answer by reading the table. Without this, 200k keys against a
+   * 100-row tree would do 200k walks to build a tree of at most 100 nodes, and
+   * pay it again for every index whose leading property matches, since
+   * planSelect runs once per index in the auction.
+   *
+   * The bound is the honest figure to compare against rather than log2(n): it
+   * also leaves room for what this arithmetic does not count, namely the nodes
+   * the result tree allocates and the cache cost of k random descents against
+   * one sequential pass.
+   */
+  protected static boolean worthLookingUp(int keyCount, long size) {
+    if ( size <= 0 ) return false;
+    long height = 2 * ( 64 - Long.numberOfLeadingZeros(size) );
+    return (long) keyCount * height < size;
+  }
+
+  /**
+   * The keys an In is testing against, or null when they cannot be read at plan
+   * time and the query has to fall back to a scan.
+   *
+   * Only a Constant or an ArrayConstant is unwrapped - the two shapes an In
+   * arrives in, one per side: ExprProperty wraps a client-built array in a
+   * Constant, MLang.prepare turns an Object[] into an ArrayConstant. Anything
+   * else may depend on the object being tested and cannot be evaluated here.
+   *
+   * A null key is refused outright: comparePropertyToValue casts both sides, and
+   * the cast throws on a primitive property, so a null in the list must keep
+   * behaving the way it does under a scan.
+   */
+  protected Object[] inKeys(In predicate) {
+    Expr arg2 = predicate.getArg2();
+
+    if ( ! ( arg2 instanceof Constant ) && ! ( arg2 instanceof ArrayConstant ) ) return null;
+
+    Object   value = arg2.f(null);
+    Object[] keys;
+
+    if ( value instanceof Object[] ) {
+      keys = (Object[]) value;
+    } else if ( value instanceof List ) {
+      keys = ((List) value).toArray();
+    } else {
+      return null;
+    }
+
+    for ( int i = 0 ; i < keys.length ; i++ ) {
+      if ( keys[i] == null ) return null;
+    }
+
+    return keys;
   }
 
   public Object put(Object state, FObject value) {

--- a/src/foam/dao/index/TreeIndexInJsTest.js
+++ b/src/foam/dao/index/TreeIndexInJsTest.js
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.index',
+  name: 'TreeIndexInJsTest',
+  extends: 'foam.core.test.JSTest',
+
+  documentation: `Client-side IN behaviour over an MDAO.
+
+    The JS evaluation path is not the Java one: In.f takes a Set fast path
+    whenever arg2 is a Constant, which is every predicate built in the browser,
+    and it compares members by their string form so that Date and other object
+    values match by value instead of by reference. These assertions pin the row
+    sets that path has to produce, and cover the enum shape the query bar
+    produces, where a string stands in for an enum value.`,
+
+  requires: [
+    'foam.dao.MDAO',
+    'foam.dao.index.AndOrderStatus',
+    'foam.mlang.predicate.In',
+    'foam.mlang.sink.Count'
+  ],
+
+  classes: [
+    {
+      name: 'Rec',
+      properties: [
+        { class: 'Long', name: 'id' },
+        { class: 'Long', name: 'caseId' },
+        { class: 'DateTime', name: 'when' },
+        { class: 'Enum', of: 'foam.dao.index.AndOrderStatus', name: 'status' }
+      ]
+    }
+  ],
+
+  methods: [
+    {
+      name: 'countWhere',
+      code: async function(dao, predicate) {
+        var c = await dao.where(predicate).select(this.Count.create({}));
+        return c.value;
+      }
+    },
+    {
+      name: 'inOn',
+      documentation: 'An IN built the way the browser builds one: arg2 adapts to a Constant.',
+      code: function(prop, values) {
+        return this.In.create({ arg1: prop, arg2: values });
+      }
+    },
+    async function runTest(x) {
+      var dao = this.MDAO.create({ of: this.Rec });
+      dao.addPropertyIndex(this.Rec.CASE_ID);
+
+      var statuses = [ this.AndOrderStatus.INIT, this.AndOrderStatus.WITHDRAWN, this.AndOrderStatus.EXCLUDED ];
+      for ( var i = 1 ; i <= 10 ; i++ ) {
+        await dao.put(this.Rec.create({
+          id:     i,
+          caseId: i % 3,
+          when:   new Date(Date.UTC(2026, 0, i)),
+          status: statuses[i % 3]
+        }));
+      }
+
+      var unsorted = await this.countWhere(dao, this.inOn(this.Rec.ID, [ 9, 1, 5, 4242 ]));
+      x.test(unsorted === 3, 'unsorted keys plus an absent key return three rows; got ' + unsorted);
+
+      var repeated = await this.countWhere(dao, this.inOn(this.Rec.ID, [ 3, 3, 5 ]));
+      x.test(repeated === 2, 'a repeated key is counted once; got ' + repeated);
+
+      var single = await this.countWhere(dao, this.inOn(this.Rec.ID, [ 7 ]));
+      x.test(single === 1, 'IN over one key returns one row; got ' + single);
+
+      var empty = await this.countWhere(dao, this.inOn(this.Rec.ID, []));
+      x.test(empty === 0, 'IN over no keys returns nothing; got ' + empty);
+
+      // caseId is i%3 over 1..10, so 0 -> {3,6,9} and 1 -> {1,4,7,10}.
+      var nonUnique = await this.countWhere(dao, this.inOn(this.Rec.CASE_ID, [ 0, 1 ]));
+      x.test(nonUnique === 7, 'IN on an indexed non-unique property returns every matching row; got ' + nonUnique);
+
+      // The reason the Set path stringifies both sides: a Set matches objects by
+      // reference, so two Date instances at the same instant are different keys.
+      var dates = await this.countWhere(dao, this.inOn(this.Rec.WHEN, [
+        new Date(Date.UTC(2026, 0, 2)),
+        new Date(Date.UTC(2026, 0, 4))
+      ]));
+      x.test(dates === 2, 'IN over Date values matches by value, not reference; got ' + dates);
+
+      // status is i%3 over 1..10: INIT -> {3,6,9}, WITHDRAWN -> {1,4,7,10}.
+      var byEnum = await this.countWhere(dao, this.inOn(this.Rec.STATUS, [ this.AndOrderStatus.INIT ]));
+      x.test(byEnum === 3, 'IN over an enum value matches; got ' + byEnum);
+
+      // What the query bar produces: a string standing in for the enum value.
+      var byEnumName = await this.countWhere(dao, this.inOn(this.Rec.STATUS, [ 'INIT' ]));
+      x.test(byEnumName === 3, 'IN over an enum name string matches; got ' + byEnumName);
+
+      // Lower case too. In.f carries an upperCase_ flag for exactly this, but it
+      // is only read by the loop, which the Constant fast path returns before
+      // reaching - so what makes this work is arg2's adapt coercing the string
+      // to the enum value, not that flag.
+      var byLowerName = await this.countWhere(dao, this.inOn(this.Rec.STATUS, [ 'init' ]));
+      x.test(byLowerName === 3, 'IN over a lower case enum name matches; got ' + byLowerName);
+    }
+  ]
+});

--- a/src/foam/dao/index/TreeIndexInTest.js
+++ b/src/foam/dao/index/TreeIndexInTest.js
@@ -1,0 +1,212 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.dao.index',
+  name: 'TreeIndexInTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `An IN over an indexed property must be answered from the tree
+    rather than by scanning every row, and must return exactly the rows a scan
+    would have returned.
+
+    Two things make that easy to get wrong. The tree compares keys through the
+    property's comparePropertyToValue, which casts both sides, while In.f
+    compares them with equals - so the two disagree on a key like "5" against a
+    Long id. And Count is answered from the tree's size while a row select
+    re-tests the predicate through ValuePlan, so a lookup that trusts the tree's
+    equality makes those two report different things about the same query. Every
+    case below therefore checks the row ids AND that Count agrees with the number
+    of rows returned; a cardinality-only test hides exactly this bug.`,
+
+  javaImports: [
+    'foam.dao.AbstractDAO',
+    'foam.dao.ArraySink',
+    'foam.dao.MDAO',
+    'foam.mlang.Constant',
+    'foam.mlang.Expr',
+    'foam.mlang.predicate.In',
+    'foam.mlang.predicate.Predicate',
+    'java.util.ArrayList',
+    'java.util.Collections',
+    'java.util.List',
+    'static foam.mlang.MLang.*'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        MDAO dao = new MDAO(AndOrderRecord.getOwnClassInfo());
+        dao.addIndex(AndOrderRecord.CASE_ID);
+        for ( long i = 1 ; i <= 1000 ; i++ ) dao.put_(x, mk(i, i % 3, "cb" + i));
+
+        // The shape a browser-built IN arrives in: ExprProperty wraps the array
+        // in a Constant, so arg2 is a Constant holding an Object[].
+        check(x, dao, in(AndOrderRecord.ID, new Object[] {9L, 1L, 5L}),
+          "1,5,9", "IN over Constant(Object[])");
+
+        // The shape MLang.IN builds: prepare() turns an Object[] into an
+        // ArrayConstant, a sibling of Constant rather than a subclass.
+        check(x, dao, IN(AndOrderRecord.ID, new Object[] {9L, 1L, 5L}),
+          "1,5,9", "IN over ArrayConstant");
+
+        // Keys out of ascending order with one that is absent. A min/max range
+        // trim gets this wrong; exact key lookups do not.
+        check(x, dao, in(AndOrderRecord.ID, new Object[] {9L, 1L, 5L, 4242L}),
+          "1,5,9", "unsorted keys plus an absent key");
+
+        // A repeated key must produce one node, not two, or the tree's size
+        // double-counts it.
+        check(x, dao, in(AndOrderRecord.ID, new Object[] {3L, 3L, 5L}),
+          "3,5", "a repeated key");
+
+        // Both go through MLang.IN: In.partialEval rewrites the Constant shape
+        // (0 keys to FALSE, 1 key to Eq) before the index ever sees it, so only
+        // the ArrayConstant shape actually exercises the lookup.
+        check(x, dao, IN(AndOrderRecord.ID, new Object[] {7L}), "7", "one key");
+        check(x, dao, IN(AndOrderRecord.ID, new Object[] {}), "", "no keys");
+
+        // Non-unique index: every row behind each key, through a TreeIndex tail
+        // rather than a ValueIndex. caseId is i%3 over 1..1000, so 0 covers 333
+        // rows and 1 covers 334.
+        long nonUnique = consistentCount(x, dao, in(AndOrderRecord.CASE_ID, new Object[] {0L, 1L}));
+        test(nonUnique == 667, "IN on a non-unique index returns every row behind each key; got " + nonUnique);
+
+        // Unindexed property: the lookup declines and the scan filters.
+        check(x, dao, in(AndOrderRecord.CB, new Object[] {"cb2", "cb4"}),
+          "2,4", "IN on an unindexed property");
+
+        // A null key cannot reach the tree - cast(null) throws on a primitive
+        // property - so this must fall back to the scan.
+        check(x, dao, in(AndOrderRecord.ID, new Object[] {null, 3L}),
+          "3", "a null key");
+
+        // A String key against a Long id: the tree matches it (cast coerces),
+        // In.f does not (equals). Whatever the answer is, Count and a row select
+        // have to agree on it, and it has to be the answer a scan gives - which
+        // is none, because In.f decides. EQ says 1 here, because Binary coerces
+        // its Constant while ArrayBinary leaves an ArrayConstant alone; that
+        // asymmetry lives in predicate construction, not in this index.
+        check(x, dao, IN(AndOrderRecord.ID, new Object[] {"5"}),
+          "", "a String key against a Long id");
+
+        // A key no cast can handle must degrade to the scan rather than throw
+        // inside the plan auction, where AltIndex would swallow it and answer
+        // nothing at all.
+        check(x, dao, IN(AndOrderRecord.ID, new Object[] {"not-a-number", 3L}),
+          "3", "an uncomparable key alongside a good one");
+
+        planCosts(x);
+      `
+    },
+    {
+      name: 'planCosts',
+      args: 'X x',
+      documentation: `Cost is what proves the index answered the query: a scan
+        costs the row count, a lookup costs the number of matches. Also pins the
+        guard that declines the lookup when it would cost more than a scan.`,
+      javaCode: `
+        TreeIndex idx   = new TreeIndex(AndOrderRecord.ID, true);
+        Object    state = null;
+        for ( long i = 1 ; i <= 1000 ; i++ ) state = idx.put(state, mk(i, i % 3, "cb" + i));
+
+        long cost = idx.planSelect(state, null, 0, AbstractDAO.MAX_SAFE_INTEGER, null,
+          in(AndOrderRecord.ID, new Object[] {9L, 1L, 5L})).cost();
+        test(cost == 3, "IN plan costs the 3 matches, not the 1000 rows; got " + cost);
+
+        // More keys than the tree has rows: looking each one up costs more than
+        // reading the table, so the plan must stay a scan.
+        Object[] many = new Object[2000];
+        for ( int i = 0 ; i < many.length ; i++ ) many[i] = (long) i;
+        long scanCost = idx.planSelect(state, null, 0, AbstractDAO.MAX_SAFE_INTEGER, null,
+          in(AndOrderRecord.ID, many)).cost();
+        test(scanCost == 1000, "an IN listing more keys than rows stays a scan; got " + scanCost);
+
+        // In.f's HashSet fast path has to cover the ArrayConstant shape too, or
+        // every MLang.IN caller keeps paying the O(n) compareTo loop.
+        In arrayIn = (In) IN(AndOrderRecord.ID, new Object[] {9L, 1L, 5L});
+        arrayIn.f(mk(9, 0, "cb9"));
+        test(arrayIn.getArg2AsSet() != null, "IN over ArrayConstant builds the HashSet fast path");
+      `
+    },
+    {
+      name: 'check',
+      args: 'X x, foam.dao.MDAO dao, foam.mlang.predicate.Predicate p, String expectedIds, String what',
+      documentation: 'Asserts the exact rows, and that Count agrees with them.',
+      javaCode: `
+        String got = ids(x, dao, p);
+        test(expectedIds.equals(got), what + " returns rows [" + expectedIds + "]; got [" + got + "]");
+        consistentCount(x, dao, p);
+      `
+    },
+    {
+      name: 'consistentCount',
+      args: 'X x, foam.dao.MDAO dao, foam.mlang.predicate.Predicate p',
+      type: 'Long',
+      documentation: `Count reads the tree size; a row select re-tests the
+        predicate. They must report the same thing about the same query.`,
+      javaCode: `
+        long counted = ((foam.mlang.sink.Count) dao.inX(x).where(p)
+          .select(new foam.mlang.sink.Count())).getValue();
+        long selected = rows(x, dao, p).size();
+        test(counted == selected,
+          "count agrees with the rows returned for " + p + "; count " + counted + ", rows " + selected);
+        return counted;
+      `
+    },
+    {
+      name: 'rows',
+      args: 'X x, foam.dao.MDAO dao, foam.mlang.predicate.Predicate p',
+      type: 'java.util.List',
+      javaCode: `
+        return ((ArraySink) dao.inX(x).where(p).select(new ArraySink())).getArray();
+      `
+    },
+    {
+      name: 'ids',
+      args: 'X x, foam.dao.MDAO dao, foam.mlang.predicate.Predicate p',
+      type: 'String',
+      javaCode: `
+        List<Long> found = new ArrayList<>();
+        for ( Object o : rows(x, dao, p) ) found.add(((AndOrderRecord) o).getId());
+        Collections.sort(found);
+
+        StringBuilder b = new StringBuilder();
+        for ( int i = 0 ; i < found.size() ; i++ ) {
+          if ( i > 0 ) b.append(',');
+          b.append(found.get(i));
+        }
+        return b.toString();
+      `
+    },
+    {
+      name: 'in',
+      documentation: `An IN whose arg2 is a Constant holding the array, which is
+        what ExprProperty.adaptValue produces for a client-built predicate.`,
+      args: 'foam.mlang.Expr arg1, Object[] keys',
+      type: 'foam.mlang.predicate.Predicate',
+      javaCode: `
+        In in = new In();
+        in.setArg1(arg1);
+        in.setArg2(new Constant(keys));
+        return in;
+      `
+    },
+    {
+      name: 'mk',
+      args: 'long id, long caseId, String cb',
+      type: 'foam.dao.index.AndOrderRecord',
+      javaCode: `
+        AndOrderRecord r = new AndOrderRecord();
+        r.setId(id);
+        r.setCaseId(caseId);
+        r.setCb(cb);
+        return r;
+      `
+    }
+  ]
+});

--- a/src/foam/dao/index/TreeNode.java
+++ b/src/foam/dao/index/TreeNode.java
@@ -107,6 +107,38 @@ public class TreeNode {
     return split(skew(state, tail), tail);
   }
 
+  /**
+   * Insert a key whose value is an already-built tail state, rather than an
+   * FObject to be put into the tail.
+   *
+   * Lets a caller assemble a tree out of nodes an existing tree handed back, so
+   * pulling k keys out of an index costs k pointer inserts instead of copying
+   * every row behind them. A key already present is left alone rather than
+   * merged: the caller is collecting distinct keys, and re-inserting one would
+   * add its tail size to the tree a second time.
+   */
+  public TreeNode putKeyTail(TreeNode state, Indexer indexer, Object key, Object tailValue, Index tail) {
+    if ( state == null || state.equals(TreeNode.getNullNode()) ) {
+      return new TreeNode(key, tailValue, tail.size(tailValue), (byte) 1, null, null);
+    }
+    state = maybeClone(state);
+    int r = indexer.comparePropertyToValue(key, state.key);
+
+    if ( r == 0 ) return state;
+
+    if ( r < 0 ) {
+      if ( state.left != null ) state.size -= state.left.size;
+      state.left  = this.putKeyTail(state.left, indexer, key, tailValue, tail);
+      state.size += state.left.size;
+    } else {
+      if ( state.right != null ) state.size -= state.right.size;
+      state.right = this.putKeyTail(state.right, indexer, key, tailValue, tail);
+      state.size += state.right.size;
+    }
+
+    return split(skew(state, tail), tail);
+  }
+
   public TreeNode skew(TreeNode node, Index tail) {
     /** 'node' should be a new (cloned) TreeNode, not a reused one. **/
     if ( node != null && node.left != null && node.left.level == node.level ) {

--- a/src/foam/dao/index/tests.jrl
+++ b/src/foam/dao/index/tests.jrl
@@ -1,2 +1,4 @@
 p({"class":"foam.dao.index.PersistedIndexTest","id":"PersistedIndex test","description":"tests the persisted index feature"})
 p({"class":"foam.dao.index.MDAOAndOrderTest","id":"MDAOAndOrderTest","description":"where(A).where(B) must equal where(AND(A,B)) for MDAO tree-index counts"})
+p({"class":"foam.dao.index.TreeIndexInTest","id":"TreeIndexInTest","description":"IN over an indexed property is answered from the tree, not by a full scan"})
+p({"class":"foam.dao.index.TreeIndexInJsTest","id":"TreeIndexInJsTest","description":"client-side IN row sets over an MDAO", language: 0})

--- a/src/foam/mlang/predicate/In.js
+++ b/src/foam/mlang/predicate/In.js
@@ -114,8 +114,11 @@ return false
   Object lhs = getArg1().f(obj);
   Object rhs = getArg2().f(obj);
 
-  // Fast path when arg2 is a Constant of Object[]
-  if ( getArg2() instanceof Constant ) {
+  // Fast path when arg2 holds a constant Object[]. ArrayConstant is a sibling
+  // of Constant, not a subclass, and it is what MLang.prepare() builds for an
+  // Object[] - so both have to be named or every MLang.IN caller keeps paying
+  // the O(n) compareTo loop below.
+  if ( getArg2() instanceof Constant || getArg2() instanceof ArrayConstant ) {
     if ( rhs instanceof Object[] ) {
       Set set = getArg2AsSet();
       if ( set == null ) {

--- a/src/pom.js
+++ b/src/pom.js
@@ -364,6 +364,8 @@ foam.POM({
     { name: "foam/dao/index/AndOrderStatus",                          flags: "js&test|java&test" },
     { name: "foam/dao/index/AndOrderRecord",                          flags: "js&test|java&test" },
     { name: "foam/dao/index/MDAOAndOrderTest",                        flags: "js&test|java&test" },
+    { name: "foam/dao/index/TreeIndexInTest",                         flags: "js&test|java&test" },
+    { name: "foam/dao/index/TreeIndexInJsTest",                       flags: "js&test|java&test" },
     { name: "foam/dao/MDAO",                                          flags: "js" },
     { name: "foam/dao/ArrayDAO",                                      flags: "js|java" },
     { name: "foam/dao/CopyOnWriteDAO",                                flags: "js|java" },


### PR DESCRIPTION

`TreeIndex.simplifyPredicate` narrows the tree for `Eq`, `Gt`, `Gte`, `Lt` and `Lte`, but an `In` falls through to a full `ScanPlan` — so an `IN` over an indexed property visits every row even when it lists three keys.

This adds the `In` case: one `TreeNode.get` per key, assembling a tree whose nodes point at the subtrees already held in the index, so no row is copied.

```
IN(id, {9, 1, 5}) over 1000 rows
  before: ScanPlan, cost 1000
  after:  ScanPlan over 3 nodes, cost 3
```

- **Hands the predicate back rather than reporting it consumed** — the tree compares keys through `comparePropertyToValue`, which casts both sides, while `In.f` compares with `equals`; the two disagree on a key like `"5"` against a `Long` id. Consuming the predicate would let `Count`, which reads the tree size, and a row select, which re-tests through `ValuePlan`, answer differently about the same query. Narrowing the candidate set and leaving the verdict to `In.f` keeps the result identical to a scan.

- **Declines when a scan is cheaper** — an AA tree's height is bounded by `2*log2(n+1)`, so `k * height >= size` stays a scan. Without that, an `IN` listing far more keys than the table holds rows would pay k descents to build a tree of at most `size` nodes, once per index whose leading property matches, since `planSelect` runs for every index in the auction. Comparing against the height bound rather than `log2(n)` also leaves room for what the arithmetic omits: the nodes the result tree allocates, and k random descents against one sequential pass.

- **Falls back on a key it cannot compare** — `cast` throws on a wrong-typed key, and `planSelect` runs inside `AltIndex`'s plan auction, which catches `Throwable`; unguarded, the index drops out of the auction and the query quietly answers nothing.

- **`In.f`'s HashSet fast path now covers `ArrayConstant`** — `MLang.prepare` builds one for any `Object[]`, and it is a sibling of `Constant` rather than a subclass, so those callers were still paying the `compareTo` loop per row.

`TreeNode.putKeyTail` is the new insert: it takes an already-built tail state instead of an `FObject`, so assembling the result costs k pointer inserts instead of copying every row behind each key.

`TreeIndexInTest` covers the server path and asserts the row ids plus that `Count` agrees with the rows returned in every case, including a non-unique index, a null key, an uncomparable key, and the plan cost that proves the index answered rather than scanned. `TreeIndexInJsTest` covers the JS evaluation path, including `Date` keys matching by value and the enum shapes.