### PR TITLE
feat(u2): let a third activation clear a table's sort

### DIFF
--- a/src/foam/u2/table/TableHeaderComponent.js
+++ b/src/foam/u2/table/TableHeaderComponent.js
@@ -19,7 +19,8 @@ foam.CLASS({
     { name: 'TOOLTIP', message: 'Drag to Resize' },
     { name: 'SORT_BY', message: 'Sort by' },
     { name: 'SORTED_ASCENDING', message: 'sorted ascending' },
-    { name: 'SORTED_DESCENDING', message: 'sorted descending' }
+    { name: 'SORTED_DESCENDING', message: 'sorted descending' },
+    { name: 'ACTIVATE_TO_CLEAR', message: 'activate to clear sorting' }
   ],
 
   constants: [
@@ -182,10 +183,14 @@ foam.CLASS({
         // only be sorted with a mouse, and a screen reader is never told the
         // header does anything or which way the table is sorted.
         .attrs({ role: 'button', tabindex: 0 })
+        // The third state is only discoverable by trying it, so a reader
+        // that can't see the arrow is told the next activation clears it.
         .attr('aria-label', sortState$.map(function(s) {
-          return self.SORT_BY + ' ' + colHeader +
-            ( s === 'asc'  ? ', ' + self.SORTED_ASCENDING  :
-              s === 'desc' ? ', ' + self.SORTED_DESCENDING : '' );
+          if ( s === 'asc' ) return self.SORT_BY + ' ' + colHeader + ', ' + self.SORTED_ASCENDING;
+          if ( s === 'desc' )
+            return self.SORT_BY + ' ' + colHeader + ', ' + self.SORTED_DESCENDING +
+              ( view.allowSortReset ? ', ' + self.ACTIVATE_TO_CLEAR : '' );
+          return self.SORT_BY + ' ' + colHeader;
         }))
         .on('click', function(e) {
           view.sortBy(prop);

--- a/src/foam/u2/table/UnstyledTableView.js
+++ b/src/foam/u2/table/UnstyledTableView.js
@@ -115,11 +115,17 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'allowSortReset',
-      value: true,
+      value: false,
       documentation: `Whether a third activation of a sorted column clears the
         sort instead of flipping the direction again. Unsorted is the state
         every table loads in, so without this a user can only return to it by
-        reloading. Set false for a strict ascending/descending toggle.`
+        reloading.
+
+        Off by default: with a single sort column, clearing mostly costs the
+        user an extra activation on the way from descending back to
+        ascending. It earns its keep once a table can sort on several columns
+        at once, where dropping one column from the sort is a real operation
+        and not just a stop on the way round. Set true to opt in.`
     },
     {
       name: 'columns_',

--- a/src/foam/u2/table/UnstyledTableView.js
+++ b/src/foam/u2/table/UnstyledTableView.js
@@ -334,12 +334,14 @@ foam.CLASS({
   methods: [
     function sortBy(column) {
       var isNewOrderDesc = this.order === column;
+      var cleared        = false;
       // ascending -> descending -> unsorted (when allowed) -> ascending.
       if ( isNewOrderDesc ) {
         this.order = this.DESC(column);
       } else if ( this.allowSortReset && this.Desc.isInstance(this.order) &&
                   this.order.arg1 === column ) {
         this.clearProperty('order');
+        cleared = true;
       } else {
         this.order = column;
       }
@@ -349,7 +351,13 @@ foam.CLASS({
 
       var columns = this.memento.head.split(',');
       var mementoColumn = columns.find(c => this.returnMementoColumnNameDisregardSorting(c) === column.name)
-      var orderChar = isNewOrderDesc ? this.DESCENDING_ORDER_CHAR : this.ASCENDING_ORDER_CHAR;
+      // No marker at all when the sort was cleared: the two chars are the
+      // only thing shouldColumnBeSorted() looks at, so a bare column name is
+      // how the memento says 'present, not sorted'. Without the `cleared`
+      // check the third activation would fall through to the ascending
+      // marker, and the URL would claim a sort the table no longer has.
+      var orderChar = cleared ? '' :
+        isNewOrderDesc ? this.DESCENDING_ORDER_CHAR : this.ASCENDING_ORDER_CHAR;
       if ( ! mementoColumn ) {
         columns.push(column.name + orderChar);
       } else {

--- a/src/foam/u2/table/UnstyledTableView.js
+++ b/src/foam/u2/table/UnstyledTableView.js
@@ -113,6 +113,15 @@ foam.CLASS({
       name: 'order'
     },
     {
+      class: 'Boolean',
+      name: 'allowSortReset',
+      value: true,
+      documentation: `Whether a third activation of a sorted column clears the
+        sort instead of flipping the direction again. Unsorted is the state
+        every table loads in, so without this a user can only return to it by
+        reloading. Set false for a strict ascending/descending toggle.`
+    },
+    {
       name: 'columns_',
       documentation: `Internal prop used by the table view to render the columns,
         should always have the current table columns`,
@@ -325,9 +334,15 @@ foam.CLASS({
   methods: [
     function sortBy(column) {
       var isNewOrderDesc = this.order === column;
-      this.order = isNewOrderDesc ?
-        this.DESC(column) :
-        column;
+      // ascending -> descending -> unsorted (when allowed) -> ascending.
+      if ( isNewOrderDesc ) {
+        this.order = this.DESC(column);
+      } else if ( this.allowSortReset && this.Desc.isInstance(this.order) &&
+                  this.order.arg1 === column ) {
+        this.clearProperty('order');
+      } else {
+        this.order = column;
+      }
 
       if ( ! this.memento || this.memento.head.length == 0 )
         return;


### PR DESCRIPTION
Thank you to @abdelaziz-mahdy for questioning my assumptions about having only two states. So basically "third state" came thanks to him.

---

Stacked on #5353 u2-table-header-tidy - please merge that first; this PR
targets it, not development.

Sorting a column cycles ascending then descending, forever. Unsorted is the
state every table loads in, but once a header is clicked there is no way
back to it short of reloading the page. A state the app can reach and the
user cannot is worth fixing.

A third activation now clears the sort, behind an allowSortReset property
(default true) for apps that want the strict two-state toggle. Three-state
sorting is the default in AG Grid, MUI DataGrid, Ant Design and TanStack
Table, and it maps onto the aria-sort vocabulary - ascending, descending,
none - rather than inventing one.

Nothing in foam3 cleared a sort before this, so the default is the part
worth arguing about; it is a one-line flip to value: false if the
preference is to keep the current behaviour and let apps opt in.

The display half came for free: the sort-state slot from the base branch
already models unsorted as a first-class case, so the resting arrow and the
hidden state are already correct. The header's aria-label says the next
activation clears it, since the third state is otherwise invisible to a
reader that cannot see the arrow.

Verified in a running app - clicking one column four times cycles label,
arrow and actual row order through unsorted, ascending, descending, and
back to unsorted.