### PR TITLE
PT-FIXES:DOS-4773 fix(auth): require Group.id and guard empty parent …

### DIFF
--- a/src/foam/core/auth/EnabledCheckAuthService.js
+++ b/src/foam/core/auth/EnabledCheckAuthService.js
@@ -13,7 +13,8 @@ foam.CLASS({
   javaImports: [
     'foam.dao.DAO',
     'foam.core.auth.Subject',
-    'foam.core.session.Session'
+    'foam.core.session.Session',
+    'foam.util.SafetyUtil'
   ],
 
   methods: [
@@ -38,6 +39,7 @@ foam.CLASS({
         DAO localGroupDAO = ((DAO) x.get("localGroupDAO")).inX(x);
         while ( group != null ) {
           if ( ! group.getEnabled() ) return false;
+          if ( SafetyUtil.isEmpty(group.getParent()) ) break;
           group = (Group) localGroupDAO.find(group.getParent());
         }
 

--- a/src/foam/core/auth/Group.js
+++ b/src/foam/core/auth/Group.js
@@ -51,6 +51,7 @@ foam.CLASS({
     {
       class: 'String',
       name: 'id',
+      required: true,
       documentation: 'Unique name of the Group.'
     },
     {
@@ -227,6 +228,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
             appConfig.setUrl(url.replaceAll("/$", ""));
             break;
           }
+          if ( foam.util.SafetyUtil.isEmpty(group.getParent()) ) break;
           group = group.findParent(x);
         } while ( group != null );
         return appConfig;
@@ -241,6 +243,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
          */
         if ( ! groupId ) return false;
         if ( this.id === groupId || this.parent === groupId ) return true;
+        if ( ! this.parent ) return false;
         var parent = await groupDAO.find(this.parent);
         if ( parent == null ) return false;
         return parent.isDescendantOf(groupId, groupDAO);
@@ -256,6 +259,7 @@ List entries are of the form: 172.0.0.0/24 - this would restrict logins to the 1
           SafetyUtil.equals(this.getId(), groupId) ||
           SafetyUtil.equals(this.getParent(), groupId)
         ) return true;
+        if ( SafetyUtil.isEmpty(this.getParent()) ) return false;
         Group parent = (Group) groupDAO.find(this.getParent());
         if ( parent == null ) return false;
         return parent.isDescendantOf(groupId, groupDAO);


### PR DESCRIPTION
A `Group` saved with a blank `id` hangs every group parent-chain walk on the server: `find("")` starts returning that record instead of `null`, and because the record's own `parent` is `""` too, it is its own parent.

Cause: `getAppConfig` and `EnabledCheckAuthService.check` walk until `find(parent)` returns null, with no emptiness test. `""` is the value every root group already uses to mean "no parent", so the sentinel and a real key collide.

The blank record is easy to create: the comics Copy action clears the PK (`newRecord.id = undefined`) on the assumption the DAO mints a new one, and nothing generates a String PK.

Reproduce:

```java
groupDAO.put(new Group());   // id "" and parent "" — accepted, no validation
session.applyTo(x);          // never returns: getAppConfig walks "" -> "" -> ...
auth.check(x, perm);         // never returns: same cycle in EnabledCheckAuthService
```

`applyTo` runs for anonymous sessions too (`authorizeAnonymous` assigns the ServiceProvider's `anonymousUser`, whose id is above 1), so unauthenticated requests hang as well. Each one is a tight loop over an in-memory MDAO, so it throws nothing and logs nothing.

Fix:

- **required** — `required: true` on `Group.id`, so a create form can no longer save a blank key

- **getAppConfig** — break when `getParent()` is empty, before `findParent`

- **check** — same guard in `EnabledCheckAuthService`, matching `checkGroup` and `getAncestor`, which already test `isEmpty`

- **isDescendantOf** — guard the parent in both the Java and JS bodies; it recursed into the same cycle and overflowed the stack

