### PR TITLE
lsp: references find .jrl journal string usages (#5264)

### DIFF
--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -10,6 +10,20 @@ foam.CLASS({
 
   documentation: 'Query layer over the FOAM runtime class registry for LSP handlers.',
 
+  constants: {
+    JAVA_EMBED_KEYS_: {
+      javaCode: true, javaFactory: true, javaGetter: true, javaSetter: true,
+      javaPreSet: true, javaPostSet: true, javaAdapt: true, javaCompare: true,
+      javaComparePropertyToObject: true, javaComparePropertyToValue: true,
+      javaCloneProperty: true, javaDiffProperty: true,
+      javaFormatJSON: true, javaJSONParser: true, javaCSVParser: true,
+      javaQueryParser: true, javaToCSV: true, javaToCSVLabel: true,
+      javaFromCSVLabelMapping: true, javaAssertValue: true,
+      javaValidateObj: true, javaCondition: true, javaValue: true,
+      javaImports: true, code: true, serviceScript: true
+    }
+  },
+
   properties: [
     {
       name: 'cache_',
@@ -1906,6 +1920,133 @@ foam.CLASS({
     // and every services.jrl file (via JrlLoader, the FOAM-native journal
     // reader), then answers `getStringUsages(name)` — every class that
     // imports the name + every services.jrl entry that registers it.
+
+    function scanJrlClassRefs(text) {
+      /**
+       * Registry-verified class references in .jrl text, offset-based.
+       * Single shared implementation behind JrlHandler's semantic tokens and
+       * the jrl usage index (#5264). Kinds: 'classValue' ("class":"…" values,
+       * top level), 'javaEmbed' (dotted ids inside serviceScript/javaCode/…
+       * blocks, longest registered prefix), 'jsonEmbed' ("class":"…" inside
+       * embedded client JSON, literal or escaped).
+       */
+      var out = [];
+
+      // 1. "class":"…" / class:'…' values, line-by-line; // lines skipped.
+      var lineStart = 0;
+      var lines = text.split('\n');
+      for ( var lineNum = 0 ; lineNum < lines.length ; lineNum++ ) {
+        var line = lines[lineNum];
+        if ( line.trim() && ! /^\s*\/\//.test(line) ) {
+          var classRegex = /(?:"class"|(?<=[{,])\s*class)\s*:\s*(?:"([^"]+)"|'([^']+)')/g;
+          var cm;
+          while ( ( cm = classRegex.exec(line) ) !== null ) {
+            var classVal = cm[1] || cm[2];
+            if ( classVal && this.classExists(classVal) ) {
+              var valIdx = line.indexOf(classVal, cm.index);
+              if ( valIdx !== -1 ) {
+                out.push({ classId: classVal, offset: lineStart + valIdx, length: classVal.length, kind: 'classValue' });
+              }
+            }
+          }
+        }
+        lineStart += line.length + 1;
+      }
+
+      // 2. Embedded value blocks (serviceScript/javaCode/… and client JSON).
+      var blocks = this.findEmbeddedBlocks_(text);
+      for ( var i = 0 ; i < blocks.length ; i++ ) {
+        var b = blocks[i];
+        var content = text.substring(b.contentStart, b.contentEnd);
+        if ( this.JAVA_EMBED_KEYS_[b.key] ) {
+          var dottedRe = /\b([a-z][\w$]*(?:\.[a-zA-Z_][\w$]*)+)\b/g;
+          var dm;
+          while ( ( dm = dottedRe.exec(content) ) !== null ) {
+            var hit = this.resolveRegisteredPrefix_(dm[1]);
+            if ( ! hit ) continue;
+            out.push({ classId: dm[1].substring(0, hit.length), offset: b.contentStart + dm.index, length: hit.length, kind: 'javaEmbed' });
+          }
+        } else if ( b.key === 'client' ) {
+          var litRe = /"class"\s*:\s*"([^"\n]+)"/g;
+          var lm;
+          while ( ( lm = litRe.exec(content) ) !== null ) {
+            var cid = lm[1];
+            if ( ! this.classExists(cid) ) continue;
+            var vIdx = content.indexOf(cid, lm.index);
+            if ( vIdx !== -1 ) out.push({ classId: cid, offset: b.contentStart + vIdx, length: cid.length, kind: 'jsonEmbed' });
+          }
+          var escRe = /\\"class\\"\s*:\s*\\"([^"\\\n]+)\\"/g;
+          var em;
+          while ( ( em = escRe.exec(content) ) !== null ) {
+            var ecid = em[1];
+            if ( ! this.classExists(ecid) ) continue;
+            var eIdx = content.indexOf(ecid, em.index);
+            if ( eIdx !== -1 ) out.push({ classId: ecid, offset: b.contentStart + eIdx, length: ecid.length, kind: 'jsonEmbed' });
+          }
+        }
+      }
+      return out;
+    },
+
+    function findEmbeddedBlocks_(text) {
+      /**
+       * Scan the full text for every triple-quote and backtick embedded
+       * value. Returns array of { key, contentStart, contentEnd, delim }
+       * where delim is '"""' or '`'. Skips `//` line comments.
+       *
+       * Approach: find `"key":` then the opening delimiter right after.
+       * Matches BOTH quoted-key (`"javaCode"`) and unquoted-key (`javaCode`).
+       */
+      var out = [];
+      var keyDelimRe = /(?:"([a-zA-Z_][\w$]*)"|([a-zA-Z_][\w$]*))\s*:\s*("""|`)/g;
+      var m;
+      while ( ( m = keyDelimRe.exec(text) ) !== null ) {
+        var key = m[1] || m[2];
+        if ( ! key ) continue;
+        var delim = m[3];
+        var openStart = m.index + m[0].length - delim.length;
+        var contentStart = openStart + delim.length;
+        var contentEnd = text.indexOf(delim, contentStart);
+        if ( contentEnd === -1 ) break;
+        out.push({ key: key, contentStart: contentStart, contentEnd: contentEnd, delim: delim });
+        keyDelimRe.lastIndex = contentEnd + delim.length;
+      }
+
+      // Escaped-in-double-quote form: `"client": "…"` where inner quotes
+      // are `\"`. Only honor `client` (FObject JSON); serviceScript also
+      // uses this form but we leave Java highlighting to grammar injection
+      // there since escaping makes it hard to detect reliably.
+      var escRe = /"(client)"\s*:\s*"(?!"")((?:\\.|[^"\\\n])*)"/g;
+      var em;
+      while ( ( em = escRe.exec(text) ) !== null ) {
+        var vStart = em.index + em[0].length - em[2].length - 1;
+        out.push({
+          key: em[1],
+          contentStart: vStart + 1,
+          contentEnd: vStart + 1 + em[2].length,
+          delim: '"',
+          escaped: true
+        });
+      }
+      return out;
+    },
+
+    function resolveRegisteredPrefix_(dottedId) {
+      /**
+       * Given `foo.X.Builder`, return the longest prefix that exists in the
+       * FOAM registry. Returns { length } (char length of the matched
+       * prefix) or null.
+       */
+      if ( ! dottedId ) return null;
+      var cand = dottedId;
+      while ( cand ) {
+        if ( this.classExists(cand) ) return { length: cand.length };
+        var dot = cand.lastIndexOf('.');
+        if ( dot === -1 ) return null;
+        cand = cand.substring(0, dot);
+      }
+      return null;
+    },
 
     function getStringUsages(name) {
       if ( ! this.stringUsageIndex_ ) this.buildStringUsageIndex_();

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -742,6 +742,13 @@ foam.CLASS({
       this.cache_ = {};
     },
 
+    function invalidateJrlUsageIndex() {
+      /** A journal save changes journal references but re-registers no
+          classes, so reindexFile calls this instead of the full
+          invalidateSymbolIndex_ drop — the class-keyed indexes stay warm. */
+      this.jrlUsageIndex_ = null;
+    },
+
     function buildFileIndex() {
       /**
        * Build class ID → { path, flags } mapping by walking ALL POMs

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -742,11 +742,17 @@ foam.CLASS({
       this.cache_ = {};
     },
 
-    function invalidateJrlUsageIndex() {
+    function invalidateJrlUsageIndex(savedPath) {
       /** A journal save changes journal references but re-registers no
           classes, so reindexFile calls this instead of the full
-          invalidateSymbolIndex_ drop — the class-keyed indexes stay warm. */
+          invalidateSymbolIndex_ drop — the class-keyed indexes stay warm.
+          A services.jrl additionally feeds the string-usage index (its
+          CSpec entries are read through JrlLoader in
+          buildStringUsageIndex_), so that index drops with it. */
       this.jrlUsageIndex_ = null;
+      if ( savedPath && /(^|[\/\\])services\.jrl$/.test(savedPath) ) {
+        this.stringUsageIndex_ = null;
+      }
     },
 
     function buildFileIndex() {
@@ -2116,7 +2122,9 @@ foam.CLASS({
       // Dedupe by resolved path rather than skipping symlinks outright:
       // foam3's root `foam3 -> .` cycle resolves to an already-visited
       // directory and stops, while journals reachable only through a
-      // symlinked tree are still indexed (once).
+      // symlinked tree are still indexed (once). Only directories and
+      // journals are resolved — realpath on every plain file nearly
+      // doubles the cold walk and bloats seenReal for no dedupe value.
       var seenReal = {};
       function walk(dir) {
         var names;
@@ -2125,14 +2133,24 @@ foam.CLASS({
           var name = names[i];
           if ( SKIP[name] || name.charAt(0) === '.' ) continue;
           var p = path_.join(dir, name);
-          var real;
-          try { real = fs_.realpathSync(p); } catch (e) { continue; }   // broken symlink
-          if ( seenReal[real] ) continue;
-          seenReal[real] = true;
           var st;
-          try { st = fs_.statSync(p); } catch (e) { continue; }
-          if ( st.isDirectory() )                                      walk(p);
-          else if ( name.length > 4 && name.lastIndexOf('.jrl') === name.length - 4 ) out.push(p);
+          try { st = fs_.statSync(p); } catch (e) { continue; }   // broken symlink
+          if ( st.isDirectory() ) {
+            var real;
+            try { real = fs_.realpathSync(p); } catch (e) { continue; }
+            if ( seenReal[real] ) continue;
+            seenReal[real] = true;
+            walk(p);
+          } else if ( name.length > 4 && name.lastIndexOf('.jrl') === name.length - 4 ) {
+            // Push the resolved path so a journal reachable both directly
+            // and through a symlink reports one canonical row, independent
+            // of readdir order.
+            var jrlReal;
+            try { jrlReal = fs_.realpathSync(p); } catch (e) { continue; }
+            if ( seenReal[jrlReal] ) continue;
+            seenReal[jrlReal] = true;
+            out.push(jrlReal);
+          }
         }
       }
       try { seenReal[fs_.realpathSync(process.cwd())] = true; } catch (e) {}

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -2114,7 +2114,10 @@ foam.CLASS({
           if ( SKIP[name] || name.charAt(0) === '.' ) continue;
           var p = path_.join(dir, name);
           var st;
-          try { st = fs_.statSync(p); } catch (e) { continue; }
+          try { st = fs_.lstatSync(p); } catch (e) { continue; }
+          // Never follow directory symlinks — foam3's root has `foam3 -> .`,
+          // which would recurse forever and double-index every journal.
+          if ( st.isSymbolicLink() ) continue;
           if ( st.isDirectory() )                                      walk(p);
           else if ( name.length > 4 && name.lastIndexOf('.jrl') === name.length - 4 ) out.push(p);
         }

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -2106,6 +2106,11 @@ foam.CLASS({
       var path_ = require('path');
       var SKIP  = { node_modules: true, build: true };
       var out   = [];
+      // Dedupe by resolved path rather than skipping symlinks outright:
+      // foam3's root `foam3 -> .` cycle resolves to an already-visited
+      // directory and stops, while journals reachable only through a
+      // symlinked tree are still indexed (once).
+      var seenReal = {};
       function walk(dir) {
         var names;
         try { names = fs_.readdirSync(dir); } catch (e) { return; }
@@ -2113,15 +2118,17 @@ foam.CLASS({
           var name = names[i];
           if ( SKIP[name] || name.charAt(0) === '.' ) continue;
           var p = path_.join(dir, name);
+          var real;
+          try { real = fs_.realpathSync(p); } catch (e) { continue; }   // broken symlink
+          if ( seenReal[real] ) continue;
+          seenReal[real] = true;
           var st;
-          try { st = fs_.lstatSync(p); } catch (e) { continue; }
-          // Never follow directory symlinks — foam3's root has `foam3 -> .`,
-          // which would recurse forever and double-index every journal.
-          if ( st.isSymbolicLink() ) continue;
+          try { st = fs_.statSync(p); } catch (e) { continue; }
           if ( st.isDirectory() )                                      walk(p);
           else if ( name.length > 4 && name.lastIndexOf('.jrl') === name.length - 4 ) out.push(p);
         }
       }
+      try { seenReal[fs_.realpathSync(process.cwd())] = true; } catch (e) {}
       walk(process.cwd());
       return out;
     },

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -1589,6 +1589,7 @@ foam.CLASS({
       this.stringUsageIndex_   = null;
       this.memberUsageIndex_   = null;
       this.viewSpecUsageIndex_ = null;
+      this.jrlUsageIndex_      = null;
       // filePosCache_ is deliberately NOT dropped here: collectAxiomPositions
       // output is a pure function of file text, and each entry carries the
       // file's mtime, so the guard in getFilePosMap_ re-parses only files that
@@ -2046,6 +2047,80 @@ foam.CLASS({
         cand = cand.substring(0, dot);
       }
       return null;
+    },
+
+    function getJrlUsages(classId) {
+      /** Journal references (#5264): [{ file, line, character, length, kind: 'usage-jrl' }].
+          Full-id matching only — short names inside serviceScript bodies via
+          embedded imports are out of scope (grep covers those). */
+      if ( ! this.jrlUsageIndex_ ) this.buildJrlUsageIndex_();
+      return this.jrlUsageIndex_.byTarget[classId] || [];
+    },
+
+    function buildJrlUsageIndex_(opt_files) {
+      var fs_      = require('fs');
+      var byTarget = {};
+      var files    = opt_files || this.findWorkspaceJrlFiles_();
+
+      for ( var f = 0 ; f < files.length ; f++ ) {
+        var text;
+        try {
+          if ( fs_.statSync(files[f]).size > 2 * 1024 * 1024 ) {
+            console.error('[foam-lsp] jrl usage index: skipping >2MB journal ' + files[f]);
+            continue;
+          }
+          text = fs_.readFileSync(files[f], 'utf8');
+        } catch (e) { continue; }
+
+        var refs = this.scanJrlClassRefs(text);
+        if ( ! refs.length ) continue;
+
+        var lineOffs = [ 0 ];
+        for ( var c = 0 ; c < text.length ; c++ ) {
+          if ( text.charCodeAt(c) === 10 ) lineOffs.push(c + 1);
+        }
+        for ( var r = 0 ; r < refs.length ; r++ ) {
+          var ref = refs[r];
+          var lo = 0, hi = lineOffs.length - 1;
+          while ( lo < hi ) {
+            var mid = (lo + hi + 1) >> 1;
+            if ( lineOffs[mid] <= ref.offset ) lo = mid; else hi = mid - 1;
+          }
+          var arr = byTarget[ref.classId] || (byTarget[ref.classId] = []);
+          arr.push({
+            file:      files[f],
+            line:      lo,
+            character: ref.offset - lineOffs[lo],
+            length:    ref.length,
+            kind:      'usage-jrl'
+          });
+        }
+      }
+      this.jrlUsageIndex_ = { byTarget: byTarget };
+    },
+
+    function findWorkspaceJrlFiles_() {
+      /** Every *.jrl under the workspace root; node_modules, build and
+          dot-directories skipped. */
+      var fs_   = require('fs');
+      var path_ = require('path');
+      var SKIP  = { node_modules: true, build: true };
+      var out   = [];
+      function walk(dir) {
+        var names;
+        try { names = fs_.readdirSync(dir); } catch (e) { return; }
+        for ( var i = 0 ; i < names.length ; i++ ) {
+          var name = names[i];
+          if ( SKIP[name] || name.charAt(0) === '.' ) continue;
+          var p = path_.join(dir, name);
+          var st;
+          try { st = fs_.statSync(p); } catch (e) { continue; }
+          if ( st.isDirectory() )                                      walk(p);
+          else if ( name.length > 4 && name.lastIndexOf('.jrl') === name.length - 4 ) out.push(p);
+        }
+      }
+      walk(process.cwd());
+      return out;
     },
 
     function getStringUsages(name) {

--- a/tools/lsp/editors/mcp/README.md
+++ b/tools/lsp/editors/mcp/README.md
@@ -44,7 +44,7 @@ positions 0-based) rather than raw LSP JSON.
 |---|---|---|
 | `foam_hover` | `symbol` \| `uri`+`line`+`character` | Class docs, property types, method signatures, short-name resolution |
 | `foam_definition` | `symbol` \| `uri`+`line`+`character` | Source location for classes in `extends:`, `requires:`, `of:`, property types |
-| `foam_references` | `symbol` \| `uri`+`line`+`character` | Subclasses, interface implementors, and JS/Java/string usages |
+| `foam_references` | `symbol` \| `uri`+`line`+`character` | Subclasses, interface implementors, and JS/Java/string/journal (.jrl) usages |
 | `foam_implementation` | `symbol` \| `uri`+`line`+`character` | Concrete implementors of an interface (or direct subclasses) |
 | `foam_type_definition` | `symbol` \| `uri`+`line`+`character` | For a property usage, the property's type class |
 | `foam_type_hierarchy` | `symbol` \| position, `direction` (`subtypes`/`supertypes`/`both`) | Supertypes (extends chain) and/or subtypes (subclasses + implementors) |

--- a/tools/lsp/handlers/JrlHandler.js
+++ b/tools/lsp/handlers/JrlHandler.js
@@ -15,20 +15,6 @@ foam.CLASS({
     'foam.parse.lsp.CursorAnalyzer'
   ],
 
-  constants: {
-    JAVA_EMBED_KEYS_: {
-      javaCode: true, javaFactory: true, javaGetter: true, javaSetter: true,
-      javaPreSet: true, javaPostSet: true, javaAdapt: true, javaCompare: true,
-      javaComparePropertyToObject: true, javaComparePropertyToValue: true,
-      javaCloneProperty: true, javaDiffProperty: true,
-      javaFormatJSON: true, javaJSONParser: true, javaCSVParser: true,
-      javaQueryParser: true, javaToCSV: true, javaToCSVLabel: true,
-      javaFromCSVLabelMapping: true, javaAssertValue: true,
-      javaValidateObj: true, javaCondition: true, javaValue: true,
-      javaImports: true, code: true, serviceScript: true
-    }
-  },
-
   properties: [
     {
       class: 'FObjectProperty',
@@ -256,171 +242,18 @@ foam.CLASS({
        * 5=comment, 6=number, 7=operator, 8=method.
        */
       var tokens = [];
-      this.collectClassValueTokens_(text, tokens);
-      this.collectEmbeddedBlockTokens_(text, tokens);
+      var refs = this.index.scanJrlClassRefs(text);
+      var lineOffsets = this.computeLineOffsets_(text);
+      for ( var i = 0 ; i < refs.length ; i++ ) {
+        var r = refs[i];
+        // classValue/jsonEmbed rendered as class tokens (1), javaEmbed as type (0)
+        this.pushTokenAt_(tokens, r.offset, r.length, r.kind === 'javaEmbed' ? 0 : 1, lineOffsets);
+      }
 
       tokens.sort(function(a, b) {
         return a.line !== b.line ? a.line - b.line : a.char - b.char;
       });
       return this.encodeTokens_(tokens);
-    },
-
-    function collectClassValueTokens_(text, tokens) {
-      /** Line-by-line scan for "class":"…" and class:"…" verified values. */
-      var lines = text.split('\n');
-      for ( var lineNum = 0 ; lineNum < lines.length ; lineNum++ ) {
-        var line = lines[lineNum];
-        if ( ! line.trim() || /^\s*\/\//.test(line) ) continue;
-
-        var classRegex = /(?:"class"|(?<=[{,])\s*class)\s*:\s*(?:"([^"]+)"|'([^']+)')/g;
-        var cm;
-        while ( ( cm = classRegex.exec(line) ) !== null ) {
-          var classVal = cm[1] || cm[2];
-          if ( classVal && this.index.classExists(classVal) ) {
-            var valIdx = line.indexOf(classVal, cm.index);
-            if ( valIdx !== -1 ) {
-              tokens.push({ line: lineNum, char: valIdx, length: classVal.length, type: 1, modifiers: 0 });
-            }
-          }
-        }
-      }
-    },
-
-    function collectEmbeddedBlockTokens_(text, tokens) {
-      /**
-       * Walk every embedded value block in the file and emit tokens for
-       * registry-verified identifiers inside. Handles:
-       *   1. Triple-quoted values:  "key": """…"""
-       *   2. Backtick values:        "key": `…`
-       *   3. Escaped-in-double-quote values: "key": "…"   (for client only)
-       *
-       * Dispatch by key:
-       *   • Java keys (serviceScript, javaCode, …)    → Java tokenization
-       *   • `client`                                  → JSON tokenization
-       */
-      var blocks = this.findEmbeddedBlocks_(text);
-      for ( var i = 0 ; i < blocks.length ; i++ ) {
-        var b = blocks[i];
-        if ( this.JAVA_EMBED_KEYS_[b.key] ) {
-          this.collectJavaEmbedTokens_(text, b, tokens);
-        } else if ( b.key === 'client' ) {
-          this.collectJsonEmbedTokens_(text, b, tokens);
-        }
-      }
-    },
-
-    function findEmbeddedBlocks_(text) {
-      /**
-       * Scan the full text for every triple-quote and backtick embedded
-       * value. Returns array of { key, contentStart, contentEnd, delim }
-       * where delim is '"""' or '`'. Skips `//` line comments.
-       *
-       * Approach: find `"key":` then the opening delimiter right after.
-       * Matches BOTH quoted-key (`"javaCode"`) and unquoted-key (`javaCode`).
-       */
-      var out = [];
-      var keyDelimRe = /(?:"([a-zA-Z_][\w$]*)"|([a-zA-Z_][\w$]*))\s*:\s*("""|`)/g;
-      var m;
-      while ( ( m = keyDelimRe.exec(text) ) !== null ) {
-        var key = m[1] || m[2];
-        if ( ! key ) continue;
-        var delim = m[3];
-        var openStart = m.index + m[0].length - delim.length;
-        var contentStart = openStart + delim.length;
-        var contentEnd = text.indexOf(delim, contentStart);
-        if ( contentEnd === -1 ) break;
-        out.push({ key: key, contentStart: contentStart, contentEnd: contentEnd, delim: delim });
-        keyDelimRe.lastIndex = contentEnd + delim.length;
-      }
-
-      // Escaped-in-double-quote form: `"client": "…"` where inner quotes
-      // are `\"`. Only honor `client` (FObject JSON); serviceScript also
-      // uses this form but we leave Java highlighting to grammar injection
-      // there since escaping makes it hard to detect reliably.
-      var escRe = /"(client)"\s*:\s*"(?!"")((?:\\.|[^"\\\n])*)"/g;
-      var em;
-      while ( ( em = escRe.exec(text) ) !== null ) {
-        var vStart = em.index + em[0].length - em[2].length - 1;
-        out.push({
-          key: em[1],
-          contentStart: vStart + 1,
-          contentEnd: vStart + 1 + em[2].length,
-          delim: '"',
-          escaped: true
-        });
-      }
-      return out;
-    },
-
-    function collectJavaEmbedTokens_(text, block, tokens) {
-      /**
-       * Emit `type` tokens (0) for dotted class IDs and short class names
-       * that the registry resolves. Registry-verified only — no hardcoded
-       * list. The surrounding grammar handles Java keyword / string /
-       * comment highlighting; we add what the grammar can't know:
-       * which identifiers are actually FOAM classes.
-       */
-      var content = text.substring(block.contentStart, block.contentEnd);
-      var lineOffsets = this.computeLineOffsets_(text);
-
-      // Dotted identifier — a.b.c.D — followed by optional `.getOwnClassInfo`
-      var dottedRe = /\b([a-z][\w$]*(?:\.[a-zA-Z_][\w$]*)+)\b/g;
-      var dm;
-      while ( ( dm = dottedRe.exec(content) ) !== null ) {
-        var id = dm[1];
-        var hit = this.resolveRegisteredPrefix_(id);
-        if ( ! hit ) continue;
-        this.pushTokenAt_(tokens, block.contentStart + dm.index, hit.length, 0, lineOffsets);
-      }
-    },
-
-    function collectJsonEmbedTokens_(text, block, tokens) {
-      /**
-       * Emit `class` tokens (1) for registry-verified `"class":"…"` values
-       * inside an embedded JSON block. If the block is escaped-in-double-
-       * quote form, `\"class\":\"…\"` — handle both literal and escaped.
-       */
-      var content = text.substring(block.contentStart, block.contentEnd);
-      var lineOffsets = this.computeLineOffsets_(text);
-
-      // Literal: "class":"com.foo.Bar"
-      var litRe = /"class"\s*:\s*"([^"\n]+)"/g;
-      var lm;
-      while ( ( lm = litRe.exec(content) ) !== null ) {
-        var cid = lm[1];
-        if ( ! this.index.classExists(cid) ) continue;
-        var valIdx = content.indexOf(cid, lm.index);
-        if ( valIdx === -1 ) continue;
-        this.pushTokenAt_(tokens, block.contentStart + valIdx, cid.length, 1, lineOffsets);
-      }
-
-      // Escaped: \"class\":\"com.foo.Bar\"
-      var escRe = /\\"class\\"\s*:\s*\\"([^"\\\n]+)\\"/g;
-      var em;
-      while ( ( em = escRe.exec(content) ) !== null ) {
-        var ecid = em[1];
-        if ( ! this.index.classExists(ecid) ) continue;
-        var eIdx = content.indexOf(ecid, em.index);
-        if ( eIdx === -1 ) continue;
-        this.pushTokenAt_(tokens, block.contentStart + eIdx, ecid.length, 1, lineOffsets);
-      }
-    },
-
-    function resolveRegisteredPrefix_(dottedId) {
-      /**
-       * Given `foo.X.Builder`, return the longest prefix that exists in the
-       * FOAM registry. Returns { length } (char length of the matched
-       * prefix) or null.
-       */
-      if ( ! dottedId ) return null;
-      var cand = dottedId;
-      while ( cand ) {
-        if ( this.index.classExists(cand) ) return { length: cand.length };
-        var dot = cand.lastIndexOf('.');
-        if ( dot === -1 ) return null;
-        cand = cand.substring(0, dot);
-      }
-      return null;
     },
 
     function computeLineOffsets_(text) {

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -135,6 +135,29 @@ foam.CLASS({
           locations.push(loc);
         }
       }
+
+      // Journal references (#5264): jrl positions come straight from the
+      // index — no class file to scan, so they bypass buildLocations_ and
+      // feed the same position dedup.
+      try {
+        var jrlUses = this.index.getJrlUsages(classId);
+        for ( var i = 0 ; i < jrlUses.length ; i++ ) {
+          var ju   = jrlUses[i];
+          var jUri = 'file://' + ju.file;
+          var jKey = jUri + ':' + ju.line + ':' + ju.character;
+          if ( seenLoc[jKey] ) continue;
+          seenLoc[jKey] = true;
+          locations.push({
+            uri: jUri,
+            range: {
+              start: { line: ju.line, character: ju.character },
+              end:   { line: ju.line, character: ju.character + ju.length }
+            }
+          });
+        }
+      } catch (e) {
+        console.error('[foam-lsp] getJrlUsages failed for ' + classId + ': ' + e.message);
+      }
       return locations;
     },
 

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -343,9 +343,10 @@ function start() {
 
     // A journal save re-registers no classes (the branch above never runs),
     // but it does change journal references — drop the jrl usage index so
-    // find-references sees the edit without an LSP restart.
+    // find-references sees the edit without an LSP restart. The uri lets
+    // the index also drop the string-usage index for a services.jrl save.
     if ( isJrlFile(uri) && typeof index.invalidateJrlUsageIndex === 'function' ) {
-      index.invalidateJrlUsageIndex();
+      index.invalidateJrlUsageIndex(uri);
     }
 
     // Compute the dependency closure — files whose diagnostics could be

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -341,6 +341,13 @@ function start() {
       }
     }
 
+    // A journal save re-registers no classes (the branch above never runs),
+    // but it does change journal references — drop the jrl usage index so
+    // find-references sees the edit without an LSP restart.
+    if ( isJrlFile(uri) && typeof index.invalidateJrlUsageIndex === 'function' ) {
+      index.invalidateJrlUsageIndex();
+    }
+
     // Compute the dependency closure — files whose diagnostics could be
     // impacted by this change. Empty list for non-FOAM saves; JRLs only
     // affect the open-file loop below.

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -1053,5 +1053,47 @@ if ( require('fs').existsSync(realJrlPath) ) {
   }
 }
 
+// === jrl usage index — fixture files (issue #5264, Tier 1) ===
+//
+// buildJrlUsageIndex_ takes an explicit file list here so fixtures carry
+// no workspace assumptions; invalidate afterwards so later tests see the
+// real workspace index, not the fixture one.
+
+section('jrl usage index — fixture files (issue #5264)');
+
+try {
+  var jOs     = require('os');
+  var jTmpJrl = path.join(jOs.tmpdir(), 'foam-lsp-jrl-fixture-' + process.pid + '.jrl');
+  fs.writeFileSync(jTmpJrl,
+    'p({"class":"foam.core.boot.CSpec","id":"fixtureSvc",\n' +      // line 0
+    '  "serviceScript":"""\n' +                                      // line 1
+    '    return new foam.dao.ArraySink();\n' +                       // line 2
+    '  """})\n' +                                                    // line 3
+    '// p({"class":"foam.core.boot.CSpec","id":"commented"})\n' +    // line 4
+    'p({"class":"no.such.Klass","id":"junk"})\n');                   // line 5
+
+  index.buildJrlUsageIndex_([ jTmpJrl ]);
+
+  var jCspec = index.getJrlUsages('foam.core.boot.CSpec');
+  // T1a: "class":"…" value indexed with exact position.
+  test(jCspec.some(function(r) { return r.file === jTmpJrl && r.line === 0 && r.kind === 'usage-jrl'; }),
+    'fixture: "class":"foam.core.boot.CSpec" indexed at line 0');
+  test(! jCspec.some(function(r) { return r.file === jTmpJrl && r.line === 4; }),
+    'fixture: // comment line not indexed');
+
+  // T1b: class id inside a serviceScript body indexed (embedded-block path).
+  test(index.getJrlUsages('foam.dao.ArraySink').some(function(r) { return r.file === jTmpJrl && r.line === 2; }),
+    'fixture: serviceScript-embedded foam.dao.ArraySink indexed at its line');
+
+  // T1c: unregistered id never indexed (registry-verified).
+  test(index.getJrlUsages('no.such.Klass').length === 0,
+    'fixture: unregistered class id not indexed');
+
+  fs.unlinkSync(jTmpJrl);
+  index.invalidateSymbolIndex_();
+} catch (err) {
+  test(false, 'jrl fixture index threw: ' + err.message);
+}
+
 // === SAVE → TARGETED REANALYZE ===
 

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -1098,6 +1098,18 @@ try {
     'invalidateJrlUsageIndex: jrl usage index dropped (rebuilds on next query)');
   test(index.usageIndex_ && index.usageIndex_.sentinel === true,
     'invalidateJrlUsageIndex: class-keyed usage index untouched');
+
+  // A services.jrl save additionally drops the string-usage index (its
+  // CSpec entries are read from services.jrl); any other journal keeps it.
+  var jPrevString = index.stringUsageIndex_;
+  index.stringUsageIndex_ = { sentinel: true };
+  index.invalidateJrlUsageIndex('/ws/journals/other.jrl');
+  test(index.stringUsageIndex_ && index.stringUsageIndex_.sentinel === true,
+    'invalidateJrlUsageIndex: non-services journal keeps string-usage index');
+  index.invalidateJrlUsageIndex('file:///ws/src/services.jrl');
+  test(index.stringUsageIndex_ === null,
+    'invalidateJrlUsageIndex: services.jrl save drops string-usage index');
+  index.stringUsageIndex_ = jPrevString;
   index.usageIndex_ = jPrevUsage;
 
   fs.unlinkSync(jTmpJrl);
@@ -1128,6 +1140,12 @@ try {
   fs.symlinkSync('.', path.join(wRoot, 'self'), 'dir');
   // A broken symlink is skipped, not a crash.
   fs.symlinkSync(path.join(wRoot, 'gone'), path.join(wRoot, 'broken'), 'dir');
+  // A journal reachable both directly and through a directory symlink —
+  // must report one row at the canonical (resolved) path regardless of
+  // readdir order.
+  fs.mkdirSync(path.join(wRoot, 'intree'));
+  fs.writeFileSync(path.join(wRoot, 'intree', 'c.jrl'), 'p({"class":"z"})\n');
+  fs.symlinkSync(path.join(wRoot, 'intree'), path.join(wRoot, 'dup_link'), 'dir');
 
   var wPrev = process.cwd();
   var wFiles;
@@ -1138,12 +1156,19 @@ try {
     process.chdir(wPrev);
   }
 
+  // The walk returns resolved paths; the fixture root itself may sit
+  // behind a symlink (macOS /tmp), so compare against its realpath.
+  var wRealRoot = fs.realpathSync(wRoot);
+
   test(wFiles.filter(function(f) { return f.indexOf('a.jrl') !== -1; }).length === 1,
     'walk: plain journal indexed exactly once despite the self -> . cycle');
   test(wFiles.some(function(f) { return f.indexOf('b.jrl') !== -1; }),
     'walk: journal reachable only through a directory symlink is indexed');
-  test(wFiles.length === 2,
-    'walk: cycle + broken symlink add nothing (2 journals total)');
+  var wDup = wFiles.filter(function(f) { return f.indexOf('c.jrl') !== -1; });
+  test(wDup.length === 1 && wDup[0] === path.join(wRealRoot, 'intree', 'c.jrl'),
+    'walk: dual-reachable journal reported once, at the canonical path');
+  test(wFiles.length === 3,
+    'walk: cycle + broken symlink add nothing (3 journals total)');
 
   fs.rmSync(wRoot, { recursive: true, force: true });
 } catch (err) {

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -1095,5 +1095,40 @@ try {
   test(false, 'jrl fixture index threw: ' + err.message);
 }
 
+
+// === jrl references — real workspace acceptance (issue #5264, Tier 2) ===
+
+section('jrl references — real workspace acceptance (issue #5264)');
+
+try {
+  // T2a: index level — CSpec rows include services.jrl (issue names
+  // foam3/src/services.jrl; assert file, not a pinned line — the file churns).
+  var realCspec = index.getJrlUsages('foam.core.boot.CSpec');
+  test(realCspec.some(function(r) { return r.file.indexOf('services.jrl') !== -1; }),
+    'issue #5264 repro: CSpec jrl rows include a services.jrl');
+
+  // T2b: handler level — .jrl locations in the references output.
+  var jrlRefHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+    index: index, cache: cache, analyzer: analyzer
+  });
+  var cspecLocs = jrlRefHandler.referencesForClassId('foam.core.boot.CSpec');
+  test(cspecLocs.some(function(l) { return l.uri.indexOf('services.jrl') !== -1; }),
+    'referencesForClassId(CSpec): includes services.jrl locations');
+
+  // T2c: a serviceScript-only class stops reading as dead.
+  // PROVENANCE: foam.core.geocode.GoogleMapsAddressParser chosen because its
+  // only occurrence outside its own definition is src/services.jrl:284
+  // (`return new foam.core.geocode.GoogleMapsAddressParser.Builder(x).build();`).
+  // Grep evidence 2026-08-23:
+  //   grep -rln "GoogleMapsAddressParser" src/foam --include="*.js"
+  //     → src/foam/core/pom.js (registration) + its own model file, nothing else
+  //   grep -n "GoogleMapsAddressParser" src/services.jrl → line 284 only.
+  var deadLocs = jrlRefHandler.referencesForClassId('foam.core.geocode.GoogleMapsAddressParser');
+  test(deadLocs.some(function(l) { return l.uri.indexOf('.jrl') !== -1; }),
+    'serviceScript-only class has journal references (was: No results)');
+} catch (err) {
+  test(false, 'jrl references acceptance threw: ' + err.message);
+}
+
 // === SAVE → TARGETED REANALYZE ===
 

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -1096,6 +1096,50 @@ try {
 }
 
 
+// === jrl file walk — symlink handling ===
+//
+// The walk dedupes by realpath: a `self -> .` cycle terminates, while a
+// journal reachable ONLY through a directory symlink is still indexed.
+
+section('jrl file walk — symlink handling');
+
+try {
+  var wOs   = require('os');
+  var wRoot = fs.mkdtempSync(path.join(wOs.tmpdir(), 'foam-lsp-walk-'));
+  fs.mkdirSync(path.join(wRoot, 'plain'));
+  fs.writeFileSync(path.join(wRoot, 'plain', 'a.jrl'), 'p({"class":"x"})\n');
+  // A journal reachable only via symlink: dot-dirs are skipped by the walk,
+  // so `.store` is invisible except through the `linked` symlink.
+  fs.mkdirSync(path.join(wRoot, '.store'));
+  fs.writeFileSync(path.join(wRoot, '.store', 'b.jrl'), 'p({"class":"y"})\n');
+  fs.symlinkSync(path.join(wRoot, '.store'), path.join(wRoot, 'linked'), 'dir');
+  // foam3-style self-cycle.
+  fs.symlinkSync('.', path.join(wRoot, 'self'), 'dir');
+  // A broken symlink is skipped, not a crash.
+  fs.symlinkSync(path.join(wRoot, 'gone'), path.join(wRoot, 'broken'), 'dir');
+
+  var wPrev = process.cwd();
+  var wFiles;
+  try {
+    process.chdir(wRoot);
+    wFiles = index.findWorkspaceJrlFiles_();
+  } finally {
+    process.chdir(wPrev);
+  }
+
+  test(wFiles.filter(function(f) { return f.indexOf('a.jrl') !== -1; }).length === 1,
+    'walk: plain journal indexed exactly once despite the self -> . cycle');
+  test(wFiles.some(function(f) { return f.indexOf('b.jrl') !== -1; }),
+    'walk: journal reachable only through a directory symlink is indexed');
+  test(wFiles.length === 2,
+    'walk: cycle + broken symlink add nothing (2 journals total)');
+
+  fs.rmSync(wRoot, { recursive: true, force: true });
+} catch (err) {
+  test(false, 'jrl walk symlink test threw: ' + err.message);
+}
+
+
 // === jrl references — real workspace acceptance (issue #5264, Tier 2) ===
 
 section('jrl references — real workspace acceptance (issue #5264)');

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -1089,6 +1089,17 @@ try {
   test(index.getJrlUsages('no.such.Klass').length === 0,
     'fixture: unregistered class id not indexed');
 
+  // Targeted invalidation: a .jrl save drops ONLY the jrl usage index —
+  // no class was re-registered, so the class-keyed indexes stay warm.
+  var jPrevUsage = index.usageIndex_;
+  index.usageIndex_ = { sentinel: true };
+  index.invalidateJrlUsageIndex();
+  test(index.jrlUsageIndex_ === null,
+    'invalidateJrlUsageIndex: jrl usage index dropped (rebuilds on next query)');
+  test(index.usageIndex_ && index.usageIndex_.sentinel === true,
+    'invalidateJrlUsageIndex: class-keyed usage index untouched');
+  index.usageIndex_ = jPrevUsage;
+
   fs.unlinkSync(jTmpJrl);
   index.invalidateSymbolIndex_();
 } catch (err) {


### PR DESCRIPTION
Fixes #5264

> **Prerequisite:** merge #5326 before this one.

Stacked on #5326 (base = `lsp-java-usage-references`); review this PR's own commits only — the base PR carries the javaImports/javaCode fix.

## Problem

References never surfaced `.jrl` journal usages: CSpec `serviceScript` entries, class-name string properties, and other journal string references were invisible. A class consumed only from `services.jrl` (e.g. `foam.core.geocode.GoogleMapsAddressParser`) reported "No results".

## Changes

- `scanJrlClassRefs` extracted into `FoamIndex` (behavior-preserving refactor first; tally-equal against the old scanner).
- New jrl usage index: fixture-addressable, 2MB per-file guard, invalidation hook on file change.
- Symlink-walk fix: the repo root contains a `foam3 -> .` self-symlink; the workspace `.jrl` walk must `lstat` and skip directory symlinks or it recurses forever.
- `.jrl` locations merged into `referencesForClassId` — journal rows are now clickable reference results.
- README capability row.

## Testing

- jrl category 140 passed / 0 failed; full LSP suite 1122/0.
- Live check over the real MCP server (stdio): `foam.core.boot.CSpec` → 315 `.jrl` reference rows, 0 duplicates; `GoogleMapsAddressParser` previously "No results" → `src/services.jrl:283`.

## Notes

The MCP server instructions still list `.jrl string references` as a blind spot — intentionally left in place here to avoid conflicting with the base PR's instructions edit. The clause gets removed when this branch rebases onto development after the base PR merges.

