### PR TITLE
Translate property units at display time

### DIFF
--- a/src/foam/i18n/fr_fr/locales.jrl
+++ b/src/foam/i18n/fr_fr/locales.jrl
@@ -89,3 +89,7 @@ p({ class: "foam.i18n.Locale", locale: "fr", source: "foam.u2.DeleteModal.FAIL_M
 
 p({ class: "foam.i18n.Locale", locale: "fr", source: "foam.u2.filter.FilterView.LABEL_FILTER", target: "Filtres" })
 p({ class: "foam.i18n.Locale", locale: "fr", source: "foam.u2.filter.FilterView.NO_FILTER", target: "Non Filtres" })
+p({ class: "foam.i18n.Locale", locale: "fr", source: "foam.units.days", target: "jours" })
+p({ class: "foam.i18n.Locale", locale: "fr", source: "foam.units.years", target: "années" })
+p({ class: "foam.i18n.Locale", locale: "fr", source: "foam.units.seconds", target: "secondes" })
+p({ class: "foam.i18n.Locale", locale: "fr", source: "foam.units.bytes", target: "octets" })

--- a/src/foam/i18n/pt_pt/locales.jrl
+++ b/src/foam/i18n/pt_pt/locales.jrl
@@ -1061,3 +1061,6 @@ p({class:"foam.i18n.Locale",locale:"pt",source:"foam.core.approval.ApprovalReque
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.dashboard.view.DashboardView.TITLE",target:"Painel"})
 
 p({class:"foam.i18n.Locale",locale:"pt",source:"foam.net.web.HTTPRequest.GENERAL_ERROR",target:"Erro de rede, verifique sua conexão e tente novamente."})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.units.days",target:"dias"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.units.years",target:"anos"})
+p({class:"foam.i18n.Locale",locale:"pt",source:"foam.units.seconds",target:"segundos"})

--- a/src/foam/u2/TextField.js
+++ b/src/foam/u2/TextField.js
@@ -22,6 +22,8 @@ foam.CLASS({
 
   mixins: [ 'foam.u2.TextInputCSS' ],
 
+  imports: [ 'translationService?' ],
+
   css: `
     ^ {
       height: $inputHeight;
@@ -69,9 +71,14 @@ foam.CLASS({
       this.SUPER();
 
       if ( this.units ) {
+        // 'units' is a plain string on the property axiom, so translate at
+        // display time; flat key shared by all property types.
+        var units  = this.translationService ?
+          this.translationService.getTranslation(foam.locale, 'foam.units.' + this.units, this.units) :
+          this.units;
         var parent = this.parentNode;
         var self   = this;
-        var span   = parent.start('span').style({display: 'inline-block', position: 'relative', 'font-weight': '300'}).add(self.units, ' ');
+        var span   = parent.start('span').style({display: 'inline-block', position: 'relative', 'font-weight': '300'}).add(units, ' ');
         var e      = span.el_();
         let restyle = () => {
           var w = Math.ceil(e.getBoundingClientRect().width);

--- a/src/foam/u2/view/ValueView.js
+++ b/src/foam/u2/view/ValueView.js
@@ -11,6 +11,8 @@ foam.CLASS({
 
   documentation: 'Just shows the value of data as a string.',
 
+  imports: [ 'translationService?' ],
+
   css: `
     ^ {
       display: block;
@@ -49,12 +51,18 @@ foam.CLASS({
           })
         );
       } else {
+        // 'units' is a plain string on the property axiom, so translate at
+        // display time; flat key shared by all property types.
+        var units = prop?.units;
+        if ( units && this.translationService ) {
+          units = this.translationService.getTranslation(foam.locale, 'foam.units.' + units, units);
+        }
         this.add(this.data$.map(v => {
           let ret = v;
           if ( prop?.name !== 'id' && foam.Number.isInstance(v) && foam.lang.Int.isSubClass(prop) && prop.formatValue ) {
             ret = Number(v).toLocaleString(foam.util.getClientLocale());
           }
-          return ret + (prop?.units ? ` ${prop?.units}` : '');
+          return ret + (units ? ` ${units}` : '');
         }));
       }
     }


### PR DESCRIPTION
The units meta-property (e.g. units: 'days' on an Int) rendered as a raw untranslated string in both consumers: the TextField suffix span and ValueView's read-only value.

This adds a translationService lookup at the two render sites using a flat key, `foam.units.<value>`, with the raw model string as the English default. Each unit word is translated once globally via Locale rows rather than per declaring property.
Precedent: Duration.js already translates time units with type-scoped keys (`foam.time.TimeUnit.<name>.plural`).

- translationService is imported optionally with a raw-string fallback, so deployments without the service are unaffected.
- Seeded fr and pt Locale rows for the word-units in use (days/years/seconds/bytes); symbol units (ms, %, Hz, s, h) are international and intentionally have no rows.
- CurrencyView inherits the TextField path; currency symbols miss the lookup and render unchanged via the default argument.