### PR TITLE
DOS-4603 CSV export: emit a reference column's id in plain mode

### DIFF
--- a/src/foam/core/column/TableColumnOutputter.js
+++ b/src/foam/core/column/TableColumnOutputter.js
@@ -64,17 +64,28 @@ foam.CLASS({
           if ( foam.lang.Time.isInstance(prop) ) {
             return this.timeToString(val);
           }
-          return await this.valueToString(val);
+          return await this.valueToString(val, addUnitPropValueToStr);
         }
         return '';
       }
     },
 
-    async function valueToString(val) {
+    async function valueToString(val, opt_addUnits) {
       // JS RefSummary.f() returns a Promise resolving to { id, summary }.
       if ( val && typeof val.then === 'function' ) {
         val = await val;
         if ( val == null ) return '';
+      }
+      // Export with 'Add Units' unchecked: a reference column (e.g. a CurrencyCode
+      // like transactionCurrency) carries a { id, summary } RefSummary map. The
+      // summary is a display label ("USD - US Dollar"); the id is the bare,
+      // spreadsheet-parseable code ("USD"). Emit the id in plain mode, mirroring
+      // how DoubleUnitValue drops its unit. Only when addUnits is explicitly false
+      // (opt_addUnits === false) — the flag is absent on other call paths, which
+      // keep the summary so existing exports are unchanged.
+      if ( opt_addUnits === false && foam.Object.isInstance(val) &&
+           val.id !== undefined && val.summary !== undefined ) {
+        return val.id == null ? '' : val.id.toString();
       }
       if ( val.toSummary ) {
         if ( val.toSummary() instanceof Promise )
@@ -118,7 +129,7 @@ foam.CLASS({
                 continue;
               }
             }
-            stringArrayForValue.push(await this.returnStringValueForProperty(x, props[i], value[i]));
+            stringArrayForValue.push(await this.returnStringValueForProperty(x, props[i], value[i], undefined, addUnitPropValueToStr));
           }
           stringValues.push(stringArrayForValue);
         }


### PR DESCRIPTION
CSV export: emit a reference column's id in plain (no units) mode

CSV export with "Add Units" unchecked already renders DoubleUnitValue money columns as a bare, spreadsheet-parseable number. A reference column (e.g. a CurrencyCode like transactionCurrency) still exported its RefSummary, i.e. the display label "USD - US Dollar", which is not spreadsheet-friendly and duplicates the code.

Thread the existing plain flag into the non-unit branch of arrayOfValuesToArrayOfStrings and into valueToString, and in plain mode emit a { id, summary } RefSummary's id ("USD") instead of its summary. Default (units on / flag absent) is unchanged, so existing exports keep the summary.