### PR TITLE
PT-FIXES:DOS-4751 fix(json): accept 1-9 fractional-second digits in DateParser

### DIFF
--- a/src/foam/lib/json/DateParser.java
+++ b/src/foam/lib/json/DateParser.java
@@ -7,7 +7,6 @@
 package foam.lib.json;
 
 import foam.lib.parse.*;
-import foam.util.SafetyUtil;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
@@ -18,20 +17,6 @@ public class DateParser
   private final static Parser instance__ = new DateParser();
 
   public static Parser instance() { return instance__; }
-
-  protected static ThreadLocal<StringBuilder> sb = new ThreadLocal<StringBuilder>() {
-    @Override
-    protected StringBuilder initialValue() {
-      return new StringBuilder();
-    }
-
-    @Override
-    public StringBuilder get() {
-      StringBuilder b = super.get();
-      b.setLength(0);
-      return b;
-    }
-  };
 
   public DateParser() {
     super(new Alt(
@@ -51,9 +36,9 @@ public class DateParser
         IntParser.instance(),
         Literal.create(":"),
         IntParser.instance(),
-        new Optional(
+        new Optional( // fraction of a second, 1-9 digits per ISO 8601
           new Seq1(1, Literal.create("."),
-          new Repeat(new Chars("0123456789"), null, 3, 3))
+          new Repeat(new Chars("0123456789"), null, 1, 9))
         ),
         Literal.create("Z")
       )),
@@ -73,9 +58,9 @@ public class DateParser
         IntParser.instance(), // 8 - min
         Literal.create(":"), // 9
         IntParser.instance(), // 10 - sec
-        new Optional( // 11 - mill
+        new Optional( // 11 - fraction of a second, 1-9 digits
           new Seq1(1, Literal.create("."),
-          new Repeat(new Chars("0123456789"), null, 3, 3))
+          new Repeat(new Chars("0123456789"), null, 1, 9))
         )),
       // YYYY-MM-DD — date-only, optionally quoted (the RFC 8259 canonical form
       // for a JSON date, since JSON has no native date type).
@@ -127,24 +112,14 @@ public class DateParser
     if ( result[11] == null ) return ps.setValue(c.getTime());
     Object[] milli = (Object[]) result[11];
 
-    boolean zeroPrefixed = true;
-    StringBuilder milliseconds = sb.get();
-
-    for ( int i = 0 ; i < milli.length ; i++ ) {
-      // do not prefix with zeros
-      if ( zeroPrefixed && '0' == (char) milli[i] ) continue;
-
-      // append millisecond
-      if ( zeroPrefixed ) zeroPrefixed = false;
-      milliseconds.append((char) milli[i]);
+    // The digits are a decimal fraction of a second: ".5" is 500 ms, ".05" is
+    // 50 ms, ".123456" truncates to 123 ms (sub-millisecond precision is not
+    // representable in java.util.Date — see the TODO above).
+    int ms = 0;
+    for ( int i = 0 ; i < 3 ; i++ ) {
+      ms = ms * 10 + ( i < milli.length ? Character.digit((char) milli[i], 10) : 0 );
     }
-
-    // try to parse milliseconds, default to 0
-    c.add(
-      Calendar.MILLISECOND,
-      ! SafetyUtil.isEmpty(milliseconds.toString()) ?
-        Integer.parseInt(milliseconds.toString(), 10) :
-        0);
+    c.add(Calendar.MILLISECOND, ms);
 
     return ps.setValue(c.getTime());
   }

--- a/src/foam/lib/json/test/JSONDateParserTest.js
+++ b/src/foam/lib/json/test/JSONDateParserTest.js
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.lib.json.test',
+  name: 'JSONDateParserTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `
+    foam.lib.json.DateParser — the parser journal replay and JSON input run
+    dates through. Covers each Alt branch (quoted ISO instant, space-separated
+    datetime, quoted date-only, bare epoch millis, null) and the
+    fraction-of-a-second rule: ISO 8601 allows 1-9 digits, scaled to
+    milliseconds, truncated past the third (java.util.Date has no
+    sub-millisecond precision).
+  `,
+
+  javaImports: [
+    'foam.lib.json.DateParser',
+    'foam.lib.parse.PStream',
+    'foam.lib.parse.ParserContext',
+    'foam.lib.parse.ParserContextImpl',
+    'foam.lib.parse.StringPStream'
+  ],
+
+  methods: [
+    {
+      name: 'parseDate',
+      type: 'java.util.Date',
+      args: 'foam.lang.X x, String input',
+      javaCode: `
+        StringPStream ps = new StringPStream(input);
+        ParserContext ctx = new ParserContextImpl();
+        ctx.set("X", x);
+        PStream out = DateParser.instance().parse(ps, ctx);
+        return out == null ? null : (java.util.Date) out.value();
+      `
+    },
+    {
+      name: 'runTest',
+      javaCode: `
+        // ---- branch coverage ----
+        long base = java.time.Instant.parse("1982-07-07T23:12:00Z").toEpochMilli();
+
+        java.util.Date d = parseDate(x, "395536320000");
+        test(d != null && d.getTime() == 395536320000L, "bare epoch millis parse");
+
+        d = parseDate(x, "\\"1982-07-07\\"");
+        test(d != null && d.getTime() == java.time.Instant.parse("1982-07-07T00:00:00Z").toEpochMilli(), "quoted date-only parses to midnight UTC");
+
+        d = parseDate(x, "1982/07/07 23:12:00");
+        test(d != null && d.getTime() == base, "space-separated datetime with slash separators");
+
+        StringPStream nps = new StringPStream("null");
+        ParserContext nctx = new ParserContextImpl();
+        PStream nout = DateParser.instance().parse(nps, nctx);
+        test(nout != null && nout.value() == null, "null literal parses to a null value");
+
+        // ---- fraction of a second ----
+        // ISO 8601 allows any number of fraction-of-a-second digits and journals
+        // in the wild carry one ("...T23:12:00.0Z"). DateParser accepts 1-9
+        // digits scaled to milliseconds, truncating past the third
+        // (java.util.Date has no sub-millisecond precision). Exactly three
+        // digits parse bit-for-bit as before.
+        d = parseDate(x, "\\"1982-07-07T23:12:00.0Z\\"");
+        test(d != null && d.getTime() == base, "DateParser: '.0' is zero milliseconds");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.5Z\\"");
+        test(d != null && d.getTime() == base + 500, "DateParser: '.5' is 500 ms, not 5");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.05Z\\"");
+        test(d != null && d.getTime() == base + 50, "DateParser: '.05' is 50 ms");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.123Z\\"");
+        test(d != null && d.getTime() == base + 123, "DateParser: '.123' is 123 ms as before");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.012Z\\"");
+        test(d != null && d.getTime() == base + 12, "DateParser: '.012' is 12 ms as before");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.123456Z\\"");
+        test(d != null && d.getTime() == base + 123, "DateParser: '.123456' truncates to 123 ms");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.999999999Z\\"");
+        test(d != null && d.getTime() == base + 999, "DateParser: nine digits truncate to 999 ms");
+        d = parseDate(x, "\\"1982-07-07T23:12:00Z\\"");
+        test(d != null && d.getTime() == base, "DateParser: no fraction still parses");
+
+        test(parseDate(x, "\\"1982-07-07T23:12:00.Z\\"") == null, "DateParser: a bare '.' with no digits does not parse");
+        test(parseDate(x, "\\"1982-07-07T23:12:00.0123456789Z\\"") == null, "DateParser: ten fraction digits do not parse");
+
+        long base2 = java.time.Instant.parse("2024-01-01T10:00:00Z").toEpochMilli();
+        d = parseDate(x, "2024-01-01 10:00:00.5");
+        test(d != null && d.getTime() == base2 + 500, "DateParser: space-separated datetime '.5' is 500 ms");
+      `
+    }
+  ]
+});

--- a/src/foam/lib/json/test/ParserOptimizationTest.js
+++ b/src/foam/lib/json/test/ParserOptimizationTest.js
@@ -28,8 +28,7 @@ foam.CLASS({
     'foam.lib.parse.Parser',
     'foam.lib.parse.ParserContext',
     'foam.lib.parse.ParserContextImpl',
-    'foam.lib.parse.StringPStream',
-    'foam.lib.json.DateParser'
+    'foam.lib.parse.StringPStream'
   ],
 
   methods: [
@@ -38,7 +37,6 @@ foam.CLASS({
       javaCode: `
         testDoubleParser(x);
         testStringParser(x);
-        testDateFractions(x);
         testJsonRoundtrip(x);
       `
     },
@@ -160,42 +158,6 @@ foam.CLASS({
       `
     },
     {
-      name: 'testDateFractions',
-      args: 'foam.lang.X x',
-      javaCode: `
-        // ISO 8601 allows any number of fraction-of-a-second digits and journals
-        // in the wild carry one ("...T23:12:00.0Z"). DateParser accepts 1-9
-        // digits scaled to milliseconds, truncating past the third
-        // (java.util.Date has no sub-millisecond precision). Exactly three
-        // digits parse bit-for-bit as before.
-        long base = java.time.Instant.parse("1982-07-07T23:12:00Z").toEpochMilli();
-
-        java.util.Date d = parseDate(x, "\\"1982-07-07T23:12:00.0Z\\"");
-        test(d != null && d.getTime() == base, "DateParser: '.0' is zero milliseconds");
-        d = parseDate(x, "\\"1982-07-07T23:12:00.5Z\\"");
-        test(d != null && d.getTime() == base + 500, "DateParser: '.5' is 500 ms, not 5");
-        d = parseDate(x, "\\"1982-07-07T23:12:00.05Z\\"");
-        test(d != null && d.getTime() == base + 50, "DateParser: '.05' is 50 ms");
-        d = parseDate(x, "\\"1982-07-07T23:12:00.123Z\\"");
-        test(d != null && d.getTime() == base + 123, "DateParser: '.123' is 123 ms as before");
-        d = parseDate(x, "\\"1982-07-07T23:12:00.012Z\\"");
-        test(d != null && d.getTime() == base + 12, "DateParser: '.012' is 12 ms as before");
-        d = parseDate(x, "\\"1982-07-07T23:12:00.123456Z\\"");
-        test(d != null && d.getTime() == base + 123, "DateParser: '.123456' truncates to 123 ms");
-        d = parseDate(x, "\\"1982-07-07T23:12:00.999999999Z\\"");
-        test(d != null && d.getTime() == base + 999, "DateParser: nine digits truncate to 999 ms");
-        d = parseDate(x, "\\"1982-07-07T23:12:00Z\\"");
-        test(d != null && d.getTime() == base, "DateParser: no fraction still parses");
-
-        test(parseDate(x, "\\"1982-07-07T23:12:00.Z\\"") == null, "DateParser: a bare '.' with no digits does not parse");
-        test(parseDate(x, "\\"1982-07-07T23:12:00.0123456789Z\\"") == null, "DateParser: ten fraction digits do not parse");
-
-        long base2 = java.time.Instant.parse("2024-01-01T10:00:00Z").toEpochMilli();
-        d = parseDate(x, "2024-01-01 10:00:00.5");
-        test(d != null && d.getTime() == base2 + 500, "DateParser: space-separated datetime '.5' is 500 ms");
-      `
-    },
-    {
       name: 'testJsonRoundtrip',
       args: 'foam.lang.X x',
       javaCode: `
@@ -265,18 +227,6 @@ foam.CLASS({
         FObject c2 = p.parseString("{class:\\""+klass+"\\",id: // after colon\\n\\"cn\\",source:\\"S2\\"}");
         test(c2 != null && "cn".equals(((foam.core.test.Test) c2).getId()) && "S2".equals(((foam.core.test.Test) c2).getSource()),
           "JSON roundtrip: // comment between ':' and the value");
-      `
-    },
-    {
-      name: 'parseDate',
-      type: 'java.util.Date',
-      args: 'foam.lang.X x, String input',
-      javaCode: `
-        StringPStream ps = new StringPStream(input);
-        ParserContext ctx = new ParserContextImpl();
-        ctx.set("X", x);
-        PStream out = DateParser.instance().parse(ps, ctx);
-        return out == null ? null : (java.util.Date) out.value();
       `
     },
     {

--- a/src/foam/lib/json/test/ParserOptimizationTest.js
+++ b/src/foam/lib/json/test/ParserOptimizationTest.js
@@ -28,7 +28,8 @@ foam.CLASS({
     'foam.lib.parse.Parser',
     'foam.lib.parse.ParserContext',
     'foam.lib.parse.ParserContextImpl',
-    'foam.lib.parse.StringPStream'
+    'foam.lib.parse.StringPStream',
+    'foam.lib.json.DateParser'
   ],
 
   methods: [
@@ -37,6 +38,7 @@ foam.CLASS({
       javaCode: `
         testDoubleParser(x);
         testStringParser(x);
+        testDateFractions(x);
         testJsonRoundtrip(x);
       `
     },
@@ -158,6 +160,42 @@ foam.CLASS({
       `
     },
     {
+      name: 'testDateFractions',
+      args: 'foam.lang.X x',
+      javaCode: `
+        // ISO 8601 allows any number of fraction-of-a-second digits and journals
+        // in the wild carry one ("...T23:12:00.0Z"). DateParser accepts 1-9
+        // digits scaled to milliseconds, truncating past the third
+        // (java.util.Date has no sub-millisecond precision). Exactly three
+        // digits parse bit-for-bit as before.
+        long base = java.time.Instant.parse("1982-07-07T23:12:00Z").toEpochMilli();
+
+        java.util.Date d = parseDate(x, "\\"1982-07-07T23:12:00.0Z\\"");
+        test(d != null && d.getTime() == base, "DateParser: '.0' is zero milliseconds");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.5Z\\"");
+        test(d != null && d.getTime() == base + 500, "DateParser: '.5' is 500 ms, not 5");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.05Z\\"");
+        test(d != null && d.getTime() == base + 50, "DateParser: '.05' is 50 ms");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.123Z\\"");
+        test(d != null && d.getTime() == base + 123, "DateParser: '.123' is 123 ms as before");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.012Z\\"");
+        test(d != null && d.getTime() == base + 12, "DateParser: '.012' is 12 ms as before");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.123456Z\\"");
+        test(d != null && d.getTime() == base + 123, "DateParser: '.123456' truncates to 123 ms");
+        d = parseDate(x, "\\"1982-07-07T23:12:00.999999999Z\\"");
+        test(d != null && d.getTime() == base + 999, "DateParser: nine digits truncate to 999 ms");
+        d = parseDate(x, "\\"1982-07-07T23:12:00Z\\"");
+        test(d != null && d.getTime() == base, "DateParser: no fraction still parses");
+
+        test(parseDate(x, "\\"1982-07-07T23:12:00.Z\\"") == null, "DateParser: a bare '.' with no digits does not parse");
+        test(parseDate(x, "\\"1982-07-07T23:12:00.0123456789Z\\"") == null, "DateParser: ten fraction digits do not parse");
+
+        long base2 = java.time.Instant.parse("2024-01-01T10:00:00Z").toEpochMilli();
+        d = parseDate(x, "2024-01-01 10:00:00.5");
+        test(d != null && d.getTime() == base2 + 500, "DateParser: space-separated datetime '.5' is 500 ms");
+      `
+    },
+    {
       name: 'testJsonRoundtrip',
       args: 'foam.lang.X x',
       javaCode: `
@@ -227,6 +265,18 @@ foam.CLASS({
         FObject c2 = p.parseString("{class:\\""+klass+"\\",id: // after colon\\n\\"cn\\",source:\\"S2\\"}");
         test(c2 != null && "cn".equals(((foam.core.test.Test) c2).getId()) && "S2".equals(((foam.core.test.Test) c2).getSource()),
           "JSON roundtrip: // comment between ':' and the value");
+      `
+    },
+    {
+      name: 'parseDate',
+      type: 'java.util.Date',
+      args: 'foam.lang.X x, String input',
+      javaCode: `
+        StringPStream ps = new StringPStream(input);
+        ParserContext ctx = new ParserContextImpl();
+        ctx.set("X", x);
+        PStream out = DateParser.instance().parse(ps, ctx);
+        return out == null ? null : (java.util.Date) out.value();
       `
     },
     {

--- a/src/foam/lib/json/test/tests.jrl
+++ b/src/foam/lib/json/test/tests.jrl
@@ -1,2 +1,7 @@
 p({"class":"foam.lib.json.test.FObjectParserJavaTest", "id":"FObjectParserJavaTest"})
 p({"class":"foam.lib.json.test.ParserOptimizationTest", "id":"ParserOptimizationTest"})
+p({
+  class:"foam.lib.json.test.JSONDateParserTest",
+  id:"JSONDateParserTest",
+  description:"foam.lib.json.DateParser branches and 1-9 digit fraction-of-a-second scaling"
+})

--- a/src/pom.js
+++ b/src/pom.js
@@ -1186,6 +1186,7 @@ foam.POM({
     { name: "foam/lib/json/UnknownFObjectArray",                      flags: "js|java" },
     { name: "foam/lib/json/test/FObjectParserJavaTest",               flags: "js&test|java&test" },
     { name: "foam/lib/json/test/ParserOptimizationTest",              flags: "js&test|java&test" },
+    { name: "foam/lib/json/test/JSONDateParserTest",                 flags: "js&test|java&test" },
     { name: "foam/lib/xml/OutputXML",                                 flags: "js|java" },
     { name: "foam/lib/query/TestModel",                               flags: "js&test|java&test" },
     { name: "foam/dao/FreezingDAO",                                   flags: "js|java" },


### PR DESCRIPTION
A date with anything other than exactly three fraction digits loses the whole field on journal replay — the record loads, the date is silently unset.

Cause: `DateParser`'s ISO branch requires exactly three fraction digits (`Repeat(..., 3, 3)`); when they don't match, every `Alt` branch fails and `ModelParserFactory` drops the property through `UnknownPropertyParser`. ISO 8601 puts no count on the fraction — `Instant.parse` accepts 1-9.

Reproduce — a real row in `users.jrl`, found by the parser survey on #5360:

```
p({ "class":"foam.core.auth.User", "id":42, ..., "birthday":"1982-07-07T23:12:00.0Z" })

".123Z"  ->  123 ms     parses (exactly three digits)
".0Z"    ->  birthday = null   <- whole field dropped
".5Z"    ->  birthday = null   <- whole field dropped
```

Fix: both fraction sites take 1-9 digits, read as a decimal fraction of a second — `.5` is 500 ms (not 5), `.05` is 50 ms, digits past the third truncate (`java.util.Date` has no sub-millisecond precision). Exactly-three-digit values parse bit-for-bit as before; the zero-stripping StringBuilder path is removed.

Covered in a new `JSONDateParserTest`: one per `Alt` branch (quoted ISO, space-separated, date-only, bare epoch millis, null) plus the fraction cases — scaling, truncation, bare `.` and ten digits still rejected.