### PR TITLE
PT-FIXES:DOS-4752 perf(json): try bare epoch millis first in DateParser

### DIFF
--- a/src/foam/lib/json/DateParser.java
+++ b/src/foam/lib/json/DateParser.java
@@ -36,6 +36,13 @@ public class DateParser
   public DateParser() {
     super(new Alt(
       NullParser.instance(),
+      // Bare epoch millis — how journals and the JSON formatter write Date
+      // values, so it goes first. The Not guard backtracks when the digits
+      // turn out to be a datetime's year ("1982-07-07..." or "1982/07/07..."),
+      // handing the input to the branches below.
+      new Seq1(0,
+        new LongParser(),
+        new Not(new Chars("-/"))),
       // YYYY-MM-DDTHH:MM:SS[.fff]Z — JSON canonical instant, optionally quoted.
       new Quoted(new Seq( // 0 year, 1 "-", 2 month, 3 "-", 4 day,
                           // 5 "T", 6 hr, 7 ":", 8 min, 9 ":", 10 sec,


### PR DESCRIPTION
Journals and the JSON formatter write Date values as bare epoch millis, but `DateParser`'s `Alt` tries the quoted ISO instant, the space-separated datetime and the quoted date-only forms before reaching `LongParser` — every Date in every journal walks three failing branches first.

Fix: one new branch at the front —

```java
new Seq1(0,
  new LongParser(),
  new Not(new Chars("-/"))),
```

The `Not` guard backtracks when the digits turn out to be a datetime's year (`1982-07-07...`, `1982/07/07...`), handing the input to the existing branches, so every input parses to the same value as before. The trailing `LongParser` stays for digits the guard rejects that no other branch takes (`1982-07-07` unquoted parses to `Date(1982)` before and after).

Measured on `ReplayShapeBenchmark`'s 10-Date model (200K entries, same machine, baseline run first so thermal drift works against the patched run):

| | Entries/s | ns/entry |
|---|---|---|
| baseline | 200,881 | 4,978 |
| bare-long first | 256,350 | 3,901 |

+28% on the date-heavy model (+37% with `StringParser.INTERN` off); per Date property ~390 ns to ~280 ns. The benchmark lives on #5360.

`ParserOptimizationTest`, `GrammarCombinatorsJavaTest`, `F3FileJournalTest` green (152 assertions). Independent of #5364 — either merges first.