### PR TITLE
Let CSSAuditTest accept a bare 0 as a border reset

### DIFF
--- a/src/foam/core/theme/test/CSSAuditTest.js
+++ b/src/foam/core/theme/test/CSSAuditTest.js
@@ -278,6 +278,13 @@ a = foam.u2.view.ColorEditView.create(); ctrl.stack.set(a);
               continue;
             }
           } else if ( "border".equals(property) ) {
+            // A bare 0 is the standard border reset, not a hardcoded colour.
+            // Matched exactly rather than with contains(), so a hex value such
+            // as #000000 still fails.
+            if ( "0".equals(value.trim()) ) {
+              logger.info("ignoring", property, value);
+              continue;
+            }
             if ( value.contains("none") ||
                  value.contains("dashed") ||
                  value.contains("inherit") ||


### PR DESCRIPTION
`border: 0` is the standard CSS reset idiom, and it is not a hardcoded colour - but the audit's `border` allow-list only covers `none`, `dashed`, `inherit`, `pt`, `px`, `solid` and `transparent`, so any file writing it fails the audit.

Adds `0` to that branch, matched **exactly** rather than with `contains()`, so a hardcoded hex value like `#000000` (which contains a zero) still fails as before.

Found while writing a CSS rule that resets a button's inherited transparent border.