### PR TITLE
Add ClearableSearchField so search boxes have a real clear button

### DIFF
--- a/src/foam/core/boot/DAOConfigSummaryView.js
+++ b/src/foam/core/boot/DAOConfigSummaryView.js
@@ -209,7 +209,7 @@ foam.CLASS({
       class: 'String',
       name: 'search',
       view: {
-       class: 'foam.u2.SearchField',
+       class: 'foam.u2.ClearableSearchField',
        onKey: true
       },
       preSet: function(o, n) { this.daoCount = 0; return n; }

--- a/src/foam/core/boot/DataManagement.js
+++ b/src/foam/core/boot/DataManagement.js
@@ -126,7 +126,7 @@ foam.CLASS({
           class: 'String',
           name: 'search',
           view: {
-           class: 'foam.u2.SearchField',
+           class: 'foam.u2.ClearableSearchField',
            onKey: true
           },
           memorable: true,

--- a/src/foam/core/menu/VerticalMenu.js
+++ b/src/foam/core/menu/VerticalMenu.js
@@ -28,8 +28,7 @@ foam.CLASS({
     'foam.core.menu.Menu',
     'foam.core.menu.VerticalMenu',
     'foam.dao.ArraySink',
-    'foam.u2.SearchField',
-    'foam.u2.borders.ClearableSearchBorder'
+    'foam.u2.ClearableSearchField'
   ],
 
   messages: [
@@ -121,10 +120,10 @@ foam.CLASS({
       class: 'String',
       name: 'menuSearch',
       view: {
-        class: 'foam.u2.SearchField',
+        class: 'foam.u2.ClearableSearchField',
         onKey: true,
         ariaLabel: 'Menu Search',
-        autocomplete: false
+        autocomplete: 'off'
       },
       value: ''
     },
@@ -171,28 +170,17 @@ foam.CLASS({
     },
 
     function renderSearch(parentEl) {
-      // Menu search wrapped in ClearableSearchBorder. Kept as its own method
-      // so subclasses reuse it instead of copying the block.
-      var self = this;
-      var searchField = this.SearchField.create({
-        data$: this.menuSearch$,
-        onKey: true,
-        ariaLabel: this.MENU_SEARCH_LABEL,
-        autocomplete: false
-      }).attrs({ name: 'menuSearch' });
+      // Kept as its own method so subclasses reuse it instead of copying the block.
       parentEl
         .start()
         .show(this.searchShown_$)
         .addClass(this.myClass('search'))
-          .start(this.ClearableSearchBorder, {
-            textSlot: this.menuSearch$,
-            onClear: function() {
-              self.menuSearch = '';
-              searchField.focus();
-            }
+          .tag(this.ClearableSearchField, {
+            data$:        this.menuSearch$,
+            ariaLabel:    this.MENU_SEARCH_LABEL,
+            autocomplete: 'off',
+            inputName:    'menuSearch'
           })
-            .add(searchField)
-          .end()
         .end();
     },
 

--- a/src/foam/doc/ModelBrowser.js
+++ b/src/foam/doc/ModelBrowser.js
@@ -178,7 +178,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'query',
-      view: { class: 'foam.u2.SearchField', onKey: true }
+      view: { class: 'foam.u2.ClearableSearchField', onKey: true }
     },
     {
       class: 'String',

--- a/src/foam/u2/ClearableSearchField.js
+++ b/src/foam/u2/ClearableSearchField.js
@@ -1,0 +1,119 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.u2',
+  name: 'ClearableSearchField',
+  extends: 'foam.u2.View',
+
+  documentation: `
+    foam.u2.SearchField plus foam.u2.borders.ClearableSearchBorder: a search
+    input with a real, keyboard-reachable clear (X) button. Prefer it anywhere a
+    user types a filter.
+
+    SearchField is an <input>, so it cannot host the button as a child - hence a
+    composite view rather than a flag on SearchField.
+
+      { class: 'String', name: 'search', view: { class: 'foam.u2.ClearableSearchField' } }
+  `,
+
+  requires: [
+    'foam.u2.SearchField',
+    'foam.u2.borders.ClearableSearchBorder'
+  ],
+
+  css: `
+    ^ { width: 100%; }
+  `,
+
+  properties: [
+    {
+      class: 'Boolean',
+      name: 'onKey',
+      value: true,
+      documentation: 'Update data on every keystroke. On by default; blur-only search is rarely wanted.'
+    },
+    {
+      class: 'String',
+      name: 'placeholder',
+      documentation: `Overrides SearchField's 'Search...'. Also taken from the
+        property's own placeholder:, which a bare SearchField ignores.`
+    },
+    {
+      class: 'String',
+      name: 'ariaLabel'
+    },
+    {
+      class: 'String',
+      name: 'autocomplete'
+    },
+    {
+      class: 'String',
+      name: 'inputName',
+      documentation: `The input's name attribute. Set it here, not with attrs() -
+        attrs() lands on the wrapper div. Defaults to the property name.`
+    },
+    {
+      name: 'field_',
+      documentation: 'Inner SearchField; kept so focus() and the clear button can reach it.'
+    },
+    {
+      name: 'prop_',
+      documentation: 'Set by fromProperty() before render; forwarded to the inner field.'
+    }
+  ],
+
+  methods: [
+    function render() {
+      var self = this;
+
+      var field = this.SearchField.create({
+        data$:     this.data$,
+        onKey:     this.onKey,
+        mode$:     this.mode$,
+        focused:   this.focused,
+        ariaLabel: this.ariaLabel
+      }, this);
+
+      if ( this.autocomplete ) field.autocomplete = this.autocomplete;
+
+      // fromProperty first, then an explicit placeholder over top of it.
+      if ( this.prop_ ) field.fromProperty(this.prop_);
+      if ( this.placeholder ) field.placeholder = this.placeholder;
+      if ( this.inputName ) field.attrs({ name: this.inputName });
+
+      this.field_ = field;
+
+      this
+        .addClass()
+        .start(this.ClearableSearchBorder, {
+          textSlot: this.data$,
+          onClear:  function() {
+            self.data = '';
+            field.focus();
+          }
+        })
+          .add(field)
+        .end();
+    },
+
+    function focus() {
+      if ( this.field_ ) {
+        this.field_.focus();
+        return this;
+      }
+      // Not rendered yet - focus the inner field once it exists.
+      this.focused = true;
+      return this;
+    },
+
+    function fromProperty(p) {
+      this.prop_ = p;
+      if ( ! this.placeholder && p.placeholder ) this.placeholder = p.placeholder;
+      if ( ! this.inputName ) this.inputName = p.name;
+    }
+  ]
+});

--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -2418,6 +2418,17 @@ foam.CLASS({
       // Template method, to be implemented in sub-models
     },
 
+    // Hands the view the property it belongs to. A view spec does not know
+    // which property it was declared on, so this is where the view picks up
+    // the property's name, placeholder and width. Called once, right after the
+    // view is built and before render().
+    //
+    // An input applies it to itself. A view that only wraps an input passes it
+    // down to that input instead - see foam.u2.ClearableSearchField.
+    //
+    // When overriding, copy only what the view does not already have, so
+    // anything set in the view spec still wins. foam.u2.TextField is the
+    // example.
     function fromProperty(p) {
       this.attr('name', p.name);
     }

--- a/src/foam/u2/SearchField.js
+++ b/src/foam/u2/SearchField.js
@@ -9,6 +9,20 @@
   name: 'SearchField',
   extends: 'foam.u2.TextField',
 
+  documentation: `
+    Bare search input: type="search", magnifier icon, 'Search...' placeholder.
+    No clear button - only the Chrome-only native ::-webkit-search-cancel-button.
+
+    Prefer foam.u2.ClearableSearchField, which pairs this with
+    ClearableSearchBorder for a real, keyboard-reachable X. Use this class alone
+    only when standing in for a plain text input, as TextSearchView does by
+    registering it under 'foam.u2.TextField'.
+
+    Gotcha: the placeholder factory always returns a value, so
+    TextField.fromProperty never copies a property's placeholder:. Pass
+    placeholder in the view spec, or use ClearableSearchField.
+  `,
+
   cssTokens: [
     [ 'searchRoundness', '$inputBorderRadius' ]
   ],

--- a/src/foam/u2/borders/ClearableSearchBorder.js
+++ b/src/foam/u2/borders/ClearableSearchBorder.js
@@ -10,16 +10,18 @@ foam.CLASS({
   extends: 'foam.u2.Element',
 
   documentation: `
-    Wraps a search field and renders an accessible clear (X) button over its
-    right edge. The native WebKit ::-webkit-search-cancel-button is suppressed
-    because it is non-standard (Chrome/Safari only), absent from the
-    accessibility tree and unreachable by keyboard; the real <button> rendered
-    here replaces it.
+    Renders an accessible clear (X) button over a search field's right edge. The
+    native ::-webkit-search-cancel-button is suppressed: Chrome/Safari only,
+    absent from the accessibility tree, unreachable by keyboard.
+
+    Low-level primitive. To wrap a plain SearchField use
+    foam.u2.ClearableSearchField - same pairing, already assembled, with the
+    property-view plumbing. Use this directly when the field is not a SearchField
+    or its visible text is not data, as in TextSearchView (SmartView's preview).
 
     Callers supply:
       textSlot - slot of the visible text; the button shows only when non-empty
-      onClear  - called when the button is activated; must clear the text and
-                 return focus to the field
+      onClear  - clears the text and returns focus to the field
   `,
 
   messages: [

--- a/src/foam/u2/markdown/Search.js
+++ b/src/foam/u2/markdown/Search.js
@@ -54,7 +54,7 @@ foam.CLASS({
       class: 'String',
       name: 'query',
       onKey: true,
-      view: 'foam.u2.SearchField',
+      view: 'foam.u2.ClearableSearchField',
       documentation: 'The current search query string.'
     },
     {

--- a/src/foam/u2/view/ColumnConfigView.js
+++ b/src/foam/u2/view/ColumnConfigView.js
@@ -92,9 +92,9 @@ foam.CLASS({
       class: 'String',
       name: 'menuSearch',
       view: {
-        class: 'foam.u2.SearchField',
+        class: 'foam.u2.ClearableSearchField',
         onKey: true,
-        autocomplete: false
+        autocomplete: 'off'
       },
       value: '',
       postSet: function() {

--- a/src/foam/u2/view/DateTimeView.js
+++ b/src/foam/u2/view/DateTimeView.js
@@ -18,8 +18,10 @@ foam.CLASS({
 
   constants: [
     {
-      // Choose the writeView delegate based on browser compatibility.
-      // Safari doesn't support date input types.
+      // Choose the delegate based on browser compatibility. The DateTimePicker
+      // arm is dead: this once covered Safari, which has supported
+      // <input type="date"> since 14.1 (2021), so no current browser takes it.
+      // TODO: drop the branch and the DateTimePicker class.
       name: 'READ_DELEGATE',
       factory: function() {
         var e = document.createElement('input');
@@ -30,8 +32,10 @@ foam.CLASS({
       }
     },
     {
-      // Choose the writeView delegate based on browser compatibility.
-      // Safari doesn't support date input types.
+      // Choose the delegate based on browser compatibility. The DateTimePicker
+      // arm is dead: this once covered Safari, which has supported
+      // <input type="date"> since 14.1 (2021), so no current browser takes it.
+      // TODO: drop the branch and the DateTimePicker class.
       name: 'WRITE_DELEGATE',
       factory: function() {
         var e = document.createElement('input');

--- a/src/foam/u2/view/DateView.js
+++ b/src/foam/u2/view/DateView.js
@@ -18,8 +18,10 @@ foam.CLASS({
 
   constants: [
     {
-      // Choose the writeView delegate based on browser compatibility.
-      // Safari doesn't support date input types.
+      // Choose the delegate based on browser compatibility. The DateTimePicker
+      // arm is dead: this once covered Safari, which has supported
+      // <input type="date"> since 14.1 (2021), so no current browser takes it.
+      // TODO: drop the branch and the DateTimePicker class.
       name: 'READ_DELEGATE',
       factory: function() {
         var e = document.createElement('input');
@@ -30,8 +32,10 @@ foam.CLASS({
       }
     },
     {
-      // Choose the writeView delegate based on browser compatibility.
-      // Safari doesn't support date input types.
+      // Choose the delegate based on browser compatibility. The DateTimePicker
+      // arm is dead: this once covered Safari, which has supported
+      // <input type="date"> since 14.1 (2021), so no current browser takes it.
+      // TODO: drop the branch and the DateTimePicker class.
       name: 'WRITE_DELEGATE',
       factory: function() {
         var e = document.createElement('input');

--- a/src/foam/u2/view/date/DateTimePicker.js
+++ b/src/foam/u2/view/date/DateTimePicker.js
@@ -10,14 +10,33 @@ foam.CLASS({
   extends: 'foam.u2.view.date.AbstractDateView',
 
   documentation: `
-  This is a simple date time picker for browsers that do not have their own implementation.
-  The date picker will automatically be used if it a browser does not support date, see Element.js`,
+  A hand-rolled date/time picker for browsers with no native <input type="date">.
+
+  DEAD CODE as of 2026. DateView and DateTimeView select it only when a test
+  input reports type 'text' instead of 'date'; every current browser supports
+  the native type, Safari since 14.1 (2021), so this widget no longer renders
+  anywhere. It has rotted accordingly - the popup dismisses itself as soon as
+  it opens, undiagnosed.
+
+  TODO: decide whether to delete this class along with the feature-detect
+  branches in DateView.js and DateTimeView.js, or restore it to working order.
+  Do not assume it works; nothing exercises it.`,
 
   requires: [
     'foam.u2.view.date.CalendarDatePicker',
     'foam.u2.view.date.Month',
     'foam.u2.view.ChoiceView'
   ],
+
+  constants: {
+    // The trailing adornment doubles as the clear affordance: it becomes an X
+    // once a date is set and the picker is open. Named so the icon expression,
+    // the CSS toggle and clearDate cannot drift apart - clearDate previously
+    // compared against a copy of this path that was missing its leading slash,
+    // so it never cleared.
+    CALENDAR_ICON: '/images/calendar.svg',
+    CANCEL_ICON:   '/images/cancel-round.svg'
+  },
 
   css: `
     ^next_btn, ^prev_btn {
@@ -253,7 +272,7 @@ foam.CLASS({
       class: 'String',
       name: 'icon',
       expression: function(isOpen_) {
-        return this.data && isOpen_ ? '/images/cancel-round.svg' : '/images/calendar.svg';
+        return this.data && isOpen_ ? this.CANCEL_ICON : this.CALENDAR_ICON;
       }
     }
   ],
@@ -287,7 +306,7 @@ foam.CLASS({
               .end()
               .start()
                 .addClass('date-display-image').enableClass('date-display-image-cancel', self.slot(function(icon) {
-                  return icon === '/images/cancel-round.svg';
+                  return icon === self.CANCEL_ICON;
                 }))
                 .start('img')
                   .attrs({ src: self.icon$ })
@@ -413,7 +432,7 @@ foam.CLASS({
     },
 
     function clearDate(event) {
-      if ( this.icon === 'images/cancel-round.svg' ) {
+      if ( this.icon === this.CANCEL_ICON ) {
         event.stopPropagation();
         this.data    = null;
         this.isOpen_ = false;

--- a/src/foam/u2/wizard/StepWizardletStepsView.js
+++ b/src/foam/u2/wizard/StepWizardletStepsView.js
@@ -168,7 +168,7 @@ foam.CLASS({
         .addClass(this.myClass())
         .start()
           .addClass(this.myClass('search'))
-          .tag(foam.u2.SearchField, {
+          .tag(foam.u2.ClearableSearchField, {
             data$: this.searchController.data$,
             onKey: true
           })

--- a/src/pom.js
+++ b/src/pom.js
@@ -582,6 +582,7 @@ foam.POM({
     { name: "foam/u2/util/ClipboardAccess",                           flags: "web" },
     { name: "foam/u2/TextField",                                      flags: "web" },
     { name: "foam/u2/SearchField",                                    flags: "web" },
+    { name: "foam/u2/ClearableSearchField",                           flags: "web" },
     { name: "foam/u2/TextInputCSS",                                   flags: "web" },
     { name: "foam/u2/IntView",                                        flags: "web" },
     { name: "foam/u2/FloatView",                                      flags: "web" },


### PR DESCRIPTION
Only two search boxes in u2 had a working clear (X) button: the sidebar menu
search and TextSearchView. Everywhere else the affordance was the native
::-webkit-search-cancel-button, which is Chrome/Safari only, absent from the
accessibility tree and unreachable by keyboard.

SearchField is an \<input>, so the button cannot be its child - that is why this
is a composite view rather than a flag on SearchField. foam.u2.ClearableSearchField
packages the SearchField + ClearableSearchBorder pairing that VerticalMenu was
already assembling by hand, and both classes' documentation now points at it,
with the cases where using them directly is still right (TextSearchView wraps a
SmartView, not a SearchField).

It also forwards a property's placeholder:, which a bare SearchField silently
drops - its placeholder factory always returns a value, so TextField.fromProperty
never copies the property's own.

Converted: VerticalMenu (deleting its hand-rolled copy), DataManagement,
DAOConfigSummaryView, ColumnConfigView, StepWizardletStepsView, markdown Search,
ModelBrowser.

Second commit is a separate find from the same sweep. DateTimePicker's trailing
glyph turns into an X once a date is set and the picker is open, but clearDate
compared this.icon against 'images/cancel-round.svg' while the icon expression
set '/images/cancel-round.svg'. The guard never passed, so the X did nothing.
Both paths are constants now. Nobody had noticed because the widget is dead:
DateView and DateTimeView reach for it only when a test input reports type
'text', and Safari - the browser their comment named - has supported
<input type="date"> since 14.1. That comment is corrected, the class is marked
dead, and its undiagnosed self-dismissing popup is recorded for whoever decides
whether to delete it along with both feature-detect branches.