### PR TITLE
PT-FIXES:DOS-4753 perf(json): bound the escape scan to the string's own span

### DIFF
--- a/src/foam/lib/json/StringParser.java
+++ b/src/foam/lib/json/StringParser.java
@@ -69,9 +69,19 @@ public class StringParser
     int closeIdx = str.indexOf(delim, pos);
     if ( closeIdx < 0 ) return null;
 
-    int escIdx = str.indexOf(ESCAPE, pos);
-    // If there's an escape before the closing delimiter, fall back to slow path
-    if ( escIdx >= 0 && escIdx < closeIdx ) return null;
+    // If there's an escape before the closing delimiter, fall back to the slow
+    // path. Bounded to the string's own span: the unbounded form scanned to the
+    // END of the input on every escape-free value, re-reading the entry once per
+    // string property. Short spans use a plain loop — the ranged indexOf's
+    // per-call overhead costs more than it saves under ~32 chars; longer spans
+    // get its vectorized scan.
+    if ( closeIdx - pos <= 32 ) {
+      for ( int i = pos ; i < closeIdx ; i++ ) {
+        if ( str.charAt(i) == ESCAPE ) return null;
+      }
+    } else if ( str.indexOf(ESCAPE, pos, closeIdx) >= 0 ) {
+      return null;
+    }
 
     // No escapes — bulk extract the string
     String value = str.substring(pos, closeIdx).intern();


### PR DESCRIPTION
Every escape-free string value re-scans the input to its END looking for a backslash — `parseFast`'s escape check is `str.indexOf(ESCAPE, pos)` with no bound, so a 50-property entry re-reads its own tail once per string property, and the cost grows with entry length, not value length.

```java
int closeIdx = str.indexOf(delim, pos);   // finds the closing quote
int escIdx   = str.indexOf(ESCAPE, pos);  // <- scans to end of input, every string
```

Fix: scan only `[pos, closeIdx)` — a plain loop up to 32 chars (the ranged `indexOf`'s per-call overhead costs more than it saves on short values, measured), the vectorized ranged `indexOf` above that.

Medians over 3-4 alternating runs of the parse benchmark on #5360 (ns/entry, single thread, intern on/off):

| Model | baseline | bounded | delta |
|---|---|---|---|
| 20 String, 256-char values, no intern | 7,458 | 4,044 | +46% |
| 20 String, 256-char values | 18,603 | 13,947 | +25% |
| 20 String, unique values | 15,988 | 13,416 | +16% |
| 50 mixed properties, no intern | 11,055 | 9,374 | +15% |
| 50 mixed properties | 14,642 | 13,328 | +9% |
| 20 String, short repeated values | 6,004 | 6,141 | −2% (within run noise) |

`ParserOptimizationTest` (escape/unicode/delimiter cases), `GrammarCombinatorsJavaTest`, `F3FileJournalTest` green — 152 assertions.