### PR TITLE
fix: the delete-secret-key in delete-secret-key.sh

### DIFF
--- a/tools/cert/delete-secret-key.sh
+++ b/tools/cert/delete-secret-key.sh
@@ -10,6 +10,7 @@ set -e
 DOMAIN=$1
 ALIAS=$2
 PASSWORD=$DOMAIN
+export KEYTOOL_STOREPASS="$PASSWORD"
 
 # Set Name variables
 DNAME="
@@ -27,7 +28,7 @@ keytool -delete \
  -v \
  -alias "$ALIAS" \
  -keystore "$DOMAIN.jks" \
- -storepass "$PASSWORD" \
+ -storepass:env KEYTOOL_STOREPASS \
  -storetype PKCS12 
 
 echo -e "Success!"


### PR DESCRIPTION
## Summary
Fix high severity security issue in `tools/cert/delete-secret-key.sh`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tools/cert/delete-secret-key.sh:1` |
| **Assessment** | Likely exploitable |

**Description**: The delete-secret-key.sh script passes the keystore password via the -storepass command line argument. This exposes the password in process listings (ps), shell history files, and system audit logs. The password is derived from the DOMAIN variable passed as the first argument to the script.

## Evidence

**Exploitation scenario**: An attacker with local system access can observe the running process via 'ps aux' or similar tools, capturing the full command line including the -storepass argument.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `tools/cert/delete-secret-key.sh`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
