### PR TITLE
Fix Data Management search: keyword matching and result count

### DIFF
--- a/src/foam/core/boot/DataManagement.js
+++ b/src/foam/core/boot/DataManagement.js
@@ -129,8 +129,7 @@ foam.CLASS({
            class: 'foam.u2.SearchField',
            onKey: true
           },
-          memorable: true,
-          preSet: function(o, n) { this.daoCount = 0; return n; }
+          memorable: true
         }
       ],
 
@@ -145,6 +144,7 @@ foam.CLASS({
           this.onDetach(this.stack.setTrailingContainer(this.E().start(this.SEARCH).focus().end()));
           this.addClass();
           var updateSections = [];
+          var entries        = [];
           var i = 0;
 
           this.filteredDAO.select().then(function(specs) {
@@ -184,7 +184,6 @@ foam.CLASS({
                 lSection = section;
               }
 
-              var localI    = i.valueOf();
               var localShow = foam.lang.SimpleSlot.create({value: true});
 
               section
@@ -197,26 +196,32 @@ foam.CLASS({
                     self.route = spec.id;
                   });
 
-                  self.search$.sub(function() {
-                    var contains = false;
-                    if ( ! self.search ) {
-                      contains = true;
-                    } else if ( label.toLowerCase().includes(self.search.toLowerCase()) ) {
-                      contains =  true;
-                    } else if ( ! contains && spec.keywords && spec.keywords.length > 0 ) {
-                      for ( var k in spec.keywords ) {
-                        if ( k.toLowerCase().includes(self.search.toLowerCase()) ) {
-                          contains  = true;
-                          break;
-                        }
-                      }
-                    }
-
-                    if ( contains ) self.daoCount++;
-                    localShow.set(contains);
-                    updateSections[localI].set(! updateSections[localI].get());
-                  });
+              entries.push({label: label, spec: spec, show: localShow});
             });
+
+            // One listener for the whole list: a per-row listener that incremented
+            // a shared counter left the count wrong whenever 'search' was set to
+            // the value it already had, since that publishes no propertyChange.
+            self.onDetach(self.search$.sub(function() {
+              var q     = self.search.toLowerCase();
+              var count = 0;
+
+              entries.forEach(function(e) {
+                var contains =
+                  ! q ||
+                  e.label.toLowerCase().includes(q) ||
+                  ( e.spec.keywords || [] ).some(function(k) { return k.toLowerCase().includes(q); });
+
+                if ( contains ) count++;
+                e.show.set(contains);
+              });
+
+              self.daoCount = count;
+
+              // Sections re-check their rows only once every row has settled.
+              updateSections.forEach(function(s) { s.set(! s.get()); });
+            }));
+
             self.start().addClass(self.myClass('footer')).add(self.daoCount$, ' of ', self.totalDAOCount$, ' shown').end();
           });
         }


### PR DESCRIPTION
Two defects in the Data Management DAO list (foam.core.boot.DataManagement, DAOListView).

1. Keyword search never matched. The filter looped `for ( var k in spec.keywords )`, and `for...in` over a StringArray yields index strings ("0", "1", ...) rather than the keyword values, so only a search for a literal digit could ever hit. Now iterates the values.

2. The "N of M shown" count could stick at 0 while the list was correctly filtered. The reset lived in search's `preSet`, which runs on every set, but the recount lived in the propertyChange listeners, which do not run when the new value equals the old (FObject.pubPropertyChange_ returns early on Object.is). Any redundant same-value set of search — a memento write-back, or a key event that does not alter the string — therefore zeroed the counter with nothing to restore it. Removed the preSet; the count is now computed from the filter result.

Also replaces one listener per row (roughly 460 subscriptions on a typical app, none of them detached) with a single listener over a collected row list, detached with the view. Letter-section slots are toggled once per search after every row has settled, instead of once per row.