### PR TITLE
fix(partition): fire listeners on PartitionedDAO put and remove

### DIFF
--- a/src/foam/core/partition/PartitionedDAO.java
+++ b/src/foam/core/partition/PartitionedDAO.java
@@ -231,11 +231,18 @@ public class PartitionedDAO
       // System.err.println("**** PUT2 " + sb.toString());
       setID(obj, sb.toString());
     }
-    return getDelegate(part).put_(x, obj);
+    FObject ret = getDelegate(part).put_(x, obj);
+    // Listeners registered via listen_ live on this DAO, not on the
+    // soft-referenced partition delegates (they would be lost on unload), so
+    // fire them here. Same as NotPartitionedDAO.
+    if ( ret != null ) onPut(ret);
+    return ret;
   }
 
   public FObject remove_(X x, FObject obj) {
-    return getDelegate(x, obj).remove_(x, obj);
+    FObject ret = getDelegate(x, obj).remove_(x, obj);
+    if ( ret != null ) onRemove(ret);
+    return ret;
   }
 
   public FObject find_(X x, Object id) {

--- a/src/foam/core/partition/test/PartitionedDAOListenTest.js
+++ b/src/foam/core/partition/test/PartitionedDAOListenTest.js
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.partition.test',
+  name: 'PartitionedDAOListenTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `A listener registered on a PartitionedDAO hears every put and
+    remove, whichever partition the write lands in, and a predicated listener
+    hears only its partition.`,
+
+  javaImports: [
+    'foam.core.fs.FileSystemStorage',
+    'foam.core.fs.Storage',
+    'foam.core.partition.PartitionedDAO',
+    'foam.dao.AbstractSink',
+    'foam.lang.Detachable',
+    'foam.lang.X',
+    'java.io.File',
+    'static foam.mlang.MLang.EQ'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        X tx = newStorageContext(x);
+        PartitionedDAO dao = new PartitionedDAO(
+          tx, PartitionStrRecord.getOwnClassInfo(), "prtListen" + System.nanoTime() + "/",
+          PartitionStrRecord.BUCKET);
+
+        int[] all    = new int[2];
+        int[] bucket = new int[1];
+        dao.listen(new AbstractSink() {
+          @Override public void put(Object o, Detachable sub)    { all[0]++; }
+          @Override public void remove(Object o, Detachable sub) { all[1]++; }
+        }, null);
+        dao.listen(new AbstractSink() {
+          @Override public void put(Object o, Detachable sub) { bucket[0]++; }
+        }, EQ(PartitionStrRecord.BUCKET, 5));
+
+        PartitionStrRecord a = new PartitionStrRecord(); a.setBucket(5); a.setData("a");
+        PartitionStrRecord b = new PartitionStrRecord(); b.setBucket(7); b.setData("b");
+        a = (PartitionStrRecord) dao.put(a);
+        dao.put(b);
+        dao.remove(a);
+
+        test(all[0] == 2, "listener heard both puts across partitions, got " + all[0]);
+        test(all[1] == 1, "listener heard the remove, got " + all[1]);
+        test(bucket[0] == 1, "predicated listener heard only its partition, got " + bucket[0]);
+      `
+    },
+    {
+      name: 'newStorageContext',
+      args: 'X x',
+      type: 'X',
+      documentation: 'Sub-context with a temp-dir FileSystemStorage so journals stay out of the runtime journals dir.',
+      javaCode: `
+        String dir = System.getProperty("java.io.tmpdir") + File.separator
+          + "prtlisten_" + System.nanoTime();
+        new File(dir).mkdirs();
+        FileSystemStorage fs = new FileSystemStorage(dir);
+        return x.put(Storage.class, fs).put(FileSystemStorage.class, fs);
+      `
+    }
+  ]
+});

--- a/src/foam/core/partition/test/pom.js
+++ b/src/foam/core/partition/test/pom.js
@@ -12,7 +12,8 @@ foam.POM({
     { name: 'PartitionLoadReplayTest',            flags: 'js&test|java&test' },
     { name: 'PartitionLoadStatusIntegrationTest', flags: 'js&test|java&test' },
     { name: 'PartitionLoadProgressDAOTest',       flags: 'js&test|java&test' },
-    { name: 'UnloadableDecoratedDAOTest',         flags: 'js&test|java&test' }
+    { name: 'UnloadableDecoratedDAOTest',         flags: 'js&test|java&test' },
+    { name: 'PartitionedDAOListenTest',           flags: 'js&test|java&test' }
   ],
 
   javaFiles: [

--- a/src/foam/core/partition/test/tests.jrl
+++ b/src/foam/core/partition/test/tests.jrl
@@ -6,3 +6,4 @@ p({"class":"foam.core.partition.test.PartitionLoadReplayTest","id":"PartitionLoa
 p({"class":"foam.core.partition.test.PartitionLoadStatusIntegrationTest","id":"PartitionLoadStatusIntegrationTest"})
 p({"class":"foam.core.partition.test.PartitionLoadProgressDAOTest","id":"PartitionLoadProgressDAOTest", language: 0})
 p({"class":"foam.core.partition.test.UnloadableDecoratedDAOTest","id":"UnloadableDecoratedDAOTest"})
+p({"class":"foam.core.partition.test.PartitionedDAOListenTest","id":"PartitionedDAOListenTest"})


### PR DESCRIPTION
A sink registered with `PartitionedDAO.listen` never fires: `put_` and `remove_` hand the write to the partition's own MDAO and return, so the listeners held on the PartitionedDAO itself are never told.

Cause: partition delegates are soft-referenced and rebuilt on unload, so listeners live on the PartitionedDAO, but only `NotPartitionedDAO` calls `onPut` / `onRemove` after delegating. `PartitionedDAO` does not.

Reproduce (`PartitionedDAOListenTest`):

```java
dao.listen(sink, null);
dao.put(a);      // sink.put never called
dao.remove(a);   // sink.remove never called
```

Fix: call `onPut(ret)` / `onRemove(ret)` after the delegate write, the same two lines `NotPartitionedDAO` already has. Test added, including a predicated listener that hears only its own partition.