### PR TITLE
lsp: correctness hardening — logged catches, parse-cache, object-form of, cssTokens forms

### DIFF
--- a/tools/lsp/CursorAnalyzer.js
+++ b/tools/lsp/CursorAnalyzer.js
@@ -601,7 +601,9 @@ foam.CLASS({
        */
       if ( index.classExists(typeName) ) return typeName;
 
-      var imports = model ? model.javaImports || [] : [];
+      var imports = model && index && typeof index.javaImportPaths === 'function' ?
+        index.javaImportPaths({ model_: model }) :
+        ( model ? (model.javaImports || []).filter(function(x) { return typeof x === 'string'; }) : [] );
       for ( var i = 0 ; i < imports.length ; i++ ) {
         var imp = imports[i];
         if ( imp.endsWith('.' + typeName) || imp.endsWith('.*') ) {

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -2015,6 +2015,25 @@ foam.CLASS({
     // every Java-side reference. Same fact pattern as the JS usage scan,
     // different axiom slots.
 
+    function javaImportPaths(cls) {
+      /**
+       * The class's javaImports as plain path strings, whichever form the
+       * model holds: raw strings (FileModelCache / pre-refinement) or
+       * foam.java.JavaImport objects ({ import: 'full.path', name: generated
+       * 'javaimport_'+import label }) — what a real boot's java refinements
+       * produce. Single normalization point: do NOT unwrap javaImports
+       * shapes anywhere else.
+       */
+      var ji  = cls && cls.model_ && cls.model_.javaImports || [];
+      var out = [];
+      for ( var i = 0 ; i < ji.length ; i++ ) {
+        var e = ji[i];
+        if ( typeof e === 'string' )                  out.push(e);
+        else if ( e && typeof e.import === 'string' ) out.push(e.import);
+      }
+      return out;
+    },
+
     function getJavaUsages(classId) {
       if ( ! this.javaUsageIndex_ ) this.buildJavaUsageIndex_();
       return this.javaUsageIndex_.byTarget[classId] || [];
@@ -2041,13 +2060,12 @@ foam.CLASS({
         var cls      = this.getClass(sourceId);
         if ( ! cls ) continue;
 
-        var javaImports = cls.model_ && cls.model_.javaImports || [];
+        var javaImports = this.javaImportPaths(cls);
         if ( javaImports.length === 0 && ! (cls.model_ && cls.model_.package) ) continue;
 
         var importLookup = {};
         for ( var x = 0 ; x < javaImports.length ; x++ ) {
           var imp = javaImports[x];
-          if ( typeof imp !== 'string' ) continue;
           if ( imp.indexOf('*') !== -1 ) continue;
           var parts = imp.split('.');
           importLookup[parts[parts.length - 1]] = imp;

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -844,7 +844,9 @@ foam.CLASS({
             };
           }
         }
-      } catch ( e ) {}
+      } catch ( e ) {
+        require('./logError').logLspError('indexFileClasses ' + filePath, e);
+      }
     },
 
     function getPomLocationForClass(classId) {
@@ -1009,9 +1011,13 @@ foam.CLASS({
 
             var subPom = { path: projPomPath, location: projLocation };
             this.walkSkippedProjects_(subPom, path_, fs_, visited);
-          } catch (e) {}
+          } catch (e) {
+            require('./logError').logLspError('POM sub-project walk ' + (projPomPath || ''), e);
+          }
         }
-      } catch (e) {}
+      } catch (e) {
+        require('./logError').logLspError('POM walk', e);
+      }
     },
 
     function parsePomProjects_(content) {
@@ -1024,7 +1030,9 @@ foam.CLASS({
       try {
         var ctx = { foam: { POM: function(m) { captured = m.projects || null; } } };
         with ( ctx ) { eval(content); }
-      } catch ( e ) {}
+      } catch ( e ) {
+        require('./logError').logLspError('POM eval (projects)', e);
+      }
       return captured;
     },
 
@@ -1037,7 +1045,9 @@ foam.CLASS({
       try {
         var ctx = { foam: { POM: function(m) { captured = m.files || null; } } };
         with ( ctx ) { eval(content); }
-      } catch ( e ) {}
+      } catch ( e ) {
+        require('./logError').logLspError('POM eval (files)', e);
+      }
       return captured;
     },
 
@@ -2218,9 +2228,13 @@ foam.CLASS({
                 file:          services[s]
               });
             }
-          } catch (e) {}
+          } catch (e) {
+            require('./logError').logLspError('services.jrl cspec scan ' + services[s], e);
+          }
         }
-      } catch (e) {}
+      } catch (e) {
+        require('./logError').logLspError('cspec scan', e);
+      }
 
       this.stringUsageIndex_ = { byName: byName };
     },

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -1090,13 +1090,21 @@ foam.CLASS({
       if ( entry && entry.mtimeMs === mtime ) return entry.posMap;
 
       var map = null;
+      var failed = false;
       try {
         var content = fs_.readFileSync(filePath, 'utf8');
         if ( content.length <= 2 * 1024 * 1024 ) {
           map = this.getGrammar().collectAxiomPositions(content);
         }
-      } catch ( e ) {}
-      this.filePosCache_[filePath] = { mtimeMs: mtime, posMap: map };
+      } catch ( e ) {
+        failed = true;
+        require('./logError').logLspError('grammar position parse ' + filePath, e);
+      }
+      // A failed parse is transient state, not a fact about the file: caching
+      // null against mtime would pin every member of this file to line 0
+      // until the next edit. Oversized files DO cache null — that skip is
+      // deliberate and permanent for the mtime.
+      if ( ! failed ) this.filePosCache_[filePath] = { mtimeMs: mtime, posMap: map };
       return map;
     },
 

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -446,7 +446,11 @@ foam.CLASS({
           var props = cls.model_.properties;
           for ( var j = 0 ; j < props.length ; j++ ) {
             var p = props[j];
-            if ( p && typeof p === 'object' && p.of === classId ) {
+            if ( ! p || typeof p !== 'object' ) continue;
+            // `of` may be the declared string OR an adapted class object
+            // whose id carries the dotted name — match either.
+            var ofId = typeof p.of === 'string' ? p.of : ( p.of && p.of.id );
+            if ( ofId === classId ) {
               result.push(ids[i]);
               break;
             }

--- a/tools/lsp/editors/mcp/server.js
+++ b/tools/lsp/editors/mcp/server.js
@@ -748,10 +748,11 @@ function main() {
           instructions:
             'foam_* tools answer FOAM structure questions from the live registry: ' +
             'hierarchy (subclasses/implementors), definitions (even when filename != ' +
-            'class name), substring symbol search, hover docs/types. Blind spots — ' +
-            'grep instead for: .jrl string references, javaImports/javaCode usages, ' +
-            'property-usage sweeps, refined property types, exact member call-site ' +
-            'lines. Name-addressable: symbol: "DetailView", a class id, or ' +
+            'class name), substring symbol search, hover docs/types, javaCode usages, ' +
+            'member call-site lines. Blind spots — ' +
+            'grep instead for: .jrl string references, ' +
+            'property-usage sweeps, refined property types. ' +
+            'Name-addressable: symbol: "DetailView", a class id, or ' +
             '"Class.member". First call boots the LSP (~10-15s). Index reflects the ' +
             'checkout, not uncommitted edits — read changed files directly.'
         });

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -674,6 +674,31 @@ foam.CLASS({
       }
     },
 
+    function cssTokenEntries_(tokens) {
+      /**
+       * Normalize a raw-file cssTokens declaration to [{name, value}].
+       * CSSTokenModelRefinement's adapt accepts three author forms — the
+       * LSP reads pre-adapt file models, so it must accept the same three:
+       *   1. [ { name, value } ]   (object array; also the registry form)
+       *   2. { name: value }       (plain map)
+       *   3. [ ['name', value] ]   (pair array)
+       */
+      if ( ! tokens ) return [];
+      var out = [];
+      if ( ! Array.isArray(tokens) ) {
+        if ( typeof tokens !== 'object' ) return [];
+        for ( var key in tokens ) out.push({ name: key, value: tokens[key] });
+        return out;
+      }
+      for ( var i = 0 ; i < tokens.length ; i++ ) {
+        var t = tokens[i];
+        if ( ! t ) continue;
+        if ( Array.isArray(t) )     out.push({ name: t[0], value: t[1] });
+        else if ( t.name )          out.push({ name: t.name, value: t.value });
+      }
+      return out;
+    },
+
     function collectLocalCssTokens_(model) {
       /**
        * Build a set of CSS token names declared on the model itself or
@@ -681,12 +706,10 @@ foam.CLASS({
        * unknown ancestors are silently skipped.
        */
       var set = Object.create(null);
+      var self = this;
       var addFrom = function(tokens) {
-        if ( ! tokens || ! tokens.length ) return;
-        for ( var i = 0 ; i < tokens.length ; i++ ) {
-          var t = tokens[i];
-          if ( t && t.name ) set[t.name] = true;
-        }
+        var entries = self.cssTokenEntries_(tokens);
+        for ( var i = 0 ; i < entries.length ; i++ ) set[entries[i].name] = true;
       };
       addFrom(model.cssTokens);
 
@@ -764,13 +787,12 @@ foam.CLASS({
         }
         return s;
       };
+      var self = this;
       var addFrom = function(tokens) {
-        if ( ! tokens || ! tokens.length ) return;
-        for ( var i = 0 ; i < tokens.length ; i++ ) {
-          var t = tokens[i];
-          if ( ! t || ! t.name ) continue;
-          var n = normalize(t.value);
-          if ( n && ! map[n] ) map[n] = t.name;
+        var entries = self.cssTokenEntries_(tokens);
+        for ( var i = 0 ; i < entries.length ; i++ ) {
+          var n = normalize(entries[i].value);
+          if ( n && ! map[n] ) map[n] = entries[i].name;
         }
       };
       addFrom(model.cssTokens);

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -126,19 +126,14 @@ foam.CLASS({
         require('../logError').logLspError('getViewSpecUsers for ' + classId, e);
       }
 
-      // Dedup by position: a file defining several classes is scanned once
-      // per class, so identical rows repeat without this. Order-preserving.
-      var locations = [];
-      var seenLoc   = {};
+      // All collectors below feed one deduping sink: a file defining several
+      // classes is scanned once per class, so identical rows repeat without
+      // this — and a future collector pushed through the sink can't
+      // reintroduce them. Order-preserving.
+      var sink = this.locationSink_();
       for ( var i = 0 ; i < refs.length ; i++ ) {
         var locs = this.buildLocations_(refs[i], classId);
-        for ( var j = 0 ; j < locs.length ; j++ ) {
-          var loc = locs[j];
-          var key = loc.uri + ':' + loc.range.start.line + ':' + loc.range.start.character;
-          if ( seenLoc[key] ) continue;
-          seenLoc[key] = true;
-          locations.push(loc);
-        }
+        for ( var j = 0 ; j < locs.length ; j++ ) sink.push(locs[j]);
       }
 
       // Journal references (#5264): jrl positions come straight from the
@@ -147,13 +142,9 @@ foam.CLASS({
       try {
         var jrlUses = this.index.getJrlUsages(classId);
         for ( var i = 0 ; i < jrlUses.length ; i++ ) {
-          var ju   = jrlUses[i];
-          var jUri = 'file://' + ju.file;
-          var jKey = jUri + ':' + ju.line + ':' + ju.character;
-          if ( seenLoc[jKey] ) continue;
-          seenLoc[jKey] = true;
-          locations.push({
-            uri: jUri,
+          var ju = jrlUses[i];
+          sink.push({
+            uri: 'file://' + ju.file,
             range: {
               start: { line: ju.line, character: ju.character },
               end:   { line: ju.line, character: ju.character + ju.length }
@@ -163,7 +154,32 @@ foam.CLASS({
       } catch (e) {
         require('../logError').logLspError('getJrlUsages for ' + classId, e);
       }
-      return locations;
+      return sink.locations;
+    },
+
+    function locationSink_() {
+      /**
+       * Order-preserving Location collector that dedups by position. Every
+       * collector feeding one result set pushes through the same sink, so a
+       * new collector can't silently reintroduce duplicate rows — the guard
+       * lives in the sink, not at each call site. `push` returns whether the
+       * location was kept.
+       */
+      var seen = {};
+      var locations = [];
+      return {
+        locations: locations,
+        // Kept-row count, so collectors with a result cap (scanPropertyRefs_)
+        // can treat the sink like the array they used to receive.
+        get length() { return locations.length; },
+        push: function(loc) {
+          var key = loc.uri + ':' + loc.range.start.line + ':' + loc.range.start.character;
+          if ( seen[key] ) return false;
+          seen[key] = true;
+          locations.push(loc);
+          return true;
+        }
+      };
     },
 
     function propertyReferences_(text, position, word, opt_uri) {
@@ -226,22 +242,14 @@ foam.CLASS({
       for ( var i = 0 ; i < reqs.length ; i++ ) addFile(reqs[i]);
       for ( var i = 0 ; i < ofs.length ; i++ )   addFile(ofs[i]);
 
-      var locations = [];
+      // Ids are deduped above, but several ids can map to ONE file, which
+      // then gets scanned once per id and would repeat every row — the sink
+      // dedups by position as the scans push into it.
+      var sink = this.locationSink_();
       for ( var i = 0 ; i < filesToScan.length ; i++ ) {
-        this.scanPropertyRefs_(filesToScan[i], word, locations);
+        this.scanPropertyRefs_(filesToScan[i], word, sink);
       }
-      // Dedup by position: ids are deduped above, but several ids can map to
-      // ONE file, which then gets scanned once per id and repeats every row.
-      var out = [];
-      var seenLoc = {};
-      for ( var i = 0 ; i < locations.length ; i++ ) {
-        var loc = locations[i];
-        var key = loc.uri + ':' + loc.range.start.line + ':' + loc.range.start.character;
-        if ( seenLoc[key] ) continue;
-        seenLoc[key] = true;
-        out.push(loc);
-      }
-      return out;
+      return sink.locations;
     },
 
     function axiomReferences_(text, position, word, opt_uri) {

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -104,6 +104,11 @@ foam.CLASS({
       try {
         var shortName = classId.split('.').pop();
         var strUses   = this.index.getStringUsages(shortName);
+        // CSpec entries key by full dotted id — probe both, as the comment
+        // above always claimed.
+        if ( shortName !== classId ) {
+          strUses = strUses.concat(this.index.getStringUsages(classId));
+        }
         for ( var i = 0 ; i < strUses.length ; i++ ) {
           if ( strUses[i].sourceClassId ) add(strUses[i].sourceClassId);
         }

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -230,7 +230,18 @@ foam.CLASS({
       for ( var i = 0 ; i < filesToScan.length ; i++ ) {
         this.scanPropertyRefs_(filesToScan[i], word, locations);
       }
-      return locations;
+      // Dedup by position: ids are deduped above, but several ids can map to
+      // ONE file, which then gets scanned once per id and repeats every row.
+      var out = [];
+      var seenLoc = {};
+      for ( var i = 0 ; i < locations.length ; i++ ) {
+        var loc = locations[i];
+        var key = loc.uri + ':' + loc.range.start.line + ':' + loc.range.start.character;
+        if ( seenLoc[key] ) continue;
+        seenLoc[key] = true;
+        out.push(loc);
+      }
+      return out;
     },
 
     function axiomReferences_(text, position, word, opt_uri) {

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -155,8 +155,34 @@ foam.CLASS({
       var classId = this.cache.getClassId(model);
       if ( ! classId ) return null;
 
-      // Collect files to scan: the defining class + every subclass (they
-      // inherit the property and commonly reference it).
+      return this.memberScanLocations_(classId, word);
+    },
+
+    function memberReferencesForClassId(classId, memberName) {
+      /**
+       * By-id member references — the name-addressed (foam/byName) twin of
+       * propertyReferences_/axiomReferences_. Returns call-site Locations
+       * when memberName is an own property, message, or constant of classId;
+       * null otherwise so the caller falls back to class references
+       * (methods stay on callHierarchy, which already has call sites).
+       */
+      var cls = typeof this.index.getClass === 'function' ?
+        this.index.getClass(classId) : null;
+      var model = cls && cls.model_;
+      if ( ! model ) return null;
+      if ( ! ( this.isOwnPropertyName_(model, memberName) ||
+               this.isOwnMessageName_(model, memberName)  ||
+               this.isOwnConstantName_(model, memberName) ) ) return null;
+      return this.memberScanLocations_(classId, memberName);
+    },
+
+    function memberScanLocations_(classId, word) {
+      /**
+       * Collect files to scan — the defining class + every subclass (they
+       * inherit the member and commonly reference it) + classes that REQUIRE
+       * or have `of: classId` (they access it through a typed variable) —
+       * then emit every call-site Location for `word` across that set.
+       */
       var seen = {};
       var filesToScan = [];
       function addFile(id) {
@@ -167,9 +193,6 @@ foam.CLASS({
       addFile(classId);
       var subs = this.transitiveSubclasses_(classId);
       for ( var i = 0 ; i < subs.length ; i++ ) addFile(subs[i]);
-
-      // Also include classes that REQUIRE or have `of: classId` — they likely
-      // access the property through a typed variable.
       var reqs = this.index.getRequirers(classId);
       var ofs  = this.index.getOfUsers(classId);
       for ( var i = 0 ; i < reqs.length ; i++ ) addFile(reqs[i]);
@@ -209,25 +232,7 @@ foam.CLASS({
 
       // Same scoping as property references — own class + transitive
       // subclasses + requirers + of-users.
-      var seen = {};
-      var files = [];
-      function addFile(id) {
-        if ( ! id || seen[id] ) return;
-        seen[id] = true; files.push(id);
-      }
-      addFile(classId);
-      var subs = this.transitiveSubclasses_(classId);
-      for ( var i = 0 ; i < subs.length ; i++ ) addFile(subs[i]);
-      var reqs = this.index.getRequirers(classId);
-      var ofs  = this.index.getOfUsers(classId);
-      for ( var i = 0 ; i < reqs.length ; i++ ) addFile(reqs[i]);
-      for ( var i = 0 ; i < ofs.length ; i++ )   addFile(ofs[i]);
-
-      var locations = [];
-      for ( var i = 0 ; i < files.length ; i++ ) {
-        this.scanPropertyRefs_(files[i], word, locations);
-      }
-      return locations;
+      return this.memberScanLocations_(classId, word);
     },
 
     function isOwnMessageName_(model, word) {

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -90,13 +90,13 @@ foam.CLASS({
         var jsUses = this.index.getJsUsages(classId);
         for ( var i = 0 ; i < jsUses.length ; i++ ) add(jsUses[i].sourceClassId);
       } catch (e) {
-        console.error('[foam-lsp] getJsUsages failed for ' + classId + ': ' + e.message);
+        require('../logError').logLspError('getJsUsages for ' + classId, e);
       }
       try {
         var javaUses = this.index.getJavaUsages(classId);
         for ( var i = 0 ; i < javaUses.length ; i++ ) add(javaUses[i].sourceClassId);
       } catch (e) {
-        console.error('[foam-lsp] getJavaUsages failed for ' + classId + ': ' + e.message);
+        require('../logError').logLspError('getJavaUsages for ' + classId, e);
       }
       // Class-name strings ARE valid context keys too (e.g. CSpec id matches
       // the dotted class id of its result type) — pick those up via the
@@ -108,7 +108,7 @@ foam.CLASS({
           if ( strUses[i].sourceClassId ) add(strUses[i].sourceClassId);
         }
       } catch (e) {
-        console.error('[foam-lsp] getStringUsages failed for ' + classId + ': ' + e.message);
+        require('../logError').logLspError('getStringUsages for ' + classId, e);
       }
       // Classes that reference the target ONLY inside a view spec
       // (`view: { class: 'X' }`, searchView, rowView, defaultNewItem, …)
@@ -118,7 +118,7 @@ foam.CLASS({
         var viewUses = this.index.getViewSpecUsers(classId);
         for ( var i = 0 ; i < viewUses.length ; i++ ) add(viewUses[i].sourceClassId);
       } catch (e) {
-        console.error('[foam-lsp] getViewSpecUsers failed for ' + classId + ': ' + e.message);
+        require('../logError').logLspError('getViewSpecUsers for ' + classId, e);
       }
 
       // Dedup by position: a file defining several classes is scanned once
@@ -528,7 +528,9 @@ foam.CLASS({
             push(hits[i].startPos, targetClassId.length);
           }
         }
-      } catch (e) {}
+      } catch (e) {
+        require('../logError').logLspError('grammar classRef scan for ' + targetClassId, e);
+      }
 
       // === B. Word-bounded full-id text scan ===
       var escapedFull = targetClassId.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -582,7 +584,9 @@ foam.CLASS({
             }
           });
         }
-      } catch (e) {}
+      } catch (e) {
+        require('../logError').logLspError('short-name axiom scan for ' + targetClassId, e);
+      }
 
       return out.length > 0 ? out : fallback;
     },

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -161,7 +161,7 @@ foam.CLASS({
           });
         }
       } catch (e) {
-        console.error('[foam-lsp] getJrlUsages failed for ' + classId + ': ' + e.message);
+        require('../logError').logLspError('getJrlUsages for ' + classId, e);
       }
       return locations;
     },

--- a/tools/lsp/handlers/ReferencesHandler.js
+++ b/tools/lsp/handlers/ReferencesHandler.js
@@ -584,9 +584,11 @@ foam.CLASS({
         }
         if ( path === targetClassId && alias ) out[alias] = true;
       }
-      var ji = cls.model_.javaImports || [];
+      // Normalized by FoamIndex.javaImportPaths — never unwrap shapes here.
+      var ji = typeof this.index.javaImportPaths === 'function' ?
+        this.index.javaImportPaths(cls) : [];
       for ( var i = 0 ; i < ji.length ; i++ ) {
-        var imp = typeof ji[i] === 'string' ? ji[i] : ( ji[i] && ji[i].path );
+        var imp = ji[i];
         if ( imp === targetClassId ) {
           var sh = imp.split('.').pop();
           if ( sh ) out[sh] = true;

--- a/tools/lsp/handlers/WorkspaceAnalyzer.js
+++ b/tools/lsp/handlers/WorkspaceAnalyzer.js
@@ -54,7 +54,7 @@ foam.CLASS({
 
     function newAcc_() {
       /** Fresh accumulator for a scan (shared by sync + async drivers). */
-      return { filesScanned: 0, filesWithIssues: 0, warnings: 0, errors: 0,
+      return { filesScanned: 0, filesFailed: 0, filesWithIssues: 0, warnings: 0, errors: 0,
                infos: 0, fileResults: {}, patternCounts: {}, slowest: [] };
     },
 
@@ -89,7 +89,9 @@ foam.CLASS({
           }
         }
       } catch (e) {
-        // File read or parse error — skip silently
+        require('../logError').logLspError('workspace scan of ' + filePath, e);
+        acc.filesFailed++;
+        return;
       }
       acc.filesScanned++;
     },
@@ -108,6 +110,7 @@ foam.CLASS({
       patterns.sort(function(a, b) { return b.count - a.count; });
       return {
         filesScanned:    acc.filesScanned,
+        filesFailed:     acc.filesFailed,
         filesWithIssues: acc.filesWithIssues,
         warnings:        acc.warnings,
         errors:          acc.errors,
@@ -183,6 +186,7 @@ foam.CLASS({
       }
 
       var filesScanned    = 0;
+      var filesFailed     = 0;
       var filesWithIssues = 0;
       var warnings        = 0;
       var errors          = 0;
@@ -207,12 +211,17 @@ foam.CLASS({
               else infos++;
             }
           }
-        } catch ( e ) {}
+        } catch ( e ) {
+          require('../logError').logLspError('diagnostics for ' + filePath, e);
+          filesFailed++;
+          continue;
+        }
         filesScanned++;
       }
 
       return {
         filesScanned:    filesScanned,
+        filesFailed:     filesFailed,
         filesWithIssues: filesWithIssues,
         warnings:        warnings,
         errors:          errors,

--- a/tools/lsp/logError.js
+++ b/tools/lsp/logError.js
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+/**
+ * Single logging idiom for degraded-but-not-fatal LSP failures. Everything
+ * that catches an error and falls back MUST leave this trace — a broken
+ * feature must never be indistinguishable from an empty result.
+ */
+function logLspError(context, err) {
+  console.error('[foam-lsp] ' + context + ': ' + (err && err.message ? err.message : String(err)));
+}
+
+module.exports = { logLspError: logLspError };

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -216,8 +216,16 @@ function start() {
         }
         return hoverHandler.buildClassHover(classId);
       }
-      case 'references':
+      case 'references': {
+        // Class.member: return the member's call-site lines when the member
+        // scan recognizes it (own property/message/constant); null falls
+        // back to class references (methods go through callHierarchy).
+        if ( info.memberName ) {
+          var mLocs = referencesHandler.memberReferencesForClassId(classId, info.memberName);
+          if ( mLocs ) return mLocs;
+        }
         return referencesHandler.referencesForClassId(classId);
+      }
       case 'implementation': {
         var targets = index.isInterface(classId) ?
           index.getImplementors(classId) : index.getSubclasses(classId);

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -754,4 +754,42 @@ test(addStrDiags("foam.CLASS({ package:'t', name:'DQ2', methods:[ function rende
 // 6. Escaped-quote argument flagged exactly once (detection, not just extract).
 test(addStrDiags("foam.CLASS({ package:'t', name:'AP2', methods:[ function render(){ this.add('Don\\'t save'); } ] })").length === 1, "escaped quote: this.add('Don\\'t save') flagged once");
 
+// --- cssTokens map + pair forms are recognized (CSSTokenModelRefinement adapt) ---
+(function() {
+  var mapForm = [
+    "foam.CLASS({",
+    "  package: 'lsptest.css', name: 'MapForm',",
+    "  cssTokens: { brandInk: '#123456' },",
+    "  css: '^ { color: $brandInk; }'",
+    "});"
+  ].join('\n');
+  var pairForm = [
+    "foam.CLASS({",
+    "  package: 'lsptest.css', name: 'PairForm',",
+    "  cssTokens: [ ['brandPaper', '#fefefe'] ],",
+    "  css: '^ { background: $brandPaper; }'",
+    "});"
+  ].join('\n');
+  var objForm = [
+    "foam.CLASS({",
+    "  package: 'lsptest.css', name: 'ObjForm',",
+    "  cssTokens: [ { name: 'brandEdge', value: '#000001' } ],",
+    "  css: '^ { border-color: $brandEdge; } .x { color: $noSuchToken; }'",
+    "});"
+  ].join('\n');
+
+  function unknownTokenDiags(text, name) {
+    var diags = diagWithTokens.handle(text, 'file:///tmp/lsptest-css-' + name + '.js');
+    return diags.filter(function(d) { return d.message.indexOf('Unknown CSS token') !== -1; });
+  }
+
+  test(unknownTokenDiags(mapForm, 'map').length === 0,
+    'map-form cssTokens recognized — no false Unknown CSS token');
+  test(unknownTokenDiags(pairForm, 'pair').length === 0,
+    'pair-form cssTokens recognized — no false Unknown CSS token');
+  var objDiags = unknownTokenDiags(objForm, 'obj');
+  test(objDiags.length === 1 && objDiags[0].message.indexOf('noSuchToken') !== -1,
+    'object form still validates AND genuinely unknown tokens still flagged');
+})();
+
 

--- a/tools/tests/lsp/foamIndex.js
+++ b/tools/tests/lsp/foamIndex.js
@@ -417,3 +417,16 @@ section('FoamIndex — failed grammar parse must not be cached against mtime');
   test(calls === 2, 'failed parse retried on next request, calls=' + calls);
   test(second && typeof second === 'object', 'retry succeeds and returns a posMap');
 })();
+
+// --- getOfUsers matches adapted (object-form) `of` values ---
+(function() {
+  foam.CLASS({ package: 'lsptest.of', name: 'Target' });
+  foam.CLASS({
+    package: 'lsptest.of', name: 'Holder',
+    properties: [ { class: 'FObjectProperty', of: 'lsptest.of.Target', name: 'target' } ]
+  });
+  delete index.cache_['of_lsptest.of.Target'];
+  var users = index.getOfUsers('lsptest.of.Target');
+  test(users.indexOf('lsptest.of.Holder') !== -1,
+    'of-user found regardless of adapted of shape, got ' + JSON.stringify(users));
+})();

--- a/tools/tests/lsp/foamIndex.js
+++ b/tools/tests/lsp/foamIndex.js
@@ -385,3 +385,35 @@ section('FoamIndex — swallowed catches leave a trace');
     return typeof m === 'string' && m.indexOf('[foam-lsp]') === 0 && m.indexOf('Broken.js') !== -1;
   }), 'indexFileClasses_ failure leaves a [foam-lsp] trace naming the file, got: ' + JSON.stringify(captured));
 })();
+
+section('FoamIndex — failed grammar parse must not be cached against mtime');
+
+// --- a transient parse fault is retried, not pinned to the file's mtime ---
+(function() {
+  var os = require('os'), fs = require('fs'), path = require('path');
+  var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'foamindex-poscache-'));
+  var f = path.join(dir, 'X.js');
+  fs.writeFileSync(f, "foam.CLASS({ package: 'x', name: 'X', properties: [ 'a' ] });");
+
+  var grammar = index.getGrammar();
+  var origCollect = grammar.collectAxiomPositions;
+  var calls = 0;
+  grammar.collectAxiomPositions = function(content) {
+    calls++;
+    if ( calls === 1 ) throw new Error('transient parse fault');
+    return origCollect.call(grammar, content);
+  };
+  var origErr = console.error;
+  var first, second;
+  try {
+    console.error = function() {};
+    first  = index.getFilePosMap_(f);   // parse throws -> null, NOT cached
+    second = index.getFilePosMap_(f);   // must RETRY (mtime unchanged)
+  } finally {
+    console.error = origErr;
+    grammar.collectAxiomPositions = origCollect;
+  }
+  test(first === null, 'failed parse returns null');
+  test(calls === 2, 'failed parse retried on next request, calls=' + calls);
+  test(second && typeof second === 'object', 'retry succeeds and returns a posMap');
+})();

--- a/tools/tests/lsp/foamIndex.js
+++ b/tools/tests/lsp/foamIndex.js
@@ -355,3 +355,33 @@ if ( index.classExists(JAVA_CLASS) && index.getFilePath(JAVA_CLASS) ) {
 } else {
   test(true, 'Java-only method tests skipped (FObject not in file index)');
 }
+
+// === SWALLOWED CATCH TRACES (Task 5) ===
+// indexFileClasses_/POM walk/cspec scan must leave a [foam-lsp] trace on
+// failure instead of silently dropping the file — same fallback, new trace.
+
+section('FoamIndex — swallowed catches leave a trace');
+
+// --- indexFileClasses_ logs instead of silently dropping a file ---
+(function() {
+  var os = require('os'), fs = require('fs'), path = require('path');
+  var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'foamindex-catch-'));
+  var bad = path.join(dir, 'Broken.js');
+  // FileModelCache.parseFileModels swallows a plain syntax error internally
+  // (returns [] without throwing), so force the throw past that layer: the
+  // eval-intercept executes the object literal, so a throwing getter fires
+  // while indexFileClasses_'s own model-walk loop is still running.
+  fs.writeFileSync(bad, "foam.CLASS({ get name() { throw new Error('boom'); } });");
+
+  var captured = [];
+  var orig = console.error;
+  console.error = function(msg) { captured.push(msg); };
+  try {
+    index.indexFileClasses_(bad, [], 'pom.js', 'Broken', fs);
+  } finally {
+    console.error = orig;
+  }
+  test(captured.some(function(m) {
+    return typeof m === 'string' && m.indexOf('[foam-lsp]') === 0 && m.indexOf('Broken.js') !== -1;
+  }), 'indexFileClasses_ failure leaves a [foam-lsp] trace naming the file, got: ' + JSON.stringify(captured));
+})();

--- a/tools/tests/lsp/java.js
+++ b/tools/tests/lsp/java.js
@@ -812,5 +812,29 @@ for ( var ai3 = 0 ; ai3 < genLines.length ; ai3++ ) {
   }
 }
 
+// --- resolveJavaTypeName vs JavaImport objects (refines path) ---
+(function() {
+  foam.CLASS({ package: 'lsptestc', name: 'Pelican', properties: [ 'x' ] });
+  foam.CLASS({
+    package: 'lsptestc', name: 'PelicanUser',
+    javaImports: [ 'lsptestc.Pelican' ]
+  });
+  var cls = foam.lookup('lsptestc.PelicanUser');
+  // Simulate SemanticTokenHandler's effectiveModel for a refines file:
+  // registry javaImports (JavaImport objects after java refinements boot,
+  // raw strings otherwise) — force the object form so the same-package
+  // fallback can't mask a broken import path.
+  var model = { javaImports: [ { name: 'javaimport_lsptestc.Pelican', import: 'lsptestc.Pelican' } ],
+                package: 'other.pkg' };
+  var resolved;
+  try {
+    resolved = analyzer.resolveJavaTypeName('Pelican', model, index);
+  } catch (e) {
+    test(false, 'resolveJavaTypeName threw on registry javaImports: ' + e.message);
+  }
+  test(resolved === 'lsptestc.Pelican',
+    'resolveJavaTypeName resolves via registry-form javaImports, got ' + resolved);
+})();
+
 // === MESSAGE AXIOM: hover + go-to-definition ===
 

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -1130,5 +1130,40 @@ try {
   test(false, 'jrl references acceptance threw: ' + err.message);
 }
 
+// === referencesForClassId string-usage probe — full id + short name ===
+
+section('referencesForClassId — string-usage probe by full id');
+
+var refsHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+  index: index, cache: cache, analyzer: analyzer
+});
+
+// --- referencesForClassId probes string-usage index by FULL id too ---
+(function() {
+  // The cspec half of the string-usage index records ent.id — full dotted
+  // ids. A class whose SHORT name never appears as a context key is only
+  // reachable through the full-id probe.
+  //
+  // sourceClassId is a real, file-backed class (foam.core.boot.CSpec,
+  // already proven indexed above) rather than a synthetic one: buildLocations_
+  // needs a source file to resolve a location for, and a class registered
+  // only in-memory during this test has none — it would report 0 locations
+  // even once the probe correctly reaches it, masking the fix under test.
+  var stub = index.getStringUsages;
+  index.getStringUsages = function(key) {
+    if ( key === 'lsptest.probe.FullIdOnly' ) {
+      return [ { sourceClassId: 'foam.core.boot.CSpec', axiomName: 'imports.x', kind: 'usage-string' } ];
+    }
+    return [];
+  };
+  foam.CLASS({ package: 'lsptest.probe', name: 'FullIdOnly' });
+  try {
+    var locs = refsHandler.referencesForClassId('lsptest.probe.FullIdOnly');
+    test(locs.length >= 1, 'full-id string usage reached the result, got ' + locs.length);
+  } finally {
+    index.getStringUsages = stub;
+  }
+})();
+
 // === SAVE → TARGETED REANALYZE ===
 

--- a/tools/tests/lsp/navigation.js
+++ b/tools/tests/lsp/navigation.js
@@ -729,6 +729,34 @@ if ( anyFilePath ) {
   test(res.filesFailed === 1, 'the throwing file counts as failed, got ' + res.filesFailed);
 })();
 
+// analyze(): the progress-loop path (scanFileInto_ / newAcc_ / finalizeAcc_)
+// gets the same success-only treatment as analyzeFiles above. analyze() takes
+// no explicit file list — it derives one from collectFilePaths_(), which reads
+// the (fully-built) shared index. Stub collectFilePaths_ on a throwaway
+// analyzer instance so this run sees exactly our two fixture files without
+// touching the shared index used by every other test in this file.
+(function() {
+  var os = require('os');
+  var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wsa-failed-progress-'));
+  var good = path.join(dir, 'Good.js');
+  fs.writeFileSync(good, "foam.CLASS({ package: 'x', name: 'Good', properties: [ 'a' ] });");
+  var missing = path.join(dir, 'Gone.js');   // never written -> readFileSync throws
+
+  var progressAnalyzer = foam.parse.lsp.handlers.WorkspaceAnalyzer.create({ index: index });
+  progressAnalyzer.collectFilePaths_ = function() { return [ good, missing ]; };
+
+  var origErr = console.error;
+  console.error = function() {};
+  var res;
+  try {
+    res = progressAnalyzer.analyze();
+  } finally {
+    console.error = origErr;
+  }
+  test(res.filesScanned === 1, 'analyze(): only the readable file counts as scanned, got ' + res.filesScanned);
+  test(res.filesFailed === 1, 'analyze(): the throwing file counts as failed, got ' + res.filesFailed);
+})();
+
 // === LSP #4999 Fix 1: property-type completion inserts full path (except foam.lang.*) ===
 
 

--- a/tools/tests/lsp/navigation.js
+++ b/tools/tests/lsp/navigation.js
@@ -709,6 +709,26 @@ if ( anyFilePath ) {
     'analyzeFiles returns fileResults map');
 }
 
+// analyzeFiles: a file that throws (missing path) is filesFailed, not filesScanned
+(function() {
+  var os = require('os');
+  var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wsa-failed-'));
+  var good = path.join(dir, 'Good.js');
+  fs.writeFileSync(good, "foam.CLASS({ package: 'x', name: 'Good', properties: [ 'a' ] });");
+  var missing = path.join(dir, 'Gone.js');   // never written -> readFileSync throws
+
+  var origErr = console.error;
+  console.error = function() {};
+  var res;
+  try {
+    res = analyzer.analyzeFiles([ good, missing ]);
+  } finally {
+    console.error = origErr;
+  }
+  test(res.filesScanned === 1, 'only the readable file counts as scanned, got ' + res.filesScanned);
+  test(res.filesFailed === 1, 'the throwing file counts as failed, got ' + res.filesFailed);
+})();
+
 // === LSP #4999 Fix 1: property-type completion inserts full path (except foam.lang.*) ===
 
 

--- a/tools/tests/lsp/usageIndex.js
+++ b/tools/tests/lsp/usageIndex.js
@@ -419,3 +419,44 @@ try {
 } catch (err) {
   test(false, 'ArraySink acceptance threw: ' + err.message);
 }
+
+
+// === memberReferencesForClassId — property call-site LINES (byName path) ===
+//
+// foam/byName `references` ignored memberName: Class.member returned class
+// references, never the member's call-site lines (#5265-adjacent blind spot,
+// verified 2026-08-23: byNameResult had no member branch). The by-id core of
+// propertyReferences_ now serves it. Truth is self-derived: the expected
+// line is found by scanning the real source file, so upstream churn moves
+// the expectation instead of breaking it.
+
+section('memberReferencesForClassId — property call-site lines (byName member path)');
+
+try {
+  var mrHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+    index: index, cache: cache, analyzer: analyzer
+  });
+
+  var mrLocs = mrHandler.memberReferencesForClassId('foam.dao.ArraySink', 'array');
+  test(Array.isArray(mrLocs) && mrLocs.length > 0,
+    'memberReferencesForClassId(ArraySink, array): returns locations');
+
+  var mrFs    = require('fs');
+  var mrPath  = index.getFilePath('foam.dao.ArraySink');
+  var mrLines = mrFs.readFileSync(mrPath, 'utf8').split('\n');
+  var mrPushLine = -1;
+  for ( var mi = 0 ; mi < mrLines.length ; mi++ ) {
+    if ( mrLines[mi].indexOf('this.array.push') !== -1 ) { mrPushLine = mi; break; }
+  }
+  test(mrPushLine !== -1, 'fixture: ArraySink.js still has a this.array.push call site');
+  test((mrLocs || []).some(function(l) {
+    return l.uri === 'file://' + mrPath && l.range.start.line === mrPushLine;
+  }), 'usage LINE matched: this.array.push call site at line ' + mrPushLine + ' (not the declaration)');
+
+  // Not an own property/message/constant: null so the caller falls back to
+  // class references (methods keep going through callHierarchy).
+  test(mrHandler.memberReferencesForClassId('foam.dao.ArraySink', 'noSuchMember') === null,
+    'unknown member returns null (falls back to class references)');
+} catch (err) {
+  test(false, 'member references section threw: ' + err.message);
+}

--- a/tools/tests/lsp/usageIndex.js
+++ b/tools/tests/lsp/usageIndex.js
@@ -336,3 +336,86 @@ try {
   console.error = lcOrigErr;
   test(false, 'logged-catch section threw: ' + err.message);
 }
+
+
+// === FoamIndex Java usage — cross-package via javaImports (issue #5265) ===
+//
+// The fixture above puts Source and Target in the SAME package, so it
+// resolves through the package fallback and never exercises the javaImports
+// lookup. These classes are cross-package on purpose: only javaImports can
+// resolve the short name. Fixture provenance: at boot the java refinements
+// adapt each javaImports string into a foam.java.JavaImport object
+// ({ name: generated 'javaimport_'+import label, import: full path }) —
+// the form production hands buildJavaUsageIndex_, and the form these
+// runtime-declared classes carry too (probed 2026-08-23).
+
+section('FoamIndex Java usage — cross-package javaImports (issue #5265)');
+
+foam.CLASS({
+  package: 'foam.parse.lsp.javausagetest.pkga',
+  name:    'CrossPkgTarget'
+});
+
+foam.CLASS({
+  package: 'foam.parse.lsp.javausagetest.pkgb',
+  name:    'CrossPkgSource',
+  javaImports: [ 'foam.parse.lsp.javausagetest.pkga.CrossPkgTarget' ],
+  methods: [
+    {
+      name:     'doIt',
+      javaCode: 'CrossPkgTarget t = new CrossPkgTarget();\nreturn t.toString();'
+    }
+  ]
+});
+
+index.invalidateSymbolIndex_();
+
+try {
+  // Provenance guard: if FOAM ever stops adapting strings to JavaImport
+  // objects, this fixture no longer represents production — fail loudly.
+  var xSrc = foam.maybeLookup('foam.parse.lsp.javausagetest.pkgb.CrossPkgSource');
+  var xJi  = xSrc.model_.javaImports[0];
+  test(xJi && typeof xJi !== 'string' && typeof xJi.import === 'string',
+    'fixture provenance: javaImports adapted to JavaImport objects at boot');
+
+  // T1a: cross-package javaCode consumer recorded.
+  var xUses = index.getJavaUsages('foam.parse.lsp.javausagetest.pkga.CrossPkgTarget');
+  test(xUses.some(function(u) { return u.sourceClassId === 'foam.parse.lsp.javausagetest.pkgb.CrossPkgSource'; }),
+    'cross-package javaCode consumer recorded via JavaImport object (issue #5265)');
+
+  // T1b: the generated JavaImport.name label is never a usage key.
+  test(index.getJavaUsages('javaimport_foam.parse.lsp.javausagetest.pkga.CrossPkgTarget').length === 0,
+    'generated javaimport_ label is not a usage key');
+} catch (err) {
+  test(false, 'cross-package java usage threw: ' + err.message);
+}
+
+
+// === Spec acceptance (issue #5265 repro): real workspace consumer ===
+//
+// Pinned to real foam3 classes on purpose — this is the literal issue repro.
+// If upstream churn ever removes DisableOldReferralCodesRuleAction, replace
+// with a committed fixture file registered under a test pom (spec, Testing).
+
+section('getJavaUsages — real workspace acceptance (issue #5265)');
+
+try {
+  var arraySinkUses = index.getJavaUsages('foam.dao.ArraySink');
+  test(arraySinkUses.some(function(u) {
+    return u.sourceClassId === 'foam.core.referral.DisableOldReferralCodesRuleAction';
+  }), 'issue #5265 repro: DisableOldReferralCodesRuleAction recorded as javaCode consumer of ArraySink');
+
+  // Location level (T2a): the consumer's FILE appears at usage lines —
+  // depends on the index fix; the handler + dedup landed in the earlier
+  // stacked tasks (execution order: Task 2 -> Task 3 -> this task).
+  var asHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+    index: index, cache: cache, analyzer: analyzer
+  });
+  var drcLocs = asHandler.referencesForClassId('foam.dao.ArraySink').filter(function(l) {
+    return l.uri.indexOf('DisableOldReferralCodesRuleAction.js') !== -1;
+  });
+  test(drcLocs.length >= 2,
+    'referencesForClassId(ArraySink): javaCode-only consumer file present at usage lines (got ' + drcLocs.length + ')');
+} catch (err) {
+  test(false, 'ArraySink acceptance threw: ' + err.message);
+}

--- a/tools/tests/lsp/usageIndex.js
+++ b/tools/tests/lsp/usageIndex.js
@@ -462,6 +462,57 @@ try {
 }
 
 
+// === memberScanLocations_ — dedup when multiple classes share a file ===
+//
+// Same dup shape as referencesForClassId's fix, but for the member scan:
+// filesToScan can list several class ids (the defining class + a subclass +
+// a requirer) that all resolve to the SAME source file, and each id is
+// scanned unconditionally — every real call-site row then repeats once per
+// class id that maps to that file.
+
+section('memberScanLocations_ — dedup when multiple classes share a file');
+
+(function() {
+  var os = require('os'), fs = require('fs'), path = require('path');
+  var dir = fs.mkdtempSync(path.join(os.tmpdir(), 'member-dedup-'));
+  var f = path.join(dir, 'Pair.js');
+  // TwoA extends lsptest.dedup.Base and TwoB requires it — BOTH ids resolve
+  // to this one file, which without dedup is scanned once per id, doubling
+  // every `.payload` row.
+  fs.writeFileSync(f, [
+    "foam.CLASS({ package: 'lsptest.dedup', name: 'TwoA', extends: 'lsptest.dedup.Base',",
+    "  methods: [ function m() { return this.payload; } ] });",
+    "foam.CLASS({ package: 'lsptest.dedup', name: 'TwoB',",
+    "  requires: [ 'lsptest.dedup.Base' ],",
+    "  methods: [ function n() { var b = this.Base.create(); return b.payload; } ] });"
+  ].join('\n'));
+
+  foam.CLASS({ package: 'lsptest.dedup', name: 'Base', properties: [ 'payload' ] });
+  foam.CLASS({ package: 'lsptest.dedup', name: 'TwoA', extends: 'lsptest.dedup.Base' });
+  foam.CLASS({ package: 'lsptest.dedup', name: 'TwoB', requires: [ 'lsptest.dedup.Base' ] });
+
+  // Point all three classes' fileIndex entries at the one fixture file:
+  index.fileIndex_ = index.fileIndex_ || {};
+  index.fileIndex_['lsptest.dedup.Base'] = { path: f, line: 0 };
+  index.fileIndex_['lsptest.dedup.TwoA'] = { path: f, line: 0 };
+  index.fileIndex_['lsptest.dedup.TwoB'] = { path: f, line: 2 };
+
+  var dedupMemberHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+    index: index, cache: cache, analyzer: analyzer
+  });
+  var locs = dedupMemberHandler.memberScanLocations_('lsptest.dedup.Base', 'payload');
+  var keys = {};
+  var dups = 0;
+  for ( var i = 0 ; i < locs.length ; i++ ) {
+    var k = locs[i].uri + ':' + locs[i].range.start.line + ':' + locs[i].range.start.character;
+    if ( keys[k] ) dups++;
+    keys[k] = true;
+  }
+  test(locs.length > 0, 'memberScanLocations_: member scan found rows in the fixture');
+  test(dups === 0, 'memberScanLocations_: no duplicate member rows for a shared file, found ' + dups + ' dups');
+})();
+
+
 // === logLspError helper ===
 //
 // Single logging idiom for degraded-but-not-fatal LSP failures — every

--- a/tools/tests/lsp/usageIndex.js
+++ b/tools/tests/lsp/usageIndex.js
@@ -534,3 +534,25 @@ section('logLspError helper');
   test(leCaptured.length === 1 && leCaptured[0] === '[foam-lsp] test op for X: boom',
     'logLspError formats [foam-lsp] context: message');
 })();
+
+// === locationSink_ — the dedup guard lives in the sink, not the call sites ===
+// Every collector feeding one references result pushes through this sink, so
+// a future collector can't silently reintroduce duplicate rows.
+section('ReferencesHandler.locationSink_ — gated dedup');
+
+try {
+  var sinkHandler = foam.parse.lsp.handlers.ReferencesHandler.create({
+    index: index, analyzer: analyzer, cache: cache
+  });
+  var sk = sinkHandler.locationSink_();
+  var mkLoc = function(line) {
+    return { uri: 'file:///x.js', range: { start: { line: line, character: 2 }, end: { line: line, character: 5 } } };
+  };
+  test(sk.push(mkLoc(1)) === true,  'first push of a location is kept (returns true)');
+  test(sk.push(mkLoc(1)) === false, 'second push of the same position is dropped (returns false)');
+  test(sk.push(mkLoc(2)) === true,  'different position is kept');
+  test(sk.locations.length === 2 && sk.length === 2,
+    'sink.locations holds kept rows and sink.length mirrors it (for capped collectors)');
+} catch (err) {
+  test(false, 'locationSink_ section threw: ' + err.message);
+}

--- a/tools/tests/lsp/usageIndex.js
+++ b/tools/tests/lsp/usageIndex.js
@@ -460,3 +460,26 @@ try {
 } catch (err) {
   test(false, 'member references section threw: ' + err.message);
 }
+
+
+// === logLspError helper ===
+//
+// Single logging idiom for degraded-but-not-fatal LSP failures — every
+// catch-and-fallback site routes through this so a broken feature is never
+// silently indistinguishable from an empty result.
+
+section('logLspError helper');
+
+(function() {
+  var leLogLspError = require('../../lsp/logError').logLspError;
+  var leOrigErr = console.error;
+  var leCaptured = [];
+  console.error = function(msg) { leCaptured.push(msg); };
+  try {
+    leLogLspError('test op for X', new Error('boom'));
+  } finally {
+    console.error = leOrigErr;
+  }
+  test(leCaptured.length === 1 && leCaptured[0] === '[foam-lsp] test op for X: boom',
+    'logLspError formats [foam-lsp] context: message');
+})();


### PR DESCRIPTION
> **Prerequisites:** merge #5326, then #5327, before this one.

Correctness hardening across the LSP, following the reference-index work. Stacked on #5327; two commits are integration merges — the javaCode-references branch (its `javaImportPaths` normalizer is a dependency) and #5327's review-round fixes (realpath walk, journal-save invalidation). Both merges flatten away when this rebases onto development after the two base PRs merge — review this PR's own commits.

## Fixes

- **Object-form `of` in reference sweeps** (`getOfUsers`): property `of` values are objects (`{id}`) about 3× more often than strings — a workspace probe counted 1434 object-form vs 463 string values — so ~75% of typed-property reference edges were silently missing (e.g. `foam.mlang.Expr` never showed `foam.graphics.TreeNodeConfig.detailDataPathFromData`). Now both forms resolve.
- **`refines` semantic-tokens crash**: `resolveJavaTypeName` consumed `javaImports` raw; now goes through `javaImportPaths` (object-form safe), with a string-filter fallback when no index is available.
- **Failed-parse cache poisoning**: a file that fails to parse no longer caches an empty position map (which pinned member symbols to line 0 until restart); parse retries on next request.
- **`filesFailed` counting** in WorkspaceAnalyzer (both walk loops) so broken files are visible rather than silently skipped, plus coverage test.
- **Logged catches everywhere**: shared `logLspError` helper; all `ReferencesHandler` catches (including `getJrlUsages`) and 7 `FoamIndex` catches now emit `[foam-lsp]` traces instead of swallowing.
- **Dual-key string-usage probe**: string usages looked up by both short name and full class id.
- **Member-scan dedup** by position.
- **`cssTokens` all three declared forms** (array of strings, map, object entries) recognized by both collectors — no more false "Unknown CSS token" for map-form declarations.

## Testing

Full LSP suite: 1148 passed, 0 failed (integration baseline before these commits: 1131/0). Each fix carries a unit test; the object-form `of` fix includes a forced-object regression test.

## Known / disclosed

- The `of`-sweep surfaces pre-existing `FObjectSpec` console noise (present before this branch; not introduced here).
- `filesFailed` is counted but not yet exposed in the `foam/analyzeWorkspace` response — planned follow-up.


