### PR TITLE
lsp: pom entry validation — whitespace, unknown flags, missing files

### DIFF
--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -50,7 +50,7 @@ The LSP boots the FOAM runtime via `pmake` (same as `build.sh`), loading all mod
 | `ImplementationHandler.js` | `textDocument/implementation` | Concrete implementors of a FOAM interface |
 | `TypeDefinitionHandler.js` | `textDocument/typeDefinition` | For a property usage, jump to the property's class (e.g. `foam.lang.Long`) |
 | `CallHierarchyHandler.js` | `textDocument/prepareCallHierarchy` + `callHierarchy/{incomingCalls,outgoingCalls}` | Who calls / who's called for any FOAM method |
-| `PomValidator.js` | `foam/validatePoms` | Orphan files, missing POM entries, duplicate registrations |
+| `PomValidator.js` | `foam/validatePoms` (+ called by Diagnostics on pom.js files) | Orphan files, missing POM entries, duplicate registrations; `validateEntries(text, pomPath)` adds entry-level checks — whitespace in name/flags values (`pom-name-whitespace`/`pom-flag-whitespace` ERROR), unknown flag tokens (`pom-flag-unknown` WARNING, vocabulary drifts), entries pointing at missing files (`pom-file-missing` ERROR). Positions come from the grammar harvest (`pomFileName`/`pomJavaFileName`/`pomFlagValue` kinds), never regex; `validate()` rolls them up as `entryIssues` |
 | `CodeLensHandler.js` | `textDocument/codeLens` | Two independent, feature-toggled lenses: `codeLens.i18n` (missing-translation counts, delegates to `I18nHandler.scanMissingLanguages` — so it inherits that entry point's `translationReady` gate AND its test/demo/mock URI exemption; also requires `hints.i18nMissingLanguage`, since clicking translates) and `codeLens.hierarchy` (subclass counts, informational — anchored on the advertised no-op command `foam.lens.info`; a click is answered with null). Both bail on a multi-model file. |
 | `ScaffoldHandler.js` | `workspace/executeCommand` `foam.scaffold.newClass` | Builds a `WorkspaceEdit` (new class file + pom.js `files:` append) from `{ dir, name }`. Nothing written to disk server-side — the client applies the edit. No `featureConfig` — the command only runs when explicitly invoked. Containment: `wsRoot` and the target dir are both `fs.realpathSync`'d before comparison (a lexical compare let `ln -s / <ws>/escape` target `/etc`), and with `requireWsRoot` set and no `rootUri` from the client it refuses outright rather than inheriting `process.cwd()`. The derived package is validated as a dotted identifier path — a folder named `it's` is refused, not emitted into `package: '…'`. |
 
@@ -210,6 +210,7 @@ all (`server.js:613-635`).
 |---|---|---|
 | `diagnostics.java` | `true` | Java-block validation diagnostics |
 | `diagnostics.i18n` | `true` | Hardcoded-display-string diagnostic |
+| `diagnostics.pom` | `true` | Entry-level pom.js diagnostics (`PomValidator.validateEntries` via `DiagnosticsHandler.pomDiagnostics_`) |
 | `hints.i18nMissingLanguage` | `true` | Every unsolicited offer to machine-translate: the missing-translation HINT, code actions C/D, AND the `codeLens.i18n` lens (clicking it translates) |
 | `completion` | `true` | `completionProvider` capability |
 | `hover` | `true` | `hoverProvider` capability |

--- a/tools/lsp/FeatureConfig.js
+++ b/tools/lsp/FeatureConfig.js
@@ -23,6 +23,7 @@ var path = require('path');
 var DEFAULTS = Object.freeze({
   'diagnostics.java': true,
   'diagnostics.i18n': true,
+  'diagnostics.pom': true,
   'hints.i18nMissingLanguage': true,
   'completion': true,
   'hover': true,

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -82,7 +82,8 @@ foam.CLASS({
       var self = this;
       var map = {
         message:     {}, value:    {}, property: {}, method:  {},
-        pomFileName: {}, classRef: {}, comment:  {}, documentation: {},
+        pomFileName: {}, pomFlagValue: {}, pomJavaFileName: {},
+        classRef: {}, comment:  {}, documentation: {},
         instCall: {}, instCreateReceiver: {}, instTagClass: {}, instClassRef: {},
         instKey: {}, instValue: {}, memberRef: {}
       };
@@ -93,7 +94,10 @@ foam.CLASS({
       // so collect every position.
       var MULTI = { classRef: true, comment: true, documentation: true,
         instCall: true, instCreateReceiver: true, instTagClass: true,
-        instClassRef: true, instKey: true, instValue: true, memberRef: true };
+        instClassRef: true, instKey: true, instValue: true, memberRef: true,
+        // pom scalar values repeat across entries ('js' in ten files:
+        // rows), so unlike pomFileName these keep every span.
+        pomFlagValue: true, pomJavaFileName: true };
 
       // Line-start offsets, computed once (O(n)), so each msg match resolves
       // line/col by binary search (O(log n)). Scanning text from offset 0 per
@@ -753,9 +757,9 @@ foam.CLASS({
         // value parser from running past its closing quote into the next
         // entry. Adding a new POM scalar value is a one-liner now.
         pomFileName:     stringValueRule({ category: 'pomFileName',     hint: 'file name',          msgKind: 'pomFileName' }),
-        pomJavaFileName: stringValueRule({ category: 'pomJavaFileName', hint: 'Java file name' }),
+        pomJavaFileName: stringValueRule({ category: 'pomJavaFileName', hint: 'Java file name',     msgKind: 'pomJavaFileName' }),
         pomProjectPath:  stringValueRule({ category: 'pomProjectPath',  hint: 'subproject path' }),
-        pomFlagValue:    stringValueRule({ category: 'pomFlagValue',    hint: 'flag combination' }),
+        pomFlagValue:    stringValueRule({ category: 'pomFlagValue',    hint: 'flag combination',   msgKind: 'pomFlagValue' }),
         pomJavaDep:      stringValueRule({ category: 'pomJavaDep',      hint: 'Java dependency' }),
 
         // Skip one character — catch-all that lets START consume the whole file

--- a/tools/lsp/editors/vscode/package.json
+++ b/tools/lsp/editors/vscode/package.json
@@ -34,6 +34,11 @@
           "default": true,
           "description": "Diagnostics for Java import/code block errors."
         },
+        "foam.features.diagnostics.pom": {
+          "type": "boolean",
+          "default": true,
+          "description": "Diagnostics for malformed pom.js entries: whitespace in name/flags values, unknown flag tokens, entries pointing at missing files."
+        },
         "foam.features.diagnostics.i18n": {
           "type": "boolean",
           "default": true,

--- a/tools/lsp/editors/vscode/package.json
+++ b/tools/lsp/editors/vscode/package.json
@@ -37,7 +37,7 @@
         "foam.features.diagnostics.pom": {
           "type": "boolean",
           "default": true,
-          "description": "Diagnostics for malformed pom.js entries: whitespace in name/flags values, unknown flag tokens, entries pointing at missing files."
+          "description": "Diagnostics for malformed pom.js entries: whitespace in name/flags values, unknown flag tokens, entries pointing at missing files. Takes effect after a server restart."
         },
         "foam.features.diagnostics.i18n": {
           "type": "boolean",

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -98,17 +98,17 @@ foam.CLASS({
     },
 
     function handle(text, opt_uri) {
-      // pom.js files carry no foam.CLASS, so they fail the isFoamFile gate —
-      // the pom lane lives BEHIND it, or a foam.CLASS file merely MENTIONING
-      // foam.POM( in a comment would lose all of its normal diagnostics.
-      // Line-anchored so a "// foam.POM(" comment in a scratch file doesn't
-      // qualify either.
-      if ( ! this.analyzer.isFoamFile(text) ) {
-        if ( /^\s*foam\.POM\(/m.test(text) ) {
-          return this.pomDiagnostics_(text, opt_uri);
-        }
-        return [];
+      // The line-anchored foam.POM( test routes to the pom lane FIRST.
+      // Both lanes' gates are text sniffs: isFoamFile trips on a pom whose
+      // comment merely mentions a foam call (a real downstream pom does,
+      // via foam.FSM(), and would sniff as a class file and get no pom
+      // validation), while the anchored test can't false-positive on a
+      // "// foam.POM(" comment — the anchored test is the reliable one,
+      // so it outranks.
+      if ( /^\s*foam\.POM\(/m.test(text) ) {
+        return this.pomDiagnostics_(text, opt_uri);
       }
+      if ( ! this.analyzer.isFoamFile(text) ) return [];
 
       var uri = opt_uri || '';
       this.uri_ = uri;

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -98,12 +98,17 @@ foam.CLASS({
     },
 
     function handle(text, opt_uri) {
-      // pom.js files carry no foam.CLASS, so they exit at the isFoamFile
-      // gate below — entry-level pom checks get their own early lane.
-      if ( text.indexOf('foam.POM(') !== -1 ) {
-        return this.pomDiagnostics_(text, opt_uri);
+      // pom.js files carry no foam.CLASS, so they fail the isFoamFile gate —
+      // the pom lane lives BEHIND it, or a foam.CLASS file merely MENTIONING
+      // foam.POM( in a comment would lose all of its normal diagnostics.
+      // Line-anchored so a "// foam.POM(" comment in a scratch file doesn't
+      // qualify either.
+      if ( ! this.analyzer.isFoamFile(text) ) {
+        if ( /^\s*foam\.POM\(/m.test(text) ) {
+          return this.pomDiagnostics_(text, opt_uri);
+        }
+        return [];
       }
-      if ( ! this.analyzer.isFoamFile(text) ) return [];
 
       var uri = opt_uri || '';
       this.uri_ = uri;

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -74,6 +74,10 @@ foam.CLASS({
       documentation: 'Optional feature-toggle config from tools/lsp/FeatureConfig (server.js wires it). Plain Node object, not an FObject, so no `class:` here. Null means "every check on" — the handler is created bare in tests and by other tooling, and an absent config must never silence a diagnostic.'
     },
     {
+      name: 'pomValidator',
+      documentation: 'Optional (server.js wires it). When set, handle() runs entry-level pom checks (validateEntries) on texts containing foam.POM(, gated by diagnostics.pom; null-safe no-op otherwise.'
+    },
+    {
       name: 'validTypes_',
       factory: function() {
         var types = {};
@@ -94,6 +98,11 @@ foam.CLASS({
     },
 
     function handle(text, opt_uri) {
+      // pom.js files carry no foam.CLASS, so they exit at the isFoamFile
+      // gate below — entry-level pom checks get their own early lane.
+      if ( text.indexOf('foam.POM(') !== -1 ) {
+        return this.pomDiagnostics_(text, opt_uri);
+      }
       if ( ! this.analyzer.isFoamFile(text) ) return [];
 
       var uri = opt_uri || '';
@@ -307,6 +316,36 @@ foam.CLASS({
         if ( name ) actionNames[name] = true;
       }
       return actionNames;
+    },
+
+    function pomDiagnostics_(text, uri) {
+      /** Entry-level pom.js diagnostics (PomValidator.validateEntries),
+       *  behind the diagnostics.pom flag. Offsets from the validator are
+       *  mapped to line/char here; file-existence checks only run when the
+       *  uri resolves to a disk path. */
+      if ( ! this.pomValidator || ! this.featureOn_('diagnostics.pom') ) return [];
+
+      var fsPath = null;
+      if ( uri && uri.indexOf('file://') === 0 ) {
+        try { fsPath = decodeURIComponent(uri.substring(7)); } catch (e) {}
+      }
+
+      var issues = this.pomValidator.validateEntries(text, fsPath);
+      var out    = [];
+      for ( var i = 0 ; i < issues.length ; i++ ) {
+        var is = issues[i];
+        out.push({
+          range: {
+            start: this.analyzer.offsetToPosition(text, is.start),
+            end:   this.analyzer.offsetToPosition(text, is.end)
+          },
+          severity: is.severity,
+          code:     is.code,
+          source:   'foam-lsp',
+          message:  is.message
+        });
+      }
+      return out;
     },
 
     function toLSPDiagnostics_(diagnostics) {

--- a/tools/lsp/handlers/PomValidator.js
+++ b/tools/lsp/handlers/PomValidator.js
@@ -75,6 +75,109 @@ foam.CLASS({
       return { orphans: orphans, missing: missing, duplicates: duplicates };
     },
 
+    function validateEntries(text, pomPath) {
+      /** Entry-level checks on ONE pom.js source text: whitespace inside
+       *  name/flags values, unknown flag tokens, entries pointing at files
+       *  that don't exist on disk. Returns
+       *  [{severity: 1|2, start, end, code, message}] with offsets into
+       *  `text`. Positions come from the grammar harvest (pomFileName /
+       *  pomJavaFileName / pomFlagValue kinds) — never from regex scans.
+       *
+       *  Deliberately validates WITHOUT trimming: it mirrors what
+       *  foam.checkFlags actually matches (src/foam.js), so a spaced token
+       *  is reported as the silent no-match it is.
+       */
+      var fs     = require('fs');
+      var path   = require('path');
+      var issues = [];
+      var map    = this.grammar_().collectAxiomPositions(text);
+      var pomDir = pomPath ? path.dirname(pomPath) : null;
+
+      // Flag vocabulary measured across the repo's poms (2026-08-23).
+      // Unknown tokens WARN rather than ERROR — this list drifts as new
+      // flags appear.
+      var KNOWN = { js: 1, java: 1, web: 1, test: 1, node: 1, swift: 1,
+        debug: 1, demo: 1, dev: 1, genjava: 1, sql: 1, firebase: 1, gcloud: 1 };
+
+      function push(rec, severity, code, message) {
+        issues.push({ severity: severity, code: code, message: message,
+          start: rec.startPos, end: rec.endPos });
+      }
+
+      // Every span of a kind, flattened; single-occurrence kinds hold one
+      // record per name, MULTI kinds an array. Dedupe by startPos — the
+      // grammar's backtracking can record the same span twice.
+      function eachSpan(kind, cb) {
+        var byName = map[kind] || {}, seen = {};
+        for ( var name in byName ) {
+          var recs = byName[name];
+          if ( ! Array.isArray(recs) ) recs = [ recs ];
+          for ( var i = 0 ; i < recs.length ; i++ ) {
+            if ( seen[recs[i].startPos] ) continue;
+            seen[recs[i].startPos] = true;
+            cb(name, recs[i]);
+          }
+        }
+      }
+
+      function checkName(kind, ext) {
+        eachSpan(kind, function(content, rec) {
+          if ( content !== content.trim() || /\s/.test(content) ) {
+            push(rec, 1, 'pom-name-whitespace',
+              'whitespace in pom file name ' + "'" + content + "'" +
+              ' — the build resolves the name verbatim');
+            return;
+          }
+          if ( ! pomDir ) return;
+          if ( ! fs.existsSync(path.resolve(pomDir, content + ext)) ) {
+            push(rec, 1, 'pom-file-missing',
+              "'" + content + ext + "'" + ' not found relative to this pom.js');
+          }
+        });
+      }
+      checkName('pomFileName',     '.js');
+      checkName('pomJavaFileName', '.java');
+
+      eachSpan('pomFlagValue', function(content, rec) {
+        // Tokens exactly as foam.checkFlags sees them: split on | then &,
+        // no trimming.
+        var ors = content.split('|');
+        for ( var i = 0 ; i < ors.length ; i++ ) {
+          var ands = ors[i].split('&');
+          for ( var j = 0 ; j < ands.length ; j++ ) {
+            var tok = ands[j];
+            if ( tok === '' ) {
+              push(rec, 1, 'pom-flag-whitespace',
+                'empty flag token in ' + "'" + content + "'");
+              return;
+            }
+            if ( tok !== tok.trim() || /\s/.test(tok) ) {
+              push(rec, 1, 'pom-flag-whitespace',
+                'whitespace in flag token ' + "'" + tok + "'" +
+                ' — foam.checkFlags matches tokens verbatim, so this flag never matches');
+              return;
+            }
+            if ( ! KNOWN[tok] ) {
+              push(rec, 2, 'pom-flag-unknown',
+                'unknown flag ' + "'" + tok + "'");
+              return;
+            }
+          }
+        }
+      });
+
+      return issues;
+    },
+
+    function grammar_() {
+      /** Lazy grammar for position harvesting — same pattern as
+       *  DefinitionHandler.grammar_(). */
+      if ( ! this.grammarInstance_ ) {
+        this.grammarInstance_ = foam.parse.lsp.FoamClassGrammar.create({ index: this.index });
+      }
+      return this.grammarInstance_;
+    },
+
     function detectSourceRoots_(indexedPaths) {
       // Compute the set of unique top-level `src/` directories that the
       // POM index already references. Each is an FS root we'll walk for

--- a/tools/lsp/handlers/PomValidator.js
+++ b/tools/lsp/handlers/PomValidator.js
@@ -54,16 +54,22 @@ foam.CLASS({
       // call but aren't in the POM index. We bound the walk to typical
       // FOAM source roots to keep this O(workspace) rather than O(fs).
       var orphans   = [];
+      var pomFiles  = [];
       var sourceRoots = this.detectSourceRoots_(indexedPaths);
       var FOAM_DECL = /foam\.(?:CLASS|ENUM|INTERFACE|RELATIONSHIP|LIB)\s*\(/;
 
       for ( var i = 0 ; i < sourceRoots.length ; i++ ) {
+        // The project's top-level pom.js sits one level ABOVE the src root
+        // the walk covers.
+        var rootPom = path.join(path.dirname(sourceRoots[i]), 'pom.js');
+        if ( fs.existsSync(rootPom) ) pomFiles.push(rootPom);
+
         this.walkSourceTree_(sourceRoots[i], function(filePath) {
           if ( ! filePath.endsWith('.js') )      return;
+          if ( filePath.endsWith('/pom.js') )     { pomFiles.push(filePath); return; }
           if ( indexedPaths[filePath] )           return;
-          // Skip test/, pom.js, generated/etc. — only flag plain-source orphans.
+          // Skip test/, generated/etc. — only flag plain-source orphans.
           if ( /\/test\//.test(filePath) )        return;
-          if ( filePath.endsWith('/pom.js') )     return;
           if ( filePath.endsWith('tests.jrl') )   return;
           try {
             var text = fs.readFileSync(filePath, 'utf8');
@@ -72,7 +78,22 @@ foam.CLASS({
         });
       }
 
-      return { orphans: orphans, missing: missing, duplicates: duplicates };
+      // Entry-level issues (whitespace, unknown flags, missing files) rolled
+      // up across every pom the walk found.
+      var entryIssues = [];
+      for ( var i = 0 ; i < pomFiles.length ; i++ ) {
+        try {
+          var pomText = fs.readFileSync(pomFiles[i], 'utf8');
+          var issues  = this.validateEntries(pomText, pomFiles[i]);
+          for ( var j = 0 ; j < issues.length ; j++ ) {
+            issues[j].pomFile = pomFiles[i];
+            entryIssues.push(issues[j]);
+          }
+        } catch (e) {}
+      }
+
+      return { orphans: orphans, missing: missing, duplicates: duplicates,
+        entryIssues: entryIssues };
     },
 
     function validateEntries(text, pomPath) {

--- a/tools/lsp/handlers/PomValidator.js
+++ b/tools/lsp/handlers/PomValidator.js
@@ -174,8 +174,7 @@ foam.CLASS({
             }
             if ( tok !== tok.trim() || /\s/.test(tok) ) {
               push(rec, 1, 'pom-flag-whitespace',
-                'whitespace in flag token ' + "'" + tok + "'" +
-                ' — foam.checkFlags matches tokens verbatim');
+                'whitespace in flag token ' + "'" + tok + "'");
               return;
             }
             if ( ! KNOWN[tok] ) {

--- a/tools/lsp/handlers/PomValidator.js
+++ b/tools/lsp/handlers/PomValidator.js
@@ -175,7 +175,7 @@ foam.CLASS({
             if ( tok !== tok.trim() || /\s/.test(tok) ) {
               push(rec, 1, 'pom-flag-whitespace',
                 'whitespace in flag token ' + "'" + tok + "'" +
-                ' — foam.checkFlags matches tokens verbatim, so this flag never matches');
+                ' — foam.checkFlags matches tokens verbatim');
               return;
             }
             if ( ! KNOWN[tok] ) {

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -68,6 +68,7 @@ function start() {
   var typeDefinitionHandler  = foam.parse.lsp.handlers.TypeDefinitionHandler.create({ index: index, cache: fileModelCache });
   var callHierarchyHandler   = foam.parse.lsp.handlers.CallHierarchyHandler.create({ index: index, cache: fileModelCache });
   var pomValidator           = foam.parse.lsp.handlers.PomValidator.create({ index: index });
+  diagnosticsHandler.pomValidator = pomValidator;
   // No featureConfig: scaffolding has no toggle. It only ever runs because
   // the user explicitly invoked the command, so there is nothing to suppress
   // — unlike the lenses/diagnostics, which the server offers unasked.

--- a/tools/tests/lsp/pom.js
+++ b/tools/tests/lsp/pom.js
@@ -177,3 +177,14 @@ test(dhOn.handle(BAD_POM, BAD_POM_URI).length === 1,
 
 test(FeatureConfig.load({}).enabled('diagnostics.pom') === true,
   'diagnostics.pom defaults ON');
+
+section('PomValidator.validate — entry issues aggregated across workspace poms');
+
+var full = validator.validate();
+test(Array.isArray(full.entryIssues),
+  'validate() result gains entryIssues: []');
+test(full.entryIssues.every(function(e) {
+    return typeof e.pomFile === 'string' && typeof e.code === 'string' &&
+           typeof e.message === 'string';
+  }),
+  'every entry issue names its pomFile, code and message');

--- a/tools/tests/lsp/pom.js
+++ b/tools/tests/lsp/pom.js
@@ -57,3 +57,77 @@ var dupMap = grammar.collectAxiomPositions(DUP_SRC);
 var dupFlags = dupMap.pomFlagValue && dupMap.pomFlagValue['js'];
 test(Array.isArray(dupFlags) && dupFlags.length === 2,
   'duplicate flag strings keep BOTH spans (dedupe by startPos happens downstream)');
+
+section('PomValidator.validateEntries — whitespace, unknown flags, missing files');
+
+var fs   = require('fs');
+var os   = require('os');
+var path = require('path');
+
+var validator = foam.parse.lsp.handlers.PomValidator.create({ index: h.index });
+
+function issuesFor(src, pomPath) {
+  return validator.validateEntries(src, pomPath || null);
+}
+function codes(issues) {
+  return issues.map(function(i) { return i.code; }).sort().join(',');
+}
+
+// (a) whitespace inside a flag token -> ERROR naming the exact token
+var fa = issuesFor("foam.POM({\n  files: [ { name: 'A', flags: 'js |java' } ]\n});\n");
+test(fa.length === 1 && fa[0].code === 'pom-flag-whitespace' && fa[0].severity === 1,
+  'flag token with whitespace -> one pom-flag-whitespace ERROR');
+test(fa.length === 1 && fa[0].message.indexOf("'js '") !== -1,
+  'the message quotes the exact offending token');
+
+// (b) whitespace in a file name -> ERROR
+var fb = issuesFor("foam.POM({\n  files: [ { name: 'foam/core/Bad ', flags: 'js' } ]\n});\n");
+test(fb.length === 1 && fb[0].code === 'pom-name-whitespace' && fb[0].severity === 1,
+  'trailing space in name -> pom-name-whitespace ERROR');
+
+// (c) unknown flag token -> WARNING naming it
+var fc = issuesFor("foam.POM({\n  files: [ { name: 'A', flags: 'js|java&tets' } ]\n});\n");
+test(fc.length === 1 && fc[0].code === 'pom-flag-unknown' && fc[0].severity === 2,
+  'misspelled flag -> pom-flag-unknown WARNING (vocabulary drifts, so never ERROR)');
+test(fc.length === 1 && fc[0].message.indexOf("'tets'") !== -1,
+  'the warning names the unknown token');
+
+// (c2) empty token from a double pipe -> whitespace-variant ERROR
+var fc2 = issuesFor("foam.POM({\n  files: [ { name: 'A', flags: 'js||java' } ]\n});\n");
+test(fc2.length === 1 && fc2[0].code === 'pom-flag-whitespace' &&
+  fc2[0].message.indexOf('empty flag token') !== -1,
+  'a double | yields an empty token -> pom-flag-whitespace variant message');
+
+// (d) file existence, only when a pomPath is given
+var tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pomv-'));
+fs.writeFileSync(path.join(tmp, 'Good.js'), '// exists\n');
+var DISK_SRC = "foam.POM({\n  files: [\n" +
+  "    { name: 'Good', flags: 'js' },\n" +
+  "    { name: 'Ghost', flags: 'js' }\n  ]\n});\n";
+var fd = issuesFor(DISK_SRC, path.join(tmp, 'pom.js'));
+test(codes(fd) === 'pom-file-missing',
+  'existing file passes, missing file -> exactly one pom-file-missing ERROR');
+test(fd[0] && fd[0].severity === 1 && fd[0].message.indexOf('Ghost') !== -1,
+  'pom-file-missing is an ERROR naming the entry');
+
+// (d2) javaFiles resolve against .java, not .js
+fs.writeFileSync(path.join(tmp, 'RealJava.java'), '// exists\n');
+var JD_SRC = "foam.POM({\n  javaFiles: [\n" +
+  "    { name: 'RealJava' },\n" +
+  "    { name: 'GhostJava' }\n  ]\n});\n";
+var fj = issuesFor(JD_SRC, path.join(tmp, 'pom.js'));
+test(codes(fj) === 'pom-file-missing' && fj[0].message.indexOf('GhostJava') !== -1,
+  'javaFiles entries resolve name + .java relative to the pom dir');
+
+// (d3) no pomPath -> existence checks skipped entirely
+var fd3 = issuesFor(DISK_SRC, null);
+test(fd3.length === 0, 'without a pomPath (unit fixture) no existence check runs');
+
+// (e) clean pom -> no issues
+var fe = issuesFor("foam.POM({\n  files: [ { name: 'A', flags: 'js|java&test' } ]\n});\n", null);
+test(fe.length === 0, 'clean fixture -> []');
+
+// offsets point into the text so the diagnostics layer can map to line/char
+test(fa[0] && typeof fa[0].start === 'number' && typeof fa[0].end === 'number' &&
+  fa[0].end > fa[0].start,
+  'issues carry start/end offsets into the source text');

--- a/tools/tests/lsp/pom.js
+++ b/tools/tests/lsp/pom.js
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// pom-entry validation tests: grammar position harvest for pom values,
+// PomValidator entry-level checks, editor diagnostics gating, and the
+// foam/validatePoms aggregation.
+
+var h = require('./_harness');
+var test = h.test, section = h.section;
+var grammar = h.grammar;
+
+section('FoamClassGrammar — pom value position harvest');
+
+// collectAxiomPositions returns, per kind, a map keyed by the harvested
+// string CONTENT: single-occurrence kinds (pomFileName) hold one record,
+// MULTI kinds (the new pomFlagValue / pomJavaFileName) hold an array —
+// flag strings like 'js' repeat across entries, so every span matters.
+
+var POM_SRC = "foam.POM({\n  name: 'demo',\n  files: [\n" +
+  "    { name: 'foam/core/Good', flags: 'js|java' },\n" +
+  "    { name: 'foam/core/Bad ', flags: 'js |java' }\n  ]\n});\n";
+
+var pomMap = grammar.collectAxiomPositions(POM_SRC);
+
+test(!! pomMap.pomFileName['foam/core/Good'] && !! pomMap.pomFileName['foam/core/Bad '],
+  'pomFileName: both files: name values harvested, trailing space preserved in the key');
+test(!! pomMap.pomFlagValue, 'pomFlagValue kind exists in the harvest map');
+
+var badFlag = pomMap.pomFlagValue && pomMap.pomFlagValue['js |java'];
+test(Array.isArray(badFlag) && badFlag.length === 1,
+  'pomFlagValue is a MULTI kind — records arrive as arrays');
+test(!! badFlag &&
+  POM_SRC.slice(badFlag[0].startPos, badFlag[0].endPos) === 'js |java',
+  'pomFlagValue span covers the string CONTENT exactly (quotes excluded)');
+
+var goodFlag = pomMap.pomFlagValue && pomMap.pomFlagValue['js|java'];
+test(Array.isArray(goodFlag) && goodFlag.length === 1,
+  'clean flag value harvested too — the validator, not the grammar, judges');
+
+var JAVA_POM_SRC = "foam.POM({\n  name: 'j',\n  javaFiles: [\n" +
+  "    { name: 'foam/core/SomeJava', flags: 'test' }\n  ]\n});\n";
+var javaMap = grammar.collectAxiomPositions(JAVA_POM_SRC);
+var javaName = javaMap.pomJavaFileName && javaMap.pomJavaFileName['foam/core/SomeJava'];
+test(Array.isArray(javaName) && javaName.length === 1 &&
+  JAVA_POM_SRC.slice(javaName[0].startPos, javaName[0].endPos) === 'foam/core/SomeJava',
+  'pomJavaFileName: javaFiles: name value harvested with exact span');
+
+// A flag string that appears in two entries must yield two spans — the
+// whole reason the new kinds are MULTI.
+var DUP_SRC = "foam.POM({\n  name: 'd',\n  files: [\n" +
+  "    { name: 'A', flags: 'js' },\n" +
+  "    { name: 'B', flags: 'js' }\n  ]\n});\n";
+var dupMap = grammar.collectAxiomPositions(DUP_SRC);
+var dupFlags = dupMap.pomFlagValue && dupMap.pomFlagValue['js'];
+test(Array.isArray(dupFlags) && dupFlags.length === 2,
+  'duplicate flag strings keep BOTH spans (dedupe by startPos happens downstream)');

--- a/tools/tests/lsp/pom.js
+++ b/tools/tests/lsp/pom.js
@@ -167,6 +167,21 @@ test(!! diags[0] && diags[0].range && diags[0].range.start.line === 3 &&
   diags[0].range.end.line === 3 && diags[0].range.end.character > diags[0].range.start.character,
   'offsets map to the correct line/char range');
 
+// A foam.CLASS file that merely MENTIONS foam.POM( (comment, doc string)
+// must keep its normal diagnostics lane — the pom lane sits behind the
+// isFoamFile gate and requires a line-anchored foam.POM( call.
+var CLASS_MENTIONING_POM =
+  "// registered via foam.POM( in the parent pom.js\n" +
+  "foam.CLASS({\n  package: 'pomtest',\n  name: 'MentionsPom',\n" +
+  "  properties: [ 'a' ]\n});\n";
+test(dh.handle(CLASS_MENTIONING_POM, 'file:///pomtest/MentionsPom.js')
+    .every(function(d) { return d.code.indexOf('pom-') !== 0; }),
+  'foam.CLASS file mentioning foam.POM( in a comment stays on the class lane');
+
+test(dh.handle("// scratch notes about foam.POM( syntax\nvar x = 1;\n",
+    'file:///scratch.js').length === 0,
+  'non-FOAM file with a foam.POM( comment gets no pom diagnostics');
+
 var dhOff = diagHandlerFor({ 'diagnostics.pom': false });
 test(dhOff.handle(BAD_POM, BAD_POM_URI).length === 0,
   'diagnostics.pom: false suppresses the pom diagnostics');

--- a/tools/tests/lsp/pom.js
+++ b/tools/tests/lsp/pom.js
@@ -131,3 +131,49 @@ test(fe.length === 0, 'clean fixture -> []');
 test(fa[0] && typeof fa[0].start === 'number' && typeof fa[0].end === 'number' &&
   fa[0].end > fa[0].start,
   'issues carry start/end offsets into the source text');
+
+section('DiagnosticsHandler — pom diagnostics, gated by diagnostics.pom');
+
+var FeatureConfig = require('../../lsp/FeatureConfig');
+
+function diagHandlerFor(features) {
+  return foam.parse.lsp.handlers.DiagnosticsHandler.create({
+    index:        h.index,
+    pomValidator: validator,
+    featureConfig: features ?
+      FeatureConfig.load({ initOptions: { features: features } }) : null
+  });
+}
+
+var BAD_POM = "foam.POM({\n  name: 'x',\n  files: [\n" +
+  "    { name: 'A', flags: 'js |java' }\n  ]\n});\n";
+
+// The uri must resolve to a real directory containing A.js, or the
+// existence check adds a second (pom-file-missing) diagnostic.
+var diagTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'pomd-'));
+fs.writeFileSync(path.join(diagTmp, 'A.js'), '// exists\n');
+var BAD_POM_URI = 'file://' + path.join(diagTmp, 'pom.js');
+
+var dh    = diagHandlerFor(null);
+var diags = dh.handle(BAD_POM, BAD_POM_URI);
+test(Array.isArray(diags) && diags.length === 1,
+  'a pom.js text produces diagnostics through the normal handle() entry point');
+test(!! diags[0] && diags[0].code === 'pom-flag-whitespace' && diags[0].severity === 1,
+  'the pom-flag-whitespace ERROR comes through with its code and severity');
+test(!! diags[0] && diags[0].source === 'foam-lsp',
+  'diagnostic source is foam-lsp');
+// span check: 'js |java' starts on line 3 (0-based) after "    { name: 'A', flags: '"
+test(!! diags[0] && diags[0].range && diags[0].range.start.line === 3 &&
+  diags[0].range.end.line === 3 && diags[0].range.end.character > diags[0].range.start.character,
+  'offsets map to the correct line/char range');
+
+var dhOff = diagHandlerFor({ 'diagnostics.pom': false });
+test(dhOff.handle(BAD_POM, BAD_POM_URI).length === 0,
+  'diagnostics.pom: false suppresses the pom diagnostics');
+
+var dhOn = diagHandlerFor({ 'diagnostics.pom': true });
+test(dhOn.handle(BAD_POM, BAD_POM_URI).length === 1,
+  'explicit diagnostics.pom: true keeps them (and the flag name is known to FeatureConfig)');
+
+test(FeatureConfig.load({}).enabled('diagnostics.pom') === true,
+  'diagnostics.pom defaults ON');

--- a/tools/tests/lsp/pom.js
+++ b/tools/tests/lsp/pom.js
@@ -182,6 +182,18 @@ test(dh.handle("// scratch notes about foam.POM( syntax\nvar x = 1;\n",
     'file:///scratch.js').length === 0,
   'non-FOAM file with a foam.POM( comment gets no pom diagnostics');
 
+// The mirror direction: a pom whose COMMENT mentions a foam call that
+// isFoamFile sniffs on (a real downstream pom references foam.FSM()) must
+// still take the pom lane — the anchored foam.POM( test outranks the sniff.
+var POM_WITH_FOAM_COMMENT =
+  "// state machines here are driven by foam.CLASS( models via foam.FSM()\n" +
+  "foam.POM({\n  name: 'x',\n  files: [\n" +
+  "    { name: 'A', flags: 'js |java' }\n  ]\n});\n";
+test(dh.handle(POM_WITH_FOAM_COMMENT, BAD_POM_URI).some(function(d) {
+    return d.code === 'pom-flag-whitespace';
+  }),
+  'pom mentioning foam calls in a comment still gets pom validation');
+
 var dhOff = diagHandlerFor({ 'diagnostics.pom': false });
 test(dhOff.handle(BAD_POM, BAD_POM_URI).length === 0,
   'diagnostics.pom: false suppresses the pom diagnostics');

--- a/tools/tests/testFoamLSP.js
+++ b/tools/tests/testFoamLSP.js
@@ -41,7 +41,7 @@ if ( require.main === module ) {
 var CATEGORIES = [
   'config',
   'foamIndex', 'grammar', 'utilities', 'completion', 'hover', 'diagnostics',
-  'i18n', 'codelens', 'scaffold',
+  'i18n', 'codelens', 'scaffold', 'pom',
   'navigation', 'java', 'jrl', 'editorFeatures', 'typeHierarchy', 'usageIndex',
   'callHierarchy', 'pomValidation', 'pomNavigation', 'mcp'
 ];


### PR DESCRIPTION
Diagnoses malformed pom.js entries in the editor. Stacked on #5373 — the diagnostics gate uses that branch's FeatureConfig; retarget the base to development after it merges.

Grammar: collectAxiomPositions gains pomFlagValue and pomJavaFileName kinds (registered as multi-occurrence — flag strings like 'js' repeat across entries, and every span matters).

PomValidator.validateEntries(text, pomPath): entry-level checks with grammar positions, never regex scans — whitespace in a name or flag token (pom-name-whitespace / pom-flag-whitespace, ERROR), unknown flag tokens (pom-flag-unknown, WARNING — the vocabulary drifts as new flags appear, so never an error), and entries pointing at files that don't exist relative to the pom (pom-file-missing, ERROR; javaFiles resolve .java). Validation is deliberately untrimmed: it reports exactly what foam.checkFlags matches.

Editor surface: DiagnosticsHandler gets an early pom lane (pom.js files carry no foam.CLASS, so they exited at the isFoamFile gate), behind a new diagnostics.pom flag (default ON, mirrored in the VS Code settings UI). foam/validatePoms rolls the same checks up across every pom in the workspace as entryIssues.

New 'pom' test category, 28 assertions; full suite 1604 passing (the one failure is the pre-existing Tabs tabActiveColor assertion on development).

A companion PR trims flag tokens in core adaptFlags/checkFlags so spaced tokens are tolerated at build time; this validator still reports them.
