### PR TITLE
fix(u2): scope group header prop/obj locally in UnstyledTableGroup

### DIFF
--- a/src/foam/u2/table/UnstyledTableGroup.js
+++ b/src/foam/u2/table/UnstyledTableGroup.js
@@ -73,7 +73,9 @@ foam.CLASS({
       }).
 
       style({ 'min-width': this.table.tableWidth_$ });
-      [prop, objReturned] = this.getCellData(objForCurrentProperty, this.table.groupBy, nestedPropertiesObjsMap);
+      // var keeps these per-group: without it they leak to globals shared by
+      // every group and table cell, breaking any reader that runs after render.
+      var [prop, objReturned] = this.getCellData(objForCurrentProperty, this.table.groupBy, nestedPropertiesObjsMap);
       this.start().addClass(self.table.myClass('group-content'),'h500')
         .start('span')
           .style({ flex: '3 0 0' })

--- a/src/foam/u2/table/UnstyledTableGroup.js
+++ b/src/foam/u2/table/UnstyledTableGroup.js
@@ -73,7 +73,7 @@ foam.CLASS({
       }).
 
       style({ 'min-width': this.table.tableWidth_$ });
-      // var keeps these per-group: without it they leak to globals shared by
+      // var keeps these per-group:- without it they leak to globals shared by
       // every group and table cell, breaking any reader that runs after render.
       var [prop, objReturned] = this.getCellData(objForCurrentProperty, this.table.groupBy, nestedPropertiesObjsMap);
       this.start().addClass(self.table.myClass('group-content'),'h500')


### PR DESCRIPTION
## Problem

`UnstyledTableGroup.render()` destructures without `var`:

```javascript
[prop, objReturned] = this.getCellData(...);
```

Bare destructuring assignment creates/overwrites **window globals** shared by every group header (and any other code reading those names). Today the readers are synchronous so it renders correctly, but any deferred reader — a click handler, a listener added later — would see the last-rendered group's values instead of its own.

The identical pattern in `UnstyledTableRow` caused exactly that bug when #5304 added a click-time reader (every copy button copied the last-rendered row) and was fixed there; this closes the remaining instance.

## Fix

Declare with `var` so the values stay local to each `render()` call. No behavior change today; removes the trap for future deferred readers and stops the global namespace pollution.