### PR TITLE
lsp: references find javaCode/javaImports usages + member call-site lines (#5265)

### DIFF
--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -2015,6 +2015,25 @@ foam.CLASS({
     // every Java-side reference. Same fact pattern as the JS usage scan,
     // different axiom slots.
 
+    function javaImportPaths(cls) {
+      /**
+       * The class's javaImports as plain path strings, whichever form the
+       * model holds: raw strings (FileModelCache / pre-refinement) or
+       * foam.java.JavaImport objects ({ import: 'full.path', name: generated
+       * 'javaimport_'+import label }) — what a real boot's java refinements
+       * produce. Single normalization point: do NOT unwrap javaImports
+       * shapes anywhere else.
+       */
+      var ji  = cls && cls.model_ && cls.model_.javaImports || [];
+      var out = [];
+      for ( var i = 0 ; i < ji.length ; i++ ) {
+        var e = ji[i];
+        if ( typeof e === 'string' )                  out.push(e);
+        else if ( e && typeof e.import === 'string' ) out.push(e.import);
+      }
+      return out;
+    },
+
     function getJavaUsages(classId) {
       if ( ! this.javaUsageIndex_ ) this.buildJavaUsageIndex_();
       return this.javaUsageIndex_.byTarget[classId] || [];
@@ -2041,13 +2060,12 @@ foam.CLASS({
         var cls      = this.getClass(sourceId);
         if ( ! cls ) continue;
 
-        var javaImports = cls.model_ && cls.model_.javaImports || [];
+        var javaImports = this.javaImportPaths(cls);
         if ( javaImports.length === 0 && ! (cls.model_ && cls.model_.package) ) continue;
 
         var importLookup = {};
         for ( var x = 0 ; x < javaImports.length ; x++ ) {
           var imp = javaImports[x];
-          if ( typeof imp !== 'string' ) continue;
           if ( imp.indexOf('*') !== -1 ) continue;
           var parts = imp.split('.');
           importLookup[parts[parts.length - 1]] = imp;

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -748,10 +748,11 @@ function main() {
           instructions:
             'foam_* tools answer FOAM structure questions from the live registry: ' +
             'hierarchy (subclasses/implementors), definitions (even when filename != ' +
-            'class name), substring symbol search, hover docs/types. Blind spots — ' +
-            'grep instead for: .jrl string references, javaImports/javaCode usages, ' +
-            'property-usage sweeps, refined property types, exact member call-site ' +
-            'lines. Name-addressable: symbol: "DetailView", a class id, or ' +
+            'class name), substring symbol search, hover docs/types, javaCode usages, ' +
+            'member call-site lines. Blind spots — ' +
+            'grep instead for: .jrl string references, ' +
+            'property-usage sweeps, refined property types. ' +
+            'Name-addressable: symbol: "DetailView", a class id, or ' +
             '"Class.member". First call boots the LSP (~10-15s). Index reflects the ' +
             'checkout, not uncommitted edits — read changed files directly.'
         });

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -155,8 +155,34 @@ foam.CLASS({
       var classId = this.cache.getClassId(model);
       if ( ! classId ) return null;
 
-      // Collect files to scan: the defining class + every subclass (they
-      // inherit the property and commonly reference it).
+      return this.memberScanLocations_(classId, word);
+    },
+
+    function memberReferencesForClassId(classId, memberName) {
+      /**
+       * By-id member references — the name-addressed (foam/byName) twin of
+       * propertyReferences_/axiomReferences_. Returns call-site Locations
+       * when memberName is an own property, message, or constant of classId;
+       * null otherwise so the caller falls back to class references
+       * (methods stay on callHierarchy, which already has call sites).
+       */
+      var cls = typeof this.index.getClass === 'function' ?
+        this.index.getClass(classId) : null;
+      var model = cls && cls.model_;
+      if ( ! model ) return null;
+      if ( ! ( this.isOwnPropertyName_(model, memberName) ||
+               this.isOwnMessageName_(model, memberName)  ||
+               this.isOwnConstantName_(model, memberName) ) ) return null;
+      return this.memberScanLocations_(classId, memberName);
+    },
+
+    function memberScanLocations_(classId, word) {
+      /**
+       * Collect files to scan — the defining class + every subclass (they
+       * inherit the member and commonly reference it) + classes that REQUIRE
+       * or have `of: classId` (they access it through a typed variable) —
+       * then emit every call-site Location for `word` across that set.
+       */
       var seen = {};
       var filesToScan = [];
       function addFile(id) {
@@ -167,9 +193,6 @@ foam.CLASS({
       addFile(classId);
       var subs = this.transitiveSubclasses_(classId);
       for ( var i = 0 ; i < subs.length ; i++ ) addFile(subs[i]);
-
-      // Also include classes that REQUIRE or have `of: classId` — they likely
-      // access the property through a typed variable.
       var reqs = this.index.getRequirers(classId);
       var ofs  = this.index.getOfUsers(classId);
       for ( var i = 0 ; i < reqs.length ; i++ ) addFile(reqs[i]);
@@ -209,25 +232,7 @@ foam.CLASS({
 
       // Same scoping as property references — own class + transitive
       // subclasses + requirers + of-users.
-      var seen = {};
-      var files = [];
-      function addFile(id) {
-        if ( ! id || seen[id] ) return;
-        seen[id] = true; files.push(id);
-      }
-      addFile(classId);
-      var subs = this.transitiveSubclasses_(classId);
-      for ( var i = 0 ; i < subs.length ; i++ ) addFile(subs[i]);
-      var reqs = this.index.getRequirers(classId);
-      var ofs  = this.index.getOfUsers(classId);
-      for ( var i = 0 ; i < reqs.length ; i++ ) addFile(reqs[i]);
-      for ( var i = 0 ; i < ofs.length ; i++ )   addFile(ofs[i]);
-
-      var locations = [];
-      for ( var i = 0 ; i < files.length ; i++ ) {
-        this.scanPropertyRefs_(files[i], word, locations);
-      }
-      return locations;
+      return this.memberScanLocations_(classId, word);
     },
 
     function isOwnMessageName_(model, word) {

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -89,11 +89,15 @@ foam.CLASS({
       try {
         var jsUses = this.index.getJsUsages(classId);
         for ( var i = 0 ; i < jsUses.length ; i++ ) add(jsUses[i].sourceClassId);
-      } catch (e) {}
+      } catch (e) {
+        console.error('[foam-lsp] getJsUsages failed for ' + classId + ': ' + e.message);
+      }
       try {
         var javaUses = this.index.getJavaUsages(classId);
         for ( var i = 0 ; i < javaUses.length ; i++ ) add(javaUses[i].sourceClassId);
-      } catch (e) {}
+      } catch (e) {
+        console.error('[foam-lsp] getJavaUsages failed for ' + classId + ': ' + e.message);
+      }
       // Class-name strings ARE valid context keys too (e.g. CSpec id matches
       // the dotted class id of its result type) — pick those up via the
       // string-reference index keyed on either the short name or the full id.
@@ -103,7 +107,9 @@ foam.CLASS({
         for ( var i = 0 ; i < strUses.length ; i++ ) {
           if ( strUses[i].sourceClassId ) add(strUses[i].sourceClassId);
         }
-      } catch (e) {}
+      } catch (e) {
+        console.error('[foam-lsp] getStringUsages failed for ' + classId + ': ' + e.message);
+      }
       // Classes that reference the target ONLY inside a view spec
       // (`view: { class: 'X' }`, searchView, rowView, defaultNewItem, …)
       // declare no requires/of for it — the view-spec index is the only edge
@@ -111,7 +117,9 @@ foam.CLASS({
       try {
         var viewUses = this.index.getViewSpecUsers(classId);
         for ( var i = 0 ; i < viewUses.length ; i++ ) add(viewUses[i].sourceClassId);
-      } catch (e) {}
+      } catch (e) {
+        console.error('[foam-lsp] getViewSpecUsers failed for ' + classId + ': ' + e.message);
+      }
 
       // Dedup by position: a file defining several classes is scanned once
       // per class, so identical rows repeat without this. Order-preserving.

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -113,10 +113,19 @@ foam.CLASS({
         for ( var i = 0 ; i < viewUses.length ; i++ ) add(viewUses[i].sourceClassId);
       } catch (e) {}
 
+      // Dedup by position: a file defining several classes is scanned once
+      // per class, so identical rows repeat without this. Order-preserving.
       var locations = [];
+      var seenLoc   = {};
       for ( var i = 0 ; i < refs.length ; i++ ) {
         var locs = this.buildLocations_(refs[i], classId);
-        for ( var j = 0 ; j < locs.length ; j++ ) locations.push(locs[j]);
+        for ( var j = 0 ; j < locs.length ; j++ ) {
+          var loc = locs[j];
+          var key = loc.uri + ':' + loc.range.start.line + ':' + loc.range.start.character;
+          if ( seenLoc[key] ) continue;
+          seenLoc[key] = true;
+          locations.push(loc);
+        }
       }
       return locations;
     },

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -584,9 +584,11 @@ foam.CLASS({
         }
         if ( path === targetClassId && alias ) out[alias] = true;
       }
-      var ji = cls.model_.javaImports || [];
+      // Normalized by FoamIndex.javaImportPaths — never unwrap shapes here.
+      var ji = typeof this.index.javaImportPaths === 'function' ?
+        this.index.javaImportPaths(cls) : [];
       for ( var i = 0 ; i < ji.length ; i++ ) {
-        var imp = typeof ji[i] === 'string' ? ji[i] : ( ji[i] && ji[i].path );
+        var imp = ji[i];
         if ( imp === targetClassId ) {
           var sh = imp.split('.').pop();
           if ( sh ) out[sh] = true;

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -216,8 +216,16 @@ function start() {
         }
         return hoverHandler.buildClassHover(classId);
       }
-      case 'references':
+      case 'references': {
+        // Class.member: return the member's call-site lines when the member
+        // scan recognizes it (own property/message/constant); null falls
+        // back to class references (methods go through callHierarchy).
+        if ( info.memberName ) {
+          var mLocs = referencesHandler.memberReferencesForClassId(classId, info.memberName);
+          if ( mLocs ) return mLocs;
+        }
         return referencesHandler.referencesForClassId(classId);
+      }
       case 'implementation': {
         var targets = index.isInterface(classId) ?
           index.getImplementors(classId) : index.getSubclasses(classId);

--- a/tools/tests/lsp/usageIndex.js
+++ b/tools/tests/lsp/usageIndex.js
@@ -419,3 +419,44 @@ try {
 } catch (err) {
   test(false, 'ArraySink acceptance threw: ' + err.message);
 }
+
+
+// === memberReferencesForClassId — property call-site LINES (byName path) ===
+//
+// foam/byName `references` ignored memberName: Class.member returned class
+// references, never the member's call-site lines (#5265-adjacent blind spot,
+// verified 2026-08-23: byNameResult had no member branch). The by-id core of
+// propertyReferences_ now serves it. Truth is self-derived: the expected
+// line is found by scanning the real source file, so upstream churn moves
+// the expectation instead of breaking it.
+
+section('memberReferencesForClassId — property call-site lines (byName member path)');
+
+try {
+  var mrHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+    index: index, cache: cache, analyzer: analyzer
+  });
+
+  var mrLocs = mrHandler.memberReferencesForClassId('foam.dao.ArraySink', 'array');
+  test(Array.isArray(mrLocs) && mrLocs.length > 0,
+    'memberReferencesForClassId(ArraySink, array): returns locations');
+
+  var mrFs    = require('fs');
+  var mrPath  = index.getFilePath('foam.dao.ArraySink');
+  var mrLines = mrFs.readFileSync(mrPath, 'utf8').split('\n');
+  var mrPushLine = -1;
+  for ( var mi = 0 ; mi < mrLines.length ; mi++ ) {
+    if ( mrLines[mi].indexOf('this.array.push') !== -1 ) { mrPushLine = mi; break; }
+  }
+  test(mrPushLine !== -1, 'fixture: ArraySink.js still has a this.array.push call site');
+  test((mrLocs || []).some(function(l) {
+    return l.uri === 'file://' + mrPath && l.range.start.line === mrPushLine;
+  }), 'usage LINE matched: this.array.push call site at line ' + mrPushLine + ' (not the declaration)');
+
+  // Not an own property/message/constant: null so the caller falls back to
+  // class references (methods keep going through callHierarchy).
+  test(mrHandler.memberReferencesForClassId('foam.dao.ArraySink', 'noSuchMember') === null,
+    'unknown member returns null (falls back to class references)');
+} catch (err) {
+  test(false, 'member references section threw: ' + err.message);
+}

--- a/tools/tests/lsp/usageIndex.js
+++ b/tools/tests/lsp/usageIndex.js
@@ -336,3 +336,86 @@ try {
   console.error = lcOrigErr;
   test(false, 'logged-catch section threw: ' + err.message);
 }
+
+
+// === FoamIndex Java usage — cross-package via javaImports (issue #5265) ===
+//
+// The fixture above puts Source and Target in the SAME package, so it
+// resolves through the package fallback and never exercises the javaImports
+// lookup. These classes are cross-package on purpose: only javaImports can
+// resolve the short name. Fixture provenance: at boot the java refinements
+// adapt each javaImports string into a foam.java.JavaImport object
+// ({ name: generated 'javaimport_'+import label, import: full path }) —
+// the form production hands buildJavaUsageIndex_, and the form these
+// runtime-declared classes carry too (probed 2026-08-23).
+
+section('FoamIndex Java usage — cross-package javaImports (issue #5265)');
+
+foam.CLASS({
+  package: 'foam.parse.lsp.javausagetest.pkga',
+  name:    'CrossPkgTarget'
+});
+
+foam.CLASS({
+  package: 'foam.parse.lsp.javausagetest.pkgb',
+  name:    'CrossPkgSource',
+  javaImports: [ 'foam.parse.lsp.javausagetest.pkga.CrossPkgTarget' ],
+  methods: [
+    {
+      name:     'doIt',
+      javaCode: 'CrossPkgTarget t = new CrossPkgTarget();\nreturn t.toString();'
+    }
+  ]
+});
+
+index.invalidateSymbolIndex_();
+
+try {
+  // Provenance guard: if FOAM ever stops adapting strings to JavaImport
+  // objects, this fixture no longer represents production — fail loudly.
+  var xSrc = foam.maybeLookup('foam.parse.lsp.javausagetest.pkgb.CrossPkgSource');
+  var xJi  = xSrc.model_.javaImports[0];
+  test(xJi && typeof xJi !== 'string' && typeof xJi.import === 'string',
+    'fixture provenance: javaImports adapted to JavaImport objects at boot');
+
+  // T1a: cross-package javaCode consumer recorded.
+  var xUses = index.getJavaUsages('foam.parse.lsp.javausagetest.pkga.CrossPkgTarget');
+  test(xUses.some(function(u) { return u.sourceClassId === 'foam.parse.lsp.javausagetest.pkgb.CrossPkgSource'; }),
+    'cross-package javaCode consumer recorded via JavaImport object (issue #5265)');
+
+  // T1b: the generated JavaImport.name label is never a usage key.
+  test(index.getJavaUsages('javaimport_foam.parse.lsp.javausagetest.pkga.CrossPkgTarget').length === 0,
+    'generated javaimport_ label is not a usage key');
+} catch (err) {
+  test(false, 'cross-package java usage threw: ' + err.message);
+}
+
+
+// === Spec acceptance (issue #5265 repro): real workspace consumer ===
+//
+// Pinned to real foam3 classes on purpose — this is the literal issue repro.
+// If upstream churn ever removes DisableOldReferralCodesRuleAction, replace
+// with a committed fixture file registered under a test pom (spec, Testing).
+
+section('getJavaUsages — real workspace acceptance (issue #5265)');
+
+try {
+  var arraySinkUses = index.getJavaUsages('foam.dao.ArraySink');
+  test(arraySinkUses.some(function(u) {
+    return u.sourceClassId === 'foam.core.referral.DisableOldReferralCodesRuleAction';
+  }), 'issue #5265 repro: DisableOldReferralCodesRuleAction recorded as javaCode consumer of ArraySink');
+
+  // Location level (T2a): the consumer's FILE appears at usage lines —
+  // depends on the index fix; the handler + dedup landed in the earlier
+  // stacked tasks (execution order: Task 2 -> Task 3 -> this task).
+  var asHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+    index: index, cache: cache, analyzer: analyzer
+  });
+  var drcLocs = asHandler.referencesForClassId('foam.dao.ArraySink').filter(function(l) {
+    return l.uri.indexOf('DisableOldReferralCodesRuleAction.js') !== -1;
+  });
+  test(drcLocs.length >= 2,
+    'referencesForClassId(ArraySink): javaCode-only consumer file present at usage lines (got ' + drcLocs.length + ')');
+} catch (err) {
+  test(false, 'ArraySink acceptance threw: ' + err.message);
+}

--- a/tools/tests/lsp/usageIndex.js
+++ b/tools/tests/lsp/usageIndex.js
@@ -276,3 +276,30 @@ try {
 } catch (err) {
   test(false, 'ReferencesHandler threw: ' + err.message + ' :: ' + (err.stack || '').split('\n').slice(0,3).join(' | '));
 }
+
+
+// === referencesForClassId — no duplicate rows + javaCode consumer file ===
+//
+// Dup cause: a file defining multiple classes gets a full-file
+// buildLocations_ scan once per defined class (live measurement 2026-08-23:
+// Commands.js:338:15 repeated for foam.core.boot.CSpec).
+
+section('referencesForClassId — dedup + java consumer locations');
+
+try {
+  var dedupHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+    index: index, cache: cache, analyzer: analyzer
+  });
+
+  // T2c: no repeated uri:line:char row for a class defined among multi-class files.
+  var cspecLocs = dedupHandler.referencesForClassId('foam.core.boot.CSpec');
+  var locSeen = {}, dupCount = 0;
+  for ( var li = 0 ; li < cspecLocs.length ; li++ ) {
+    var lk = cspecLocs[li].uri + ':' + cspecLocs[li].range.start.line + ':' + cspecLocs[li].range.start.character;
+    if ( locSeen[lk] ) dupCount++;
+    locSeen[lk] = true;
+  }
+  test(dupCount === 0, 'referencesForClassId(CSpec): no duplicate uri:line:char rows (dups: ' + dupCount + ')');
+} catch (err) {
+  test(false, 'dedup section threw: ' + err.message);
+}

--- a/tools/tests/lsp/usageIndex.js
+++ b/tools/tests/lsp/usageIndex.js
@@ -303,3 +303,36 @@ try {
 } catch (err) {
   test(false, 'dedup section threw: ' + err.message);
 }
+
+
+// === referencesForClassId — index failures logged, not swallowed ===
+//
+// The four usage-index lookups were wrapped in bare catch(e){} — a broken
+// index was indistinguishable from "no usages" (how #5265 shipped unseen).
+
+section('referencesForClassId — index failures are logged');
+
+var lcOrigErr = console.error;
+try {
+  var lcHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+    index: index, cache: cache, analyzer: analyzer
+  });
+
+  var lcOrig = index.getJavaUsages;
+  index.getJavaUsages = function() { throw new Error('boom-java-index'); };
+  var lcMsgs = [];
+  console.error = function(m) { lcMsgs.push(String(m)); };
+
+  var lcLocs = lcHandler.referencesForClassId('foam.dao.ArraySink');
+
+  console.error = lcOrigErr;
+  index.getJavaUsages = lcOrig;
+
+  test(Array.isArray(lcLocs) && lcLocs.length > 0,
+    'throwing index still returns the other indexes\' locations');
+  test(lcMsgs.some(function(m) { return m.indexOf('boom-java-index') !== -1 && m.indexOf('foam.dao.ArraySink') !== -1; }),
+    'index failure logged with error message and target class');
+} catch (err) {
+  console.error = lcOrigErr;
+  test(false, 'logged-catch section threw: ' + err.message);
+}


### PR DESCRIPTION
Fixes #5265

## Problem

`foam_references` / textDocument/references returned nothing for classes whose only consumers are server-side: `javaImports` + `javaCode` usages were invisible, so classes like `foam.dao.ArraySink` looked dead when used only from Java-side code. Member references (`Class.member`) also pointed at the class declaration instead of call-site lines.

## Root cause

`model_.javaImports` entries are adapted at model-build time into `foam.java.JavaImport` objects (`{name: 'javaimport_' + import, import}`), but the usage index did string-only lookups on them, so every import edge silently dropped. The existing test fixture masked this: its consumer classes live in the same package as the target, where no import is needed.

## Changes

- `FoamIndex.javaImportPaths(cls)` — single normalization boundary for javaImports (accepts both string and JavaImport-object forms); `shortNamesFor_` fixed to use it. Core #5265 fix.
- Member call-site lines: shared `memberScanLocations_` core + `memberReferencesForClassId`, with server routing for `Class.member` byName references — results now land on the actual call-site lines.
- Reference rows deduplicated by position (previously duplicate rows when a file matched via multiple probes).
- Silent catches in the usage-index path now log instead of swallowing.
- MCP server instructions updated: `javaCode usages` and `member call-site lines` removed from the blind-spot list (both fixed here).

## Testing

- Full LSP suite: 1124 passed, 0 failed (usage-index category 41/0).
- Live check over the real MCP server (stdio): `ArraySink` → 240 reference rows, 0 duplicates, including javaCode-only consumer `DisableOldReferralCodesRuleAction.js` at lines 18/33/39; `ArraySink.array` → 56 member call-site rows.

## Notes

Remaining swallowed catches in `ReferencesHandler` are addressed in a stacked follow-up PR (correctness hardening) rather than here, to keep this diff scoped to the reference-index fix.
