### PR TITLE
PT-FIXES:DOS-4754 Wait on the outcome in the interner GC test, not on a round count

### DIFF
--- a/src/foam/util/test/StringInternerTest.js
+++ b/src/foam/util/test/StringInternerTest.js
@@ -51,17 +51,29 @@ foam.CLASS({
         // null passes through
         test(StringInterner.intern(null) == null, "null passes through");
 
-        // entries die with their string: intern uniques, drop them, force GC
-        int before = StringInterner.size();
+        // entries die with their string: intern uniques, drop them, force GC.
+        // System.gc() is a hint and the reference handler enqueues on its own
+        // thread, so wait for the outcome under a deadline rather than for a
+        // fixed number of rounds: a healthy run leaves on the first pass, and a
+        // loaded machine gets the time it needs instead of a failure.
+        // The map is measured against its own baseline, not against a full
+        // 10000: a GC during the fill loop already collects some probes, so
+        // requiring every one of them to still be present fails on a fast
+        // collector for the very reason the test is checking.
+        int  before   = StringInterner.size();
         for ( int i = 0 ; i < 10000 ; i++ ) StringInterner.intern("gc-probe-" + i + "-" + System.nanoTime());
-        int filled = StringInterner.size();
-        for ( int i = 0 ; i < 5 && StringInterner.size() > filled - 9000 ; i++ ) {
+        int  filled   = StringInterner.size();
+        int  target   = before + 1000;
+        long deadline = System.currentTimeMillis() + 30000;
+        while ( StringInterner.size() > target && System.currentTimeMillis() < deadline ) {
           System.gc();
-          try { Thread.sleep(100); } catch (InterruptedException e) { Thread.currentThread().interrupt(); }
+          try { Thread.sleep(50); } catch (InterruptedException e) { Thread.currentThread().interrupt(); break; }
+          // intern() drains the whole queue, so this call is what drops the entries
           StringInterner.intern("drain-trigger");
         }
-        test(filled >= before + 10000 && StringInterner.size() <= filled - 9000,
-          "collected strings leave the interner (was " + filled + ", now " + StringInterner.size() + ")");
+        test(filled > before + 1000 && StringInterner.size() <= target,
+          "collected strings leave the interner (baseline " + before + ", filled " + filled +
+          ", now " + StringInterner.size() + ")");
 
         // the parser dedups repeated short values across entries
         JSONParser p = new JSONParser();


### PR DESCRIPTION
`StringInternerTest` fails intermittently on CI and on a fast collector locally, with the interner behaving correctly in both cases — it bets on GC timing twice: five fixed rounds for the reference handler to enqueue 10 000 weak refs, and all 10 000 still present when the map is measured.

```
CI     ✘ collected strings leave the interner (was 14799, now 10155)   // refs not enqueued within 5 rounds
local  ✘ collected strings leave the interner (was 11524, now  1524)   // drained fully, off by one at fill time
```

`System.gc()` is a hint and enqueueing is asynchronous, so no round count is safe on a shared runner; a collection during the fill loop is the same behavior the test exists to prove.

Now it waits until the map returns to its baseline under a 30s deadline — a healthy run exits on the first pass — and asserts against that baseline instead of a full 10 000 surviving.

`./build.sh -W9090 server-tests:StringInternerTest` → 9 passed, 0 failed: `baseline 1523, filled 11523, now 1524`.