### PR TITLE
🚨CORE🚨: throw on malformed flag strings in adaptFlags/checkFlags

### DIFF
--- a/src/foam.js
+++ b/src/foam.js
@@ -89,7 +89,8 @@
 
       function and(fs) {
         if ( ! fs ) return true;
-        fs = fs.split('&');
+        // Trim: an inner "js& java" token survives adaptFlags' |-level trim.
+        fs = fs.split('&').map(function(s) { return s.trim(); });
         for ( var i = 0 ; i < fs.length ; i++ ) {
           if ( ! foam.flags[fs[i]] ) return false;
         }
@@ -135,15 +136,19 @@
       return false;
     },
     adaptFlags: function(flags) {
-      return typeof flags === 'string' ? flags.split('|') : flags;
+      // Trim each token: a hand-edited "js |java" otherwise silently
+      // matches nothing.
+      return typeof flags === 'string' ?
+        flags.split('|').map(function(s) { return s.trim(); }) :
+        flags;
     },
     checkForFlag: function (flags, desired) {
       if ( ! flags || ! desired ) return false;
       desired = this.adaptFlags(desired);
 
       function and(fs, ds) {
-        fs = fs.split('&');
-        ds = ds.split('&');
+        fs = fs.split('&').map(function(s) { return s.trim(); });
+        ds = ds.split('&').map(function(s) { return s.trim(); });
         for ( var i = 0 ; i < ds.length ; i++ )
           if ( ! fs.includes(ds[i]) )
             return false;

--- a/src/foam.js
+++ b/src/foam.js
@@ -89,8 +89,8 @@
 
       function and(fs) {
         if ( ! fs ) return true;
-        // Trim: an inner "js& java" token survives adaptFlags' |-level trim.
-        fs = fs.split('&').map(function(s) { return s.trim(); });
+        foam.assertFlags(fs);
+        fs = fs.split('&');
         for ( var i = 0 ; i < fs.length ; i++ ) {
           if ( ! foam.flags[fs[i]] ) return false;
         }
@@ -135,20 +135,29 @@
       foam.loaded[fn] = true;
       return false;
     },
+    assertFlags: function(flags) {
+      // A flags string/clause is WORD ( [|&] WORD )*. Whitespace or an empty
+      // token ("js |java", "js||java") used to match nothing silently,
+      // dropping the entry from every build with no trace. Fail the load
+      // loudly at the author instead.
+      if ( /\s/.test(flags) || /(^|[|&])([|&]|$)/.test(flags) ) {
+        throw new Error('foam: malformed flags ' + JSON.stringify(flags) +
+          " - whitespace or empty token; expected e.g. 'js|java&test'");
+      }
+    },
     adaptFlags: function(flags) {
-      // Trim each token: a hand-edited "js |java" otherwise silently
-      // matches nothing.
-      return typeof flags === 'string' ?
-        flags.split('|').map(function(s) { return s.trim(); }) :
-        flags;
+      if ( typeof flags !== 'string' ) return flags;
+      foam.assertFlags(flags);
+      return flags.split('|');
     },
     checkForFlag: function (flags, desired) {
       if ( ! flags || ! desired ) return false;
       desired = this.adaptFlags(desired);
 
       function and(fs, ds) {
-        fs = fs.split('&').map(function(s) { return s.trim(); });
-        ds = ds.split('&').map(function(s) { return s.trim(); });
+        foam.assertFlags(fs);
+        fs = fs.split('&');
+        ds = ds.split('&');
         for ( var i = 0 ; i < ds.length ; i++ )
           if ( ! fs.includes(ds[i]) )
             return false;

--- a/src/foam.js
+++ b/src/foam.js
@@ -147,6 +147,10 @@
     },
     adaptFlags: function(flags) {
       if ( typeof flags !== 'string' ) return flags;
+      // '' means "no flags" — e.g. a flagless pom entry's [] joined back
+      // into a string (LSP FoamIndex.matchesActiveFlags). Always matches
+      // (checkFlags([]) is true), never malformed.
+      if ( flags === '' ) return [];
       foam.assertFlags(flags);
       return flags.split('|');
     },


### PR DESCRIPTION
A pom entry written `flags: 'js |java'` or `'js& java'` silently matched nothing — adaptFlags and the and() helpers in checkFlags/checkForFlag compare tokens verbatim against foam.flags, so a stray space excluded the file from every build with no error anywhere.

Per review discussion on #5374: instead of trimming (which legitimizes the whitespace and still leaves an inner-space token like `'j s'` matching nothing), foam.assertFlags now rejects the string loudly at load time. Any whitespace or empty token (`'js |java'`, `'js||java'`) throws an Error naming the bad flags value. The check is one whole-string regex — flags grammar is WORD([|&]WORD)*, so any whitespace at all is inside some token.

The repo was swept for violations (string and array forms): clean — the only `flags: ''` hits are LSP test fixtures that never reach checkFlags (falsy early-out).

Behavior note: a pom that today silently drops an entry via a spaced flag will now fail to load until the flag is fixed. Loud beats silent — that is the fix working as intended.

Companion to #5374, whose editor validator reports these same tokens as errors at edit time, before the load ever runs.