### PR TITLE
Add foam-model-builder skill; document nested skill discovery

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,6 +1,9 @@
 # FOAM Agent Skills
 
-This directory holds [Claude Code Agent Skills](https://code.claude.com/docs/en/skills) that are authored **once here in `foam3`** and shared by every application that uses `foam3` as a git submodule. `foam3` is the single source of truth — apps do **not** copy the files, they symlink to them.
+This directory holds [Claude Code Agent Skills](https://code.claude.com/docs/en/skills) authored
+**once here in `foam3`** and available to every application that uses `foam3` as a git submodule.
+Applications do not copy the files and do not symlink them — Claude Code discovers them where
+they are.
 
 Each skill is a directory containing a `SKILL.md` (YAML frontmatter + instructions), e.g.:
 
@@ -10,48 +13,67 @@ foam3/.claude/skills/
     SKILL.md
 ```
 
-## Why this works
+## How consuming apps pick these up
 
-Claude Code discovers project-level skills under `<project-root>/.claude/skills/`, and **it follows symlinks** — a `<skill-name>` entry there may be a symlink to a directory elsewhere on disk, and Claude Code reads `SKILL.md` from the link target. Git stores symlinks natively (mode `120000`), so the link is committed, not the file contents. Working directly inside the `foam3` repo also picks these up, since `foam3/.claude/skills/` is then the project-level dir.
+Nothing to wire. Claude Code loads skills from nested `.claude/skills/` directories below the
+working directory: the first time Claude reads or edits a file under `foam3/`, the skills here
+become available for the rest of the session, listed under a directory-qualified name —
+`foam3:foam-view-builder`.
 
-## Wiring a skill into a consuming app
+Working directly inside the `foam3` repo, `foam3/.claude/skills/` **is** the project-level
+directory, so these load at startup under their plain names.
 
-From the **application repo root** (where `foam3/` is the submodule), create a symlink per skill you want, then commit it:
+## Skills that exist on both sides
 
-```bash
-mkdir -p .claude/skills
+An application may define a skill with the same name at its own root. Both stay available, and
+Claude Code routes between them:
 
-# one line per skill (relative target keeps it portable):
-ln -s ../../foam3/.claude/skills/foam-view-builder .claude/skills/foam-view-builder
-
-git add .claude/skills/foam-view-builder    # committed as a symlink
-git commit -m "Link foam-view-builder skill from foam3 submodule"
+```
+myapp/.claude/skills/foam-view-builder/        → "foam-view-builder"        (default)
+myapp/foam3/.claude/skills/foam-view-builder/  → "foam3:foam-view-builder"  (files under foam3/)
 ```
 
-The symlink target is **relative** (`../../foam3/...`) so it resolves the same in every checkout.
+Invoking the unqualified name loads the application's skill, and Claude Code appends the
+directory-qualified variants with an instruction to also invoke whichever one's directory holds
+the files being worked on. So the `foam3` version applies to `foam3` work without the
+application having to reference it.
+
+Because the two files are independent, the application's copy must stand on its own for work
+outside `foam3/` — a nested skill does not load while Claude is editing application code. Write
+the app-side skill as a complete document, not as a delta against this one.
+
+### Why not symlink
+
+A symlink makes both paths resolve to one file, and Claude Code loads a skill once per target.
+That is the right tool for using this skill *verbatim*, but it removes the application's ability
+to hold different content under the same name — the routing above stops being possible. Prefer
+nested discovery; reach for a symlink only when an app wants this exact file and no additions.
 
 ## Verifying
 
-- In a **new** Claude Code session (the skill registry loads at startup), run `/skills` — the skill should be listed. If you added it mid-session, restart first.
-- A fresh clone must have the submodule initialized for the link to resolve:
-  ```bash
-  git submodule update --init
-  ```
+- Run `/skills` after Claude has touched a file under `foam3/` — the `foam3:`-prefixed entries
+  should be listed. They are absent before that first read; that is expected, not a failure.
+- A fresh clone must have the submodule initialized: `git submodule update --init`.
 
-## Platform notes / no-symlink fallback
+## Out-of-tree checkouts
 
-FOAM builds on Linux and macOS, and on Windows **only under [WSL](https://learn.microsoft.com/windows/wsl/)** — a Linux environment. On all of these, symlinks work natively, so the setup above is the norm everywhere FOAM runs; there are no native-Windows `core.symlinks` / Developer-Mode caveats to worry about (you're in Linux under WSL).
-
-The only time you'd need a fallback is the rare case where a checkout genuinely can't create or follow the symlink (e.g. the repo was cloned onto a native-Windows filesystem, outside WSL, with symlink support off). There, add the submodule as an extra directory instead of symlinking:
+The discovery above requires `foam3/` to sit inside the working directory. When it does not,
+add it explicitly:
 
 ```bash
-claude --add-dir ./foam3
+claude --add-dir /path/to/foam3
 ```
 
-Claude Code loads `.claude/skills/` (and `.claude/commands/`) from `--add-dir` paths automatically.
+Claude Code loads `.claude/skills/` and `.claude/commands/` from each `--add-dir` directory. Note
+this is specific to `--add-dir` and `/add-dir`: the `permissions.additionalDirectories` setting in
+`settings.json` grants file access only and does **not** load skills.
 
 ## Adding a new shared skill
 
-1. Create `foam3/.claude/skills/<skill-name>/SKILL.md`. Keep the frontmatter to portable Agent-Skills fields (`name`, `description`; optionally `when_to_use`, `license`, `metadata`, `allowed-tools`) so it stays packageable.
-2. Commit it in the `foam3` repo.
-3. In each consuming app, add the symlink as shown above and bump the submodule pointer.
+1. Create `foam3/.claude/skills/<skill-name>/SKILL.md`. Keep the frontmatter to portable
+   Agent-Skills fields (`name`, `description`; optionally `when_to_use`, `license`, `metadata`,
+   `allowed-tools`) so it stays packageable.
+2. Keep `SKILL.md` short and move long pattern catalogues into `references/*.md` alongside it,
+   pointing at them from the body. Only `SKILL.md` loads when the skill is invoked; reference
+   files load when Claude actually needs them.
+3. Commit it here. Consuming apps pick it up on their next submodule bump — no per-app wiring.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -2,8 +2,8 @@
 
 This directory holds [Claude Code Agent Skills](https://code.claude.com/docs/en/skills) authored
 **once here in `foam3`** and available to every application that uses `foam3` as a git submodule.
-Applications do not copy the files and do not symlink them — Claude Code discovers them where
-they are.
+Applications do not copy the files, and normally do not symlink them either — Claude Code
+discovers them where they are. (One case still wants a symlink; see "Why not symlink" below.)
 
 Each skill is a directory containing a `SKILL.md` (YAML frontmatter + instructions), e.g.:
 

--- a/.claude/skills/foam-model-builder/SKILL.md
+++ b/.claude/skills/foam-model-builder/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: foam-model-builder
+description: >-
+  Author a FOAM model and wire it into the build — the `foam.CLASS` skeleton, choosing property classes, `id` and sequence numbers, the `services.jrl` DAO config, and the `pom.js` entry that makes it compile. Use when creating a model, adding properties to an existing one, setting up a DAO for it, or working out why a new model does not appear at runtime. Views are in `foam-view-builder`; framework-level design decisions are in the FOAM design guides.
+---
+
+# Authoring a FOAM Model
+
+Four steps: write the model, choose property classes, register a DAO, wire it into the POM.
+Skipping the last one is the usual reason a new model "does not exist" at runtime.
+
+## 1. Model skeleton
+
+```javascript
+foam.CLASS({
+  package: 'com.example',
+  name: 'Transaction',
+  properties: [
+    { class: 'Long', name: 'id' },
+    { class: 'String', name: 'accountId', aliases: ['account_id'] }
+  ],
+  methods: [...]
+});
+```
+
+- `package` + `name` form the class id (`com.example.Transaction`). That id is written into
+  journals, `services.jrl`, and every `of:` reference — it is the model's identity on disk.
+- `aliases` lets journal or upload data arrive under a different key (`account_id` →
+  `accountId`) without a transform in between.
+
+**Renaming a class breaks every existing journal.** FOAM3 has no class-alias mechanism:
+`context.lookup("com.old.ClassName")` asserts if the class is not registered, and there is no
+`classAliases`, no `legacyClassNames`, no `foam.registerClassAlias()`. Evolve in place — add
+new properties, hide old ones, migrate values via `javaPostSet` on the deprecated property.
+
+## 2. Property types
+
+**Verify the exact class name in `foam3/src/foam/lang/types.js` before use.** The names are
+case-sensitive and several near-misses do not exist.
+
+Common: `String`, `Int`, `Long`, `Float`, `Double`, `Boolean`, `Date`, `DateTime`, `DateTimeUTC`.
+
+- `DateTimeUTC` is correct (all caps); `DateTimeUtc` is not a class.
+- `DateTime` renders in the viewer's local timezone; `DateTimeUTC` renders in UTC. Pick by
+  what the value means, not by what looks right in your own timezone.
+
+**Do not restate a type's own default.** `String` → `''`, `Boolean` → `false`,
+`Int`/`Long`/`Float`/`Double` → `0`, `Array` → `[]`. Writing these adds noise and, for
+properties where "unset" is meaningful, defeats the `propertyNameIsSet_` check.
+
+## 3. `id` and sequence numbers
+
+- `id` should be `Long`, not `String`: `{ class: 'Long', name: 'id' }`.
+- **Never put `setSeqNo: true` on a model property.** Sequence numbers are a DAO concern —
+  configure them in `services.jrl` through the EasyDAO builder:
+
+  ```
+  return new foam.dao.EasyDAO.Builder(x).setSeqNo(true).setOf(MyModel.getOwnClassInfo()).build();
+  ```
+
+- When the source data carries its own preserved identifiers, keep them and declare a
+  multi-part key instead: `ids: ['seq']`.
+
+## 4. Register the DAO in `services.jrl`
+
+`services.jrl` defines DAO configuration — persistence, identifiers, journal file. Place it in
+the same directory as the models it serves; it is picked up from there automatically.
+
+- `.setSeqNo(true)` — auto-incrementing identifiers
+- `.setPm(true)` — wrap in PMDAO for performance measurement
+- `.setJournalName("filename")` — the journal file backing the DAO
+- `.setOf(YourModel.getOwnClassInfo())` — binds the DAO to the model
+
+## 5. Wire it into the POM
+
+`pom.js` files declare projects, dependencies, and per-file flags:
+
+```javascript
+foam.POM({
+  name: 'projectname',
+  projects: [...],
+  files: [ { name: 'MyModel', flags: 'js|java' } ],  // 'js', 'java', 'web', or combos
+  javaDependencies: [...]
+});
+```
+
+Add the model to the **nearest parent `pom.js`** — find it by searching for a sibling file's
+name. Flags select which targets the file is generated for:
+
+| File type | Where | Flag |
+|-----------|-------|------|
+| FOAM class (JS + Java) | `files:` | `"js\|java"` |
+| JS only | `files:` | `"js"` |
+| Java only (a real `.java` file) | `javaFiles:` | (none, or `"test"`) |
+| Dual implementation (separate JS and Java files) | BOTH | `"js"` in `files:`, entry in `javaFiles:` |
+| Test files | either | append `&test` |
+
+A `.jrl` in the same directory as the `pom.js` auto-loads — do **not** add it to the POM.
+`journalFiles:` is only for pulling journals in from another directory, which is rare.
+
+## Further reading
+
+- `foam3/doc/guides/POM.md` — the POM format in full
+- `foam3/doc/guides/EasyDao.md`, `foam3/doc/guides/Services.md` — DAO configuration
+- `foam3/doc/guides/PropertyGotchas.md` — when `postSet` never fires, expressions going cold,
+  the `isSet` gate, what `transient` cascades into
+- `foam3/doc/guides/DaoGotchas.md` — decorator ordering, frozen results, context scoping
+- `foam3/doc/guides/Journals.md` — journal format and replay
+
+## Project-specific rules
+
+An application built on foam3 may add its own model conventions — scoping properties, required
+audit fields, naming rules. Those live in that project's own `foam-model-builder` skill, which
+takes precedence outside `foam3/`, or in the nearest `CLAUDE.md`. Check there before assuming
+this guide is complete for the repository you are in.

--- a/.claude/skills/foam-model-builder/SKILL.md
+++ b/.claude/skills/foam-model-builder/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: foam-model-builder
 description: >-
-  Author a FOAM model and wire it into the build — the `foam.CLASS` skeleton, choosing property classes, `id` and sequence numbers, the `services.jrl` DAO config, and the `pom.js` entry that makes it compile. Use when creating a model, adding properties to an existing one, setting up a DAO for it, or working out why a new model does not appear at runtime. Views are in `foam-view-builder`; framework-level design decisions are in the FOAM design guides.
+  Author a FOAM model and wire it into the build — the `foam.CLASS` skeleton, choosing property classes, `id` and sequence numbers, the `services.jrl` DAO config, and the `pom.js` entry that makes it compile. Use when creating a model, adding properties to an existing one, setting up a DAO for it, or working out why a new model does not appear at runtime. Views are in `foam-view-builder`; framework-level design decisions are in `doc/guides/DesignPatterns.md`.
 ---
 
 # Authoring a FOAM Model
 
-Four steps: write the model, choose property classes, register a DAO, wire it into the POM.
+Five steps: write the model, choose property classes, settle the id, register a DAO, wire it
+into the POM.
 Skipping the last one is the usual reason a new model "does not exist" at runtime.
 
 ## 1. Model skeleton
@@ -27,6 +28,8 @@ foam.CLASS({
   journals, `services.jrl`, and every `of:` reference — it is the model's identity on disk.
 - `aliases` lets journal or upload data arrive under a different key (`account_id` →
   `accountId`) without a transform in between.
+- A new `.js` file starts with the Apache `@license` header every other file in the tree carries
+  — copy it from a neighbouring model rather than retyping it.
 
 **Renaming a class breaks every existing journal.** FOAM3 has no class-alias mechanism:
 `context.lookup("com.old.ClassName")` asserts if the class is not registered, and there is no

--- a/.claude/skills/foam-model-builder/SKILL.md
+++ b/.claude/skills/foam-model-builder/SKILL.md
@@ -35,7 +35,7 @@ new properties, hide old ones, migrate values via `javaPostSet` on the deprecate
 
 ## 2. Property types
 
-**Verify the exact class name in `foam3/src/foam/lang/types.js` before use.** The names are
+**Verify the exact class name in `src/foam/lang/types.js` before use.** The names are
 case-sensitive and several near-misses do not exist.
 
 Common: `String`, `Int`, `Long`, `Float`, `Double`, `Boolean`, `Date`, `DateTime`, `DateTimeUTC`.
@@ -60,6 +60,9 @@ properties where "unset" is meaningful, defeats the `propertyNameIsSet_` check.
 
 - When the source data carries its own preserved identifiers, keep them and declare a
   multi-part key instead: `ids: ['seq']`.
+- `seqNo`, `guid`, and `fuid` are **mutually exclusive** — pick one (`src/foam/dao/EasyDAO.js:417-435`).
+- The sequence lands on the property named by `seqPropertyName`, which defaults to `id`
+  (`src/foam/dao/EasyDAO.js:440-441`). Set it explicitly if your identifier is named anything else.
 
 ## 4. Register the DAO in `services.jrl`
 
@@ -100,12 +103,12 @@ A `.jrl` in the same directory as the `pom.js` auto-loads — do **not** add it 
 
 ## Further reading
 
-- `foam3/doc/guides/POM.md` — the POM format in full
-- `foam3/doc/guides/EasyDao.md`, `foam3/doc/guides/Services.md` — DAO configuration
-- `foam3/doc/guides/PropertyGotchas.md` — when `postSet` never fires, expressions going cold,
+- `doc/guides/POM.md` — the POM format in full
+- `doc/guides/EasyDao.md`, `doc/guides/Services.md` — DAO configuration
+- `doc/guides/PropertyGotchas.md` — when `postSet` never fires, expressions going cold,
   the `isSet` gate, what `transient` cascades into
-- `foam3/doc/guides/DaoGotchas.md` — decorator ordering, frozen results, context scoping
-- `foam3/doc/guides/Journals.md` — journal format and replay
+- `doc/guides/DaoGotchas.md` — decorator ordering, frozen results, context scoping
+- `doc/guides/Journals.md` — journal format and replay
 
 ## Project-specific rules
 


### PR DESCRIPTION
`.claude/skills/README.md` tells consuming apps to symlink each skill into their own `.claude/skills/`. That step isn't needed, and it blocks the case an app is most likely to want.

Claude Code already loads skills from nested `.claude/skills/` directories below the working directory. An app with foam3 as a subdirectory picks these up the first time Claude reads a file under `foam3/`, listed under a qualified name — `foam3:foam-view-builder`. No wiring, no committed link, nothing to keep in sync.

The symlink is also the wrong tool when an app wants its own version of a skill. A skill loads once per link target, so linking makes both paths resolve to a single file and the app can no longer differ. Leave the link out and both stay available: the app's own skill is the default, and the `foam3:`-qualified one takes priority for files under `foam3/`.

The README now documents that routing, plus the `--add-dir` path for checkouts where foam3 isn't a subdirectory. Worth knowing there: `--add-dir` loads skills from the added directory, but the `permissions.additionalDirectories` setting grants file access only and does not.

It also picks up a size rule — keep `SKILL.md` short and push long pattern catalogues into `references/*.md`, since only `SKILL.md` loads when a skill is invoked.

Second half of the PR is a new `foam-model-builder` skill: the `foam.CLASS` skeleton, choosing property classes, `id` and sequence numbers, DAO registration, and the `pom.js` entry that actually makes a model compile — that last one being the usual reason a new model "doesn't exist" at runtime. It leads with the trap that renaming a class breaks every existing journal, since there's no alias mechanism to fall back on.