### PR TITLE
DOS-4603 reflow: tolerate i18n label objects in dao/daofilter commands

### DIFF
--- a/src/foam/core/reflow/DAOFilterPrompt.js
+++ b/src/foam/core/reflow/DAOFilterPrompt.js
@@ -69,7 +69,7 @@ foam.CLASS({
       class: 'String',
       name: 'label',
       factory: function() {
-        return this.dao ? this.dao.of.model_.plural + ' Filter' : 'DAO Filter';
+        return this.dao ? foam.String.localizeLabel(this.dao.of.model_.plural) + ' Filter' : 'DAO Filter';
       }
     },
     {

--- a/src/foam/core/reflow/DAOPrompt.js
+++ b/src/foam/core/reflow/DAOPrompt.js
@@ -186,7 +186,7 @@ foam.CLASS({
       hidden: true,
       onKey: true,
       expression: function(dao) {
-        return dao.of.model_.plural;
+        return foam.String.localizeLabel(dao.of.model_.plural);
       },
       displayWidth: 60
     },

--- a/src/foam/core/reflow/cmd/DAO.js
+++ b/src/foam/core/reflow/cmd/DAO.js
@@ -24,7 +24,7 @@ foam.CLASS({
     function execute(dao, opt_label) {
       let args  = {dao: dao, label: opt_label};
       let p     = this.DAOPrompt.create(args);
-      let label = p.dao.of.model_.plural;
+      let label = foam.String.localizeLabel(p.dao.of.model_.plural);
 
       p.addToE(this.out);
       this.currentBlock.flowName = opt_label || this.createFlowChildName(label.replaceAll(' ', '').toLowerCase());
@@ -68,7 +68,7 @@ foam.CLASS({
       }
       if ( ! args ) args = {dao: dao, label: opt_label};
       let p     = this.DAOPrompt.create(args);
-      let label = p.dao.of.model_.plural;
+      let label = foam.String.localizeLabel(p.dao.of.model_.plural);
 
       p.addToE(this.out);
       this.currentBlock.flowName = opt_label || args.label || this.createFlowChildName(label.replaceAll(' ', '').toLowerCase());

--- a/src/foam/lang/stdlib.js
+++ b/src/foam/lang/stdlib.js
@@ -581,6 +581,28 @@ foam.LIB({
       })
     },
     {
+      // Coerce a model label / plural to a plain String. FOAM i18n permits these
+      // to be objects keyed by locale ({ en: '...', fr: '...' }); consumers that
+      // string-manipulate them (e.g. reflow's replaceAll on model_.plural) need a
+      // String. Resolve to the current foam.locale, then its language prefix,
+      // then English, then the first available value. Not memoized: the input can
+      // be an object (unstable as a memoize key).
+      name: 'localizeLabel',
+      code: function(v) {
+        if ( typeof v === 'string' ) return v;
+        if ( v == null ) return '';
+        if ( typeof v === 'object' ) {
+          var loc = foam.locale || 'en';
+          return v[loc] ||
+                 v[loc.split('-')[0]] ||
+                 v.en ||
+                 Object.values(v)[0] ||
+                 '';
+        }
+        return '' + v;
+      }
+    },
+    {
       /**
        * Takes a key and creates a slot name for it.  Generally key -> key + '$'.
        *


### PR DESCRIPTION
The reflow `dao` and `daofilter` commands, and the DAOPrompt / DAOFilterPrompt label factories, read `dao.of.model_.plural` and call String methods on it (replaceAll, concat). FOAM i18n allows a model's label/plural to be an object keyed by locale ({ en, fr }); when a model uses one (e.g. AbstractDisputeTransaction after the dispute i18n work), the reflow Console crashed on load with "label.replaceAll is not a function".

Add foam.String.localizeLabel to coerce a String or i18n label object to a locale-resolved String (current foam.locale -> language prefix -> en -> first value), and use it at the four reflow read sites. Behaviour for plain String labels is unchanged.