### PR TITLE
fix(u2): hover-reveal the table sort arrow, make sorting keyboard-reachable

### DIFF
--- a/src/foam/u2/table/TableHeaderComponent.js
+++ b/src/foam/u2/table/TableHeaderComponent.js
@@ -16,7 +16,10 @@ foam.CLASS({
   ],
 
   messages: [
-    { name: 'TOOLTIP', message: 'Drag to Resize' }
+    { name: 'TOOLTIP', message: 'Drag to Resize' },
+    { name: 'SORT_BY', message: 'Sort by' },
+    { name: 'SORTED_ASCENDING', message: 'sorted ascending' },
+    { name: 'SORTED_DESCENDING', message: 'sorted descending' }
   ],
 
   constants: [
@@ -129,7 +132,7 @@ foam.CLASS({
               })
               .add(colHeader)
             .end()
-            .callIf(isFirstLevelProperty && prop.sortable, this.addSortAffordance_, [self, prop])
+            .callIf(isFirstLevelProperty && prop.sortable, this.addSortAffordance_, [self, prop, colHeader])
         .end()
         .startContext({data: this})
           .start(this.DRAG_TO_RESIZE, { buttonStyle: 'TERTIARY', themeIcon: 'drag', size: 'SMALL' })
@@ -160,31 +163,53 @@ foam.CLASS({
     // Called with `this` bound to the element it builds into
     // (foam.lang.Fluent.call/callIf), so the header component arrives as
     // the `self` argument.
-    function addSortAffordance_(self, prop) {
+    function addSortAffordance_(self, prop, colHeader) {
       // `this`: the header's inner flex row - label and arrow together are
       // the click target.
       var view = self.data;
-      var currArrow = view.restingIcon;
-      this.on('click', function(e) {
-        view.sortBy(prop);
-      }).
-      callIf(prop.label !== '', function() {
-        this.start()
-          .start('img')
-            .style({ 'max-width': 'initial' })
-            .attr('src', this.slot(function(view$order) {
-              var order = view$order;
-              if ( prop === order ) {
-                currArrow = view.ascIcon;
-              } else {
-                if ( view.Desc.isInstance(order) && order.arg1 === prop )
-                currArrow = view.descIcon;
-              }
-              return currArrow;
-            }, view.order$))
-          .end()
-        .end();
+      // '' whenever another column (or nothing) holds the sort, so a column
+      // that loses the sort falls back to the resting arrow instead of
+      // keeping the direction it was last sorted by.
+      var sortState$ = view.order$.map(function(order) {
+        if ( prop === order ) return 'asc';
+        if ( view.Desc.isInstance(order) && order.arg1 === prop ) return 'desc';
+        return '';
       });
+
+      this
+        .addClass(view.myClass('sortable'))
+        // A div carries no semantics of its own: without these the column can
+        // only be sorted with a mouse, and a screen reader is never told the
+        // header does anything or which way the table is sorted.
+        .attrs({ role: 'button', tabindex: 0 })
+        .attr('aria-label', sortState$.map(function(s) {
+          return self.SORT_BY + ' ' + colHeader +
+            ( s === 'asc'  ? ', ' + self.SORTED_ASCENDING  :
+              s === 'desc' ? ', ' + self.SORTED_DESCENDING : '' );
+        }))
+        .on('click', function(e) {
+          view.sortBy(prop);
+        })
+        .on('keydown', function(e) {
+          if ( e.key !== 'Enter' && e.key !== ' ' ) return;
+          // Space would scroll the table; Enter would re-fire as a click.
+          e.preventDefault();
+          view.sortBy(prop);
+        })
+        .callIf(prop.label !== '', function() {
+          this.start()
+            .addClass(view.myClass('sortIcon'))
+            .enableClass(view.myClass('sortIconActive'), sortState$.map(function(s) { return !! s; }))
+            .start('img')
+              .style({ 'max-width': 'initial' })
+              .attr('src', sortState$.map(function(s) {
+                if ( s === 'asc' )  return view.ascIcon;
+                if ( s === 'desc' ) return view.descIcon;
+                return view.restingIcon;
+              }))
+            .end()
+          .end();
+        });
     },
 
     function updateDragWidth() {

--- a/src/foam/u2/table/TableHeaderComponent.js
+++ b/src/foam/u2/table/TableHeaderComponent.js
@@ -170,11 +170,19 @@ foam.CLASS({
       // '' whenever another column (or nothing) holds the sort, so a column
       // that loses the sort falls back to the resting arrow instead of
       // keeping the direction it was last sorted by.
-      var sortState$ = view.order$.map(function(order) {
+      //
+      // Built with slot() rather than view.order$.map(): both make an
+      // ExpressionSlot subscribed to order$, but slot() also registers it
+      // for detach. order$ belongs to the table, which outlives this header,
+      // so an unregistered subscription would keep the header and its
+      // closures alive for as long as the table lives. The slots derived
+      // from this one below need no such registration - they subscribe to
+      // sortState$, not to anything the table holds.
+      var sortState$ = this.slot(function(order) {
         if ( prop === order ) return 'asc';
         if ( view.Desc.isInstance(order) && order.arg1 === prop ) return 'desc';
         return '';
-      });
+      }, view.order$);
 
       this
         .addClass(view.myClass('sortable'))
@@ -193,7 +201,12 @@ foam.CLASS({
         .on('keydown', function(e) {
           if ( e.key !== 'Enter' && e.key !== ' ' ) return;
           // Space would scroll the table; Enter would re-fire as a click.
+          // Kept ahead of the repeat check so a held Space still cannot
+          // scroll on the repeats it is about to be ignored for.
           e.preventDefault();
+          // A held key auto-repeats keydown and preventDefault does not stop
+          // the repeat, so without this, holding Space re-sorts continuously.
+          if ( e.repeat ) return;
           view.sortBy(prop);
         })
         .callIf(prop.label !== '', function() {

--- a/src/foam/u2/table/TableHeaderComponent.js
+++ b/src/foam/u2/table/TableHeaderComponent.js
@@ -129,29 +129,7 @@ foam.CLASS({
               })
               .add(colHeader)
             .end()
-            .callIf(isFirstLevelProperty && prop.sortable, function() {
-              var currArrow = view.restingIcon;
-              this.on('click', function(e) {
-                view.sortBy(prop);
-              }).
-              callIf(prop.label !== '', function() {
-                this.start()
-                  .start('img')
-                    .style({ 'max-width': 'initial' })
-                    .attr('src', this.slot(function(view$order) {
-                      var order = view$order;
-                      if ( prop === order ) {
-                        currArrow = view.ascIcon;
-                      } else {
-                        if ( view.Desc.isInstance(order) && order.arg1 === prop )
-                        currArrow = view.descIcon;
-                      }
-                      return currArrow;
-                    }, view.order$))
-                  .end()
-                .end();
-              });
-            })
+            .callIf(isFirstLevelProperty && prop.sortable, this.addSortAffordance_, [self, prop])
         .end()
         .startContext({data: this})
           .start(this.DRAG_TO_RESIZE, { buttonStyle: 'TERTIARY', themeIcon: 'drag', size: 'SMALL' })
@@ -177,6 +155,36 @@ foam.CLASS({
       // A header can be torn down mid-drag (columns_ rebuild); release
       // everything the drag holds.
       this.onDetach(function() { self.endDrag_(); });
+    },
+
+    // Called with `this` bound to the element it builds into
+    // (foam.lang.Fluent.call/callIf), so the header component arrives as
+    // the `self` argument.
+    function addSortAffordance_(self, prop) {
+      // `this`: the header's inner flex row - label and arrow together are
+      // the click target.
+      var view = self.data;
+      var currArrow = view.restingIcon;
+      this.on('click', function(e) {
+        view.sortBy(prop);
+      }).
+      callIf(prop.label !== '', function() {
+        this.start()
+          .start('img')
+            .style({ 'max-width': 'initial' })
+            .attr('src', this.slot(function(view$order) {
+              var order = view$order;
+              if ( prop === order ) {
+                currArrow = view.ascIcon;
+              } else {
+                if ( view.Desc.isInstance(order) && order.arg1 === prop )
+                currArrow = view.descIcon;
+              }
+              return currArrow;
+            }, view.order$))
+          .end()
+        .end();
+      });
     },
 
     function updateDragWidth() {

--- a/src/foam/u2/table/TableView.js
+++ b/src/foam/u2/table/TableView.js
@@ -121,6 +121,16 @@
        hover, so there the arrow stays visible. */
     ^sortable {
       cursor: pointer;
+      border-radius: 4px;
+      padding: 0.2em;
+    }
+
+    /* The header is focusable, so it needs a visible focus state. Inset the
+       outline: ^th clips its overflow, so a ring drawn outside the box would
+       be cut off. :focus-visible so a mouse click leaves no ring behind. */
+    ^sortable:focus-visible {
+      outline: 2px solid $borderBrand;
+      outline-offset: -2px;
     }
 
     ^sortIcon {

--- a/src/foam/u2/table/TableView.js
+++ b/src/foam/u2/table/TableView.js
@@ -114,8 +114,31 @@
       margin-left: 8px;
     }
 
-    ^th:hover {
+    /* Sort affordance. The sorted column keeps its arrow on screen; an
+       unsorted column reveals the resting arrow on hover or keyboard focus.
+       Opacity rather than display so the header never reflows, and the
+       hiding is confined to hover-capable pointers - a touch device has no
+       hover, so there the arrow stays visible. */
+    ^sortable {
       cursor: pointer;
+    }
+
+    ^sortIcon {
+      align-items: center;
+      display: flex;
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      ^sortIcon {
+        opacity: 0;
+        transition: opacity 0.1s ease;
+      }
+
+      ^sortable:hover ^sortIcon,
+      ^sortable:focus-within ^sortIcon,
+      ^sortIconActive {
+        opacity: 1;
+      }
     }
 
     /**

--- a/src/foam/u2/table/TableView.js
+++ b/src/foam/u2/table/TableView.js
@@ -122,6 +122,10 @@
     ^sortable {
       cursor: pointer;
       border-radius: 4px;
+      /* Padding keeps the focus ring off the glyphs. The negative side
+         margin gives it back, so a sortable label starts at the same x as a
+         non-sortable one instead of sitting 0.2em further into the column. */
+      margin: 0 -0.2em;
       padding: 0.2em;
     }
 


### PR DESCRIPTION
Three problems in the table column header, all in the sort affordance.

The resting arrow was painted on every sortable column at all times, so a
wide table showed a row of arrows that carried no information. It now
appears only on the sorted column, or while its header is hovered or
focused. The hiding is confined to hover-capable pointers via
@media (hover: hover) and (pointer: fine), so a touch device - which has no
hover - keeps the affordance. Opacity rather than display, so the header
never reflows when the arrow appears.

The arrow also lied. The icon came from a closure variable that was only
ever assigned in the ascending and descending branches, with no reset, so a
column that lost the sort kept the direction it was last sorted by. Sort A
then B and both looked sorted, while only B was. A derived sort-state slot
now returns ascending, descending, or unsorted as a first-class third case.

Sorting was mouse-only. The header is a plain div with a click handler: no
tabindex, no role, no key handler, and nothing announced. It now carries
role=button, tabindex and Enter/Space, plus an aria-label reporting the
current direction (strings added to messages: so they stay translatable).

Also: cursor: pointer moved off every header onto the sortable ones - it
previously claimed non-sortable columns were clickable.

The first commit is a pure move with no behaviour change, extracting the
sort block out of a 70-line render() chain so the fix is reviewable on its
own.

Verified in a running app: default state has role=button/tabindex=0 and
opacity 0; cursor is pointer on sortable columns and auto on non-sortable;
keyboard focus reveals the arrow; Enter sorts and updates the label; and
sorting a second column resets the first back to the resting arrow.