### PR TITLE
Add foam-design-patterns: the review rules as an Agent Skill

### DIFF
--- a/.claude/skills/foam-design-patterns/SKILL.md
+++ b/.claude/skills/foam-design-patterns/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: foam-design-patterns
+description: Use when about to write or change any FOAM code, in foam3 or an app built on it - a model, property, view, DAO, decorator, rule, service, or Reflow block. Also use when a PR comes back with "why not just", "not needed", "already the default", "should be on the model", or when reviewing a FOAM diff for design rather than defects.
+---
+
+# FOAM design patterns
+
+What maintainer review asks for, from thousands of review comments. Each principle: heading, why, `Don't`, `Do`.
+
+## The spine
+
+### Declare what things are, not what to do when things happen
+Code is a liability; the declaration is the asset the framework regenerates behaviour from.
+Don't: an event handler that styles a node, validates a field, or copies a value
+Do:    a slot bound at declaration, a `validateObj`, an `expression:`
+
+### Ask the object; never keep a registry about it
+Bookkeeping in a consumer describes state the owning structure already knows, and goes stale.
+Don't: `Set<String>` of index signatures in the DAO
+Do:    `covers(Index)` on `Index`
+
+### More implementations behind fewer interfaces
+A new `DAO`, `Sink`, `View`, `Predicate` or `Agent` composes with everything; a new interface with nothing.
+Don't: a WebAgent per model, a new Button class, a second TimeUnit enum
+Do:    DIG, `foam.lang.Action`, refine the enum that exists
+
+### Delete the second statement of anything already stated
+A restated default or a duplicated fact is a line review will ask you to remove.
+Don't: `implements: ['foam.mlang.Expressions']` on a View, `value: false` on a Boolean
+Do:    nothing; the framework already says it
+
+## Ten questions before writing
+
+1. Already the default? (`start()`, `addClass()`, `after`, `&test`, `value:`)
+2. A one-liner already does it? (`tag`, `show`, `enableClass`, `copyFrom`, `IN`)
+3. A class already does it? Extend or refine; never parallel.
+4. Model or view? Property config, action, enum value first.
+5. Which axiom: `value`, `factory`, `expression`, `adapt`, `postSet`?
+6. Whose context: the caller's `x`, the ruler's, the object's?
+7. How many classes learn the new concept? Push down until one.
+8. Only the change in the diff?
+9. Anything left from debugging?
+10. Style matches the guide, character for character?
+
+## Read before writing, by task
+
+The mechanics live in `references/`. Open every file on your task's row before writing a line.
+
+| Task | Read |
+|---|---|
+| a view, or CSS | `defaults-and-reuse.md`, `u2-views.md`, `where-behaviour-lives.md` |
+| a model or property | `defaults-and-reuse.md`, `property-axioms.md` |
+| a DAO, decorator, rule, service, or `javaCode` | `context-and-dao.md`, `where-behaviour-lives.md`, `java-server.md` |
+| a flow, block, command, or agent | `reflow.md`, `defaults-and-reuse.md` |
+| a foam3 core class, index, or codegen | `foam3-core.md` |
+| any PR | `style-mechanics.md` |
+| a review | `review-checklist.md` |
+
+First step on every row: grep for the thing you are about to add. A class by name under `src/`, a
+command id in `cmds.jrl`, an agent in `agents.jrl`, a property on the base class.
+
+## Reviewing a diff
+
+Walk `review-checklist.md` top to bottom. One finding per line:
+`<path:line> — <principle heading> — <do line>`. Cite the reference file, never a person.
+A review workflow runs this as its design and simplicity passes; an application may layer its own patterns on top.

--- a/.claude/skills/foam-design-patterns/references/context-and-dao.md
+++ b/.claude/skills/foam-design-patterns/references/context-and-dao.md
@@ -1,0 +1,67 @@
+# Context and DAO
+
+Context is never implicit. The one "major security hole" in the review corpus was a DAO run in the
+system context; every other rule here is the same instinct at smaller scale.
+
+| Principle | One-line test |
+|---|---|
+| Take `x` from the argument and pass it down | does any method reach for `getX()` when an `x` was handed in? |
+| Inside a decorator, call the `_` methods with `x` | any bare `find(`/`put(`/`select(` on `getDelegate()`? |
+| Inside a rule, `x` reads, `ruler.getX()` writes | which context does the `put` use? |
+| Existence is `find`, count is `COUNT()` | any `ArraySink` followed by `isEmpty()` or `size()`? |
+| Configure EasyDAO before writing a new layer | is there a `cache`, `decorator`, or `pm` switch for this? |
+
+### Take `x` from the argument and pass it down
+The caller's `x` carries the user, session, and decorators; `getX()` is the object's boot context and runs as system.
+Don't: `dao = (DAO) getX().get("userDAO")` in a web agent or service method that received `x`
+Do:    `dao = ((DAO) x.get("userDAO")).inX(x)` when handed a system DAO; `PM.create(x, ...)`, `(Logger) x.get("logger")`
+Review asked: "This is a major security hole since you let a user perform arbitrary queries in the system context... do: dao = dao.inX(x)"
+
+### Inside a decorator, call `find_`, `put_`, `select_` with `x`
+The bare form re-enters the stack with the DAO's own context, so the rest of the chain runs as system and drops every query argument.
+Don't: `getDelegate().find(id)`; `getDelegate().select(sink)` inside a `select_` override
+Do:    `getDelegate().find_(x, id)`; `getDelegate().select_(x, sink, skip, limit, order, predicate)`
+
+### Inside a rule, `x` reads and `ruler.getX()` writes
+The ruler decorates `x` read-only; a write through it fails, and a write through `getX()` bypasses the ruler.
+Don't: `getX().get("fooDAO").put(obj)` in a `RuleAction`
+Do:    `((DAO) x.get("fooDAO")).find_(x, id)` to read; `((DAO) ruler.getX().get("fooDAO")).put_(ruler.getX(), obj)` to write; re-put the object's own DAO through `agency.submit(...)` then `ruler.stop()`
+Review asked: "use the argument x." / "replace getX() with ruler.getX() to get a non Readonly DAO."
+
+### `XLocator.get()` only in property hooks, with the reason beside it
+`getX()` is `EmptyX` during journal replay, so hooks need the thread-local context; anywhere else it hides a missing `x`.
+Don't: `XLocator.get()` in a service method
+Do:    `X x = XLocator.get();` inside `javaPostSet`/`javaFactory`, null-checking the context and the DAO
+
+### Import the DAO you own; `inX` the DAO you were handed
+A named `imports:` entry arrives already scoped to the object's context; `inX` exists for a DAO that came from elsewhere.
+Don't: `((DAO) getX().get("localUserDAO")).inX(getX())`
+Do:    `imports: [ { name: 'userDAO', javaType: 'DAO', key: 'localUserDAO' } ]` then `getUserDAO()`
+
+### Existence is `find`, count is `COUNT()`
+A sink materializes rows to answer a yes/no question.
+Don't: `ArraySink s = new ArraySink(); dao.where(p).limit(1).select(s); return ! s.getArray().isEmpty();`
+Do:    `return dao.find(p) != null;` or `dao.select(COUNT())`
+Review asked: "Can be done with find() or if you don't care about the result then a COUNT()."
+
+### Express the query; let the DAO answer it
+A loop that compares rows in Java bypasses indices and the decorators that would have scoped it.
+Don't: `OR(EQ(p, a), EQ(p, b), ...)` built in a loop; string join keys per comparison; `List.remove` inside a merge
+Do:    `IN(p, values)`; `addPropertyIndex` on the columns the query uses; sort once and merge
+
+### Configure EasyDAO before writing a new layer
+EasyDAO already has the cache, the TTL, the decorator slot, and the PM switch.
+Don't: a hand-written caching DAO; a `ModuleSupport` wrapper with `clearCache()`
+Do:    `"cache": true, "ttlSelectPurgeTime": ...` in `services.jrl`; `.setDecorator(...)`; `.setPm(true)`
+Review asked: "Is not just adding a TTL cache (supported by the EasyDAO config) to that DAO not sufficient?"
+
+### A decorator answers `cmd_` with `null`, never throws
+`cmd_` is a "does anyone handle this?" probe; a throw makes a retrying stack loop.
+Don't: `throw new UnsupportedOperationException()` in `cmd_`
+Do:    `return null;` for commands the decorator does not own; `return getDelegate().cmd_(x, obj);` otherwise
+
+### Never use `ctrl`; import the exported function or `requires:` the class
+`ctrl` exists for debugging and only in apps with the standard controller.
+Don't: `imports: ['ctrl']` then `this.ctrl.routeTo(...)`
+Do:    `imports: ['routeTo', 'pushMenu', 'notify']` then `this.routeTo(...)`
+Review asked: "ctrl is meant for debugging purposes only" (PR #4166)

--- a/.claude/skills/foam-design-patterns/references/defaults-and-reuse.md
+++ b/.claude/skills/foam-design-patterns/references/defaults-and-reuse.md
@@ -1,0 +1,56 @@
+# Defaults and reuse
+
+The largest cluster in the review corpus by a wide margin. Every line here is cheap to fix before
+the PR and costs a round after it.
+
+| Principle | One-line test |
+|---|---|
+| Never write a value that is already the default | delete it; does anything change? |
+| Use the one-liner the framework already has | grep the base class before writing three lines |
+| Extend the class that exists; never build a parallel one | `grep -r "name: '<Thing>'" src/` first |
+| The diff contains only the change | every hunk traces to the ticket |
+| Nothing left from debugging | `grep -n 'console.log\|println\|debugger\|///'` on the diff |
+
+### Never write a value that is already the default
+The framework knows its defaults; restating them is noise review must read past.
+Don't: `start('div')`; `addClass(this.myClass())`; `implements: ['foam.mlang.Expressions']` on a View; `factory: function() { return []; }` on an Array; `.select(this.ArraySink.create())`; `value: false` on a Boolean; `after: false, async: false` on a rule; `&test` under a `flags: 'test'` pom; `literal('x')` in a grammar
+Do:    `start()`; `addClass()`; call `this.EQ(...)` directly, View already mixes Expressions in; `{ class: 'Array', name: 'ids' }`; `.select()`; omit; omit; omit; `'x'`
+Review asked: "No need to waste space and slow startup by defining empty fields. FOAM knows the default values." (PR #3732); "DIV is the default value for start()"; "after and async default to false"
+
+### Use the one-liner the framework already has
+Three hand-written lines where a fluent call exists is the second most common comment.
+Don't: `.start().end()` with a slot, `if ( cond ) el.show()`, `enableClass(c, s$.map(v => ! v))`, copying fields one by one, `OR(EQ(p,a), EQ(p,b))`, `typeof a === 'string'`, `sort((a,b) => a.order - b.order)`
+Do:    `.tag('', null, slot$)`, `.show(cond$)`, `.enableClass(c, s$, true)`, `copyFrom(obj)`, `IN(p, [a,b])`, `foam.String.isInstance(a)`, `sort(Property.ORDER.compare)`
+Review asked: "You can just do this.addClass(), since if no arg is provided it defaults to this.myClass()." (PR #3534); "Isn't this already the default factory: for FObjectArrays?" (PR #1878)
+
+### Extend the class that exists; never build a parallel one
+A second class with the same job splits every future fix in two and loses theme, permission, and a11y behaviour the original already carries.
+Don't: a new TimeUnit enum; a second `button` command when `cmds.jrl` has one; a tabs view with its own CSS; a hand-rolled `getTransactions` beside a Relationship; a filter view copied from StringFilterView
+Do:    grep first: `grep -rn "name: '<Thing>'" src/`, `grep -n '"id": *"<cmd>"' cmds.jrl`; then refine `foam.nanos.TimeUnit`; extend the existing command; `extends: 'foam.u2.UnderlinedTabs'`; the Relationship's accessor; `extends: 'foam.u2.filter.properties.StringFilterView'`
+Review asked: "Foam already has a TimeUnit enum, can you just refine that instead?" (PR #4049); "the getTransactions(x) was removed as it is already provided by the Relationship. This is a feature of foam."; "How is this different than the DAONameParser?"
+
+### The diff contains only the change
+Reviewers say "revert" on every hunk they cannot trace to the ticket, and block the PR on a feature they disagree with.
+Don't: a reformat, a rename, or a second feature riding along
+Do:    one behaviour per PR; formatting as its own commit; split the extra into its own PR
+Review asked: "Should this be part of this PR?" (PR #2362); "Should have been a PR on its own." (PR #4351)
+
+### Nothing left from debugging
+A `console.log` or `debugger` in a view freezes every user with devtools open; a commented-out block is dead weight.
+Don't: `console.log('rendering', x)`, `System.err.println("THERE::")`, `if ( ! p ) debugger;`, a commented-out `init()`
+Do:    delete, or gate behind a `Logger` at debug level
+Review asked: "remove log()" (PR #3952); "Will this remain in the final commit?" (PR #4559)
+
+### Say why when the code looks like an omission
+A guard that looks redundant gets "fixed" by the next reader unless the reason sits beside it.
+Don't: a bare `if ( ! this.x ) return;` that exists for a browser quirk
+Do:    the same line with a one-sentence comment naming the quirk, or `documentation:` on the property
+Review asked: "add a comment so that someone doesn't just delete this in the future thinking its redundant" (PR #1708)
+
+## Rationalisations seen in testing
+
+| Rationalisation | Reality |
+|---|---|
+| "The skill says not to add `implements Expressions`, so I'll create a local `foam.mlang.Expressions.create()`" | View already mixes it in. `this.EQ(...)` works with no declaration at all. |
+| "I read three sibling widgets and none was a button, so I'll add one" | The registry is `cmds.jrl`, not the sibling files. Grep the id there before adding a command. |
+| "I'll keep `addClass(this.myClass())` for clarity" | It is the default. The reviewer will ask for `addClass()`. |

--- a/.claude/skills/foam-design-patterns/references/foam3-core.md
+++ b/.claude/skills/foam-design-patterns/references/foam3-core.md
@@ -1,0 +1,64 @@
+# foam3 core
+
+Changing a core class, an index, a DAO primitive, or codegen. Every principle here came from a
+foam3 PR being sent back.
+
+| Principle | One-line test |
+|---|---|
+| Ask the object; never keep a registry about it | any new Map, Set, or counter describing objects the class holds? |
+| Push it down until nobody outside needs to know | how many classes changed to learn the concept? |
+| Log when you skip work | any early `return` that declines the request silently? |
+| Interface defaults fail toward the status quo | what happens if the default answer is wrong? |
+| Measure the case that happens | does the benchmark time what a user waits for? |
+
+### Ask the object; never keep a registry about it
+Bookkeeping in a consumer goes stale; the structure already knows.
+Don't: `Set<String>` of index signatures in `MDAO.addIndex`
+Do:    `covers(Index)` on `Index`, implemented by `TreeIndex`, aggregated by `AltIndex`
+Review asked: "better to use the index itself to have a method to know if it's redundant, that will be way cleaner." (PR #5339)
+
+### Push it down until nobody outside needs to know
+The lowest point every caller already passes through enforces the rule once, with no coordination.
+Don't: the coverage check in `MDAO.addIndex`
+Do:    the check in `AltIndex.addIndex`; `MDAO` stays byte-identical to upstream
+Review asked: "would this be simpler if this code were moved into AltIndex? Then nobody outside of AltIndex would need to know?" (PR #5339)
+
+### Recurse over self-similar structures
+Index chains, node trees, nested predicates, and context chains are shallow; recursion restores polymorphism and drops the casts.
+Don't: `while ( true ) { mine = (TreeIndex) mine.tail_; theirs = (TreeIndex) theirs.tail_; }`
+Do:    `return tail_.covers(theirs.tail_);`
+
+### Log when you skip work
+A silent no-op is indistinguishable from a request that never happened, and surfaces later as a performance mystery.
+Don't: `if ( covers(i) ) return state;`
+Do:    `if ( covers(i) ) { Logger l = ...; if ( l != null ) l.info("Index already covered, not added", i); return state; }` with a null-checked context and logger
+
+### Interface defaults fail toward the status quo
+A wrong `false` costs a redundant index; a wrong `true` silently loses one, and there is no `removeIndex`.
+Don't: `default boolean covers(Index i) { return true; }`
+Do:    `return false;` with the asymmetry stated in the javadoc
+
+### Use the framework's instrument; check it is not already there
+`PMDAO` already records count and total per DAO operation; a hand-rolled timer disagrees with it.
+Don't: `System.nanoTime()` accumulators around a seed loop
+Do:    read `PMInfo`; remember PM counters accumulate from server start
+
+### Extend codegen at the seam that already receives what you need
+A hook next to a hook that already works is the version that gets rejected; a whole-method override takes ownership of scaffolding it did not mean to.
+Don't: a new `javaToJSON` sibling when `javaFormatJSON` already has the object; `javaGetter` to change one field read; `%FIELD%` placeholder templates; `cls` threaded into a hook body to read a backing field
+Do:    the existing hook; `javaInnerGetter`/`javaInnerSetter`; a `factory:` using `this.name`; a generated accessor on the class the other accessors live on
+
+### Generate once in `java/refinements.js`, never per model
+A core model says what an axiom is; everything that emits Java lives in the java refinement layer, so a JS-only build never loads it.
+Don't: `buildJavaClass()` inside `src/foam/core/StubMethod.js`
+Do:    the same method in `src/foam/java/refinements.js`; a generated hook for every model instead of asking each to add it
+
+### Predicate simplification is where silent wrong answers live
+`partialEval` that reduces with the wrong operator returns confident wrong rows.
+Don't: `And.partialEval` calling `reduceOr`
+Do:    each rule written as two English sentences in a comment, comparing the whole `arg1`/`arg2` pair
+
+### Measure the case that happens
+A benchmark that times the wrong thing produces a commit message the reviewer stops trusting.
+Don't: a browser structure vs a 244-row server DAO; reading a million rows when the UI pages; crediting the newer of two commits
+Do:    like for like at equal size; time one page; trust the profile over the guess; check the call site inlines before treating an allocation as a cost; one build per commit before attributing; say "structural" when it is structural

--- a/.claude/skills/foam-design-patterns/references/java-server.md
+++ b/.claude/skills/foam-design-patterns/references/java-server.md
@@ -1,0 +1,64 @@
+# Java inside `javaCode`
+
+Server code is reviewed for what it allocates, what it shares between threads, and what it logs.
+
+| Principle | One-line test |
+|---|---|
+| An allocation on a per-row path draws a comment | is this line inside a loop, a `put`, or a `f()`? |
+| Shared mutable state is synchronized | any collection or counter touched from two threads? |
+| `Loggers.logger(x, this)`, comma tokens | any `+` inside a log call? |
+| Log or throw, never swallow; keep the cause | any `catch` that neither logs nor rethrows? |
+| `fclone()` before mutating a DAO result | any setter on the return of `find`/`select`/`put`? |
+
+### An allocation on a per-row path draws a comment
+Garbage in a loop, a `put`, or a predicate `f()` multiplies by rows.
+Don't: `new Builder(x)` per call; `Long.toString(id)`; `substring` for one char; a `SimpleDateFormat` or `Pattern` per call; `new HashSet<>(list)` per check; `ArraySink` then loop
+Do:    a constructor; `sb.append(id)`; `charAt(len - 1)`; a hoisted constant or transient cached field; `select(new AbstractSink() { put(...) { ...; d.detach(); } })`
+Review asked: "Rather than selecting into an ArraySink, you could just process directly... you don't generate garbage." (PR #854)
+
+### Shared mutable state is synchronized or concurrent
+A `HashMap` or counter touched from two threads is a race; `notify()` wakes one arbitrary waiter.
+Don't: `static HashMap`; `count++` in a service; `notify()`; an unbounded queue
+Do:    `ConcurrentHashMap`/`AtomicLong`, or `synchronized: true` on the method axiom; `notifyAll()`; `new LinkedBlockingQueue<>(128)`
+
+### One logger per method; comma-separated tokens
+`Loggers.logger(x, this)` prefixes the class; concatenation builds the string even when the level is off.
+Don't: `logger.error("UploadAgent error: " + msg + " for " + id)`
+Do:    `Logger logger = Loggers.logger(x, this); logger.warning("parse", "id", id, msg)`; the level word is never in the message
+Review asked: "'error' is redundant. An error log output will already contain the 'error' string." (PR #4549)
+
+### Log or throw, never swallow; keep the cause
+A swallowed exception hides the failure; a rethrow without the cause hides the origin.
+Don't: `catch (Exception e) { }`; `throw new RuntimeException("failed")`; `new ClientRuntimeException(MSG);` never thrown
+Do:    `catch (Throwable t) { logger.error(...); throw new RuntimeException(t); }`; a `// nop` catch says why it is empty
+
+### Level-gate diagnostics; never log a payload on a hot or PII path
+A `debug` with a request body is a PII leak the moment the level is raised.
+Don't: `logger.debug("payload", payload)` on every request
+Do:    an `EventRecord` on failure or when debug is enabled; one WARN aggregating many parse failures
+
+### `SafetyUtil`, `fclone`, and set-then-clear
+DAO results are frozen; `null` checks miss whitespace; clearing needs the value and the isSet flag.
+Don't: `s != null && ! s.isEmpty()`; `obj.setX(v)` on a `find` result; `obj.setX(null)` to unset
+Do:    `! SafetyUtil.isEmpty(s)`; `obj = (T) obj.fclone(); obj.setX(v); dao.put_(x, obj)`; `obj.setX(0); obj.clearX();`
+
+### PM in try/finally; PM before a hand-rolled timer
+`PMDAO` already counts every DAO op; a `System.nanoTime()` accumulator disagrees with it.
+Don't: `long t0 = System.nanoTime(); ... total += System.nanoTime() - t0;`
+Do:    `PM pm = PM.create(x, this, "scan"); try { ... pm.log(x); } catch (Throwable t) { pm.error(x, t); throw t; }`
+
+### String-form `args:` with primitives; `javaThrows` listed
+The array form is boilerplate; boxed types allocate per call; hidden throws surprise callers.
+Don't: `args: [ { name: 'x', type: 'X' }, { name: 'id', type: 'Long' } ]`
+Do:    `args: 'X x, long id'`; `javaThrows: ['java.io.IOException']`
+Review asked: "It is more efficient to use type: 'long', instead of 'Long' because it is a primitive type"
+
+### Flatten control flow; extract the named method
+`else` after `return`, nested `if`s, or a repeated try/finally hide the shape of the logic.
+Don't: `if ( ! x ) return false; else return true;`; two copies of `try { set } finally { clear }`
+Do:    `return x;`; guard clauses; a flat `else if` chain; one named method called twice
+
+### Do work once
+Config resolved per call, a lock per id, or a lookup inside a loop multiplies a fixed cost by traffic.
+Don't: `x.get("appConfig")` per log line; a `synchronized` block per generated id; `dao.find` inside `for`
+Do:    resolve at construction into a property; double-checked init plus `AtomicInteger`; one `select` then a map

--- a/.claude/skills/foam-design-patterns/references/property-axioms.md
+++ b/.claude/skills/foam-design-patterns/references/property-axioms.md
@@ -1,0 +1,60 @@
+# Property axioms
+
+Which hook, which type, and the three mistakes that produce shared state, stale values, or a race.
+
+| Principle | One-line test |
+|---|---|
+| `value` literal, `factory` mutable, `expression` derived, `adapt` coerce, `postSet` rewire | does the hook name match what the code does? |
+| `value: []` shares one array across every instance | any `value:` that is an object or array is wrong |
+| A server-created object never runs a JS hook | who creates this: Java or the browser? |
+| Type the property to the domain | is a number, date, code, or currency stored as `String`? |
+| A derived value is transient with paired `factory`/`javaFactory` | would a stored copy go stale? |
+
+### Pick the hook by what the code does
+Each hook has one timing; using another produces a value that is stale, shared, or undefined.
+Don't: `factory:` for a value that depends on other properties; `preSet:` that side-effects; `postSet:` that computes this property's own value
+Do:    `value:` literal scalar · `factory:` per-instance object or needs `this` · `expression:` pure function of the named properties · `adapt:` coerce input · `postSet:` detach the old, subscribe the new, on other objects
+Review asked: "Don't use expression: and factory: interchangeably." (`doc/guides/claude.md:1059`)
+
+### `value: []` shares one array across every instance
+`value` is evaluated once at class definition; every instance points at the same object.
+Don't: `{ class: 'Array', name: 'ids', value: [] }`
+Do:    `{ class: 'Array', name: 'ids' }` (Array already has the factory), or `factory: function() { return []; }`
+Review asked: "Should never do value: [] otherwise all instances will share the same array" (PR #3821)
+
+### Never return `undefined` from a factory, expression, or slot function
+The framework warns, `isSet` lies, and downstream slots see a hole.
+Don't: `factory: function() { if ( ! this.x ) return; ... }`
+Do:    return the type's empty value, or move the computation to a `postSet` on the property it depends on
+
+### A server-created object never runs a JS hook
+`postSet` in JS runs in the browser; an object built by a Java rule never passes through it, and `find().then()` resolves after the read.
+Don't: `postSet: function(o, n) { this.userDAO.find(n).then(u => this.userName = u.toSummary()); }`
+Do:    a `javaFactory` on a `storageTransient` property, or a `Reference` property whose view resolves the name
+Review asked: "Aren't these created on the server in java? The JS postSet will never be run. Also, it would be a race condition"
+
+### Async coercion is `normalize`, never `postSet`
+`normalize` is awaited by the DAO before `put`; a `postSet` that writes back later loses the race with the caller.
+Don't: `postSet` that fires a DAO `find` and writes the property when it resolves
+Do:    `normalize: async function() { ... }` on the property
+
+### Type the property to the domain
+A `String` column defeats indexing, arithmetic, comparison, the query parser, and journal size; `Float` loses cents.
+Don't: `class: 'String'` for an amount, a date, a direction code, an ISO currency
+Do:    `Double` for money, `Enum` + `of:` for codes, `Date`/`DateTimeUTC` for timestamps, `CurrencyCode`, `Int` for ISO numerics
+
+### A derived value is transient with paired `factory` and `javaFactory`
+A stored copy of something computable goes stale the moment its inputs change.
+Don't: a persisted `netAmount` column written by a rule
+Do:    `{ class: 'Double', name: 'netAmt', storageTransient: true, factory: ..., javaFactory: ... }`
+Review asked: "More efficient to be a factory on a transient field."
+
+### `isSet` is false until the factory runs; an Enum is never `null`
+Enum properties default to ordinal 0, so a null check never fires; a factory-backed property reports unset until first read.
+Don't: `if ( getStatus() == null )`; `if ( ! xIsSet_ ) /* treat as absent */` when `x` has a factory
+Do:    `if ( ! statusIsSet_ )`; read the value and let the factory run
+
+### A per-subclass constant is a method override, not a property
+A property costs a settable field, a serialization slot, and a shadowing hazard; a method costs nothing.
+Don't: `properties: [ { name: 'category', value: IndexCategory.BOOLEAN } ]` in each subclass
+Do:    `methods: [ { name: 'category', code: ..., javaCode: 'return IndexCategory.BOOLEAN;' } ]`

--- a/.claude/skills/foam-design-patterns/references/property-axioms.md
+++ b/.claude/skills/foam-design-patterns/references/property-axioms.md
@@ -22,10 +22,11 @@ Don't: `{ class: 'Array', name: 'ids', value: [] }`
 Do:    `{ class: 'Array', name: 'ids' }` (Array already has the factory), or `factory: function() { return []; }`
 Review asked: "Should never do value: [] otherwise all instances will share the same array" (PR #3821)
 
-### Never return `undefined` from a factory, expression, or slot function
-The framework warns, `isSet` lies, and downstream slots see a hole.
-Don't: `factory: function() { if ( ! this.x ) return; ... }`
-Do:    return the type's empty value, or move the computation to a `postSet` on the property it depends on
+### Return `null`, never `undefined`, from a factory or expression
+`undefined` means "not computed yet" to the getter, so an expression that returns it is re-run, and re-subscribed, on every read.
+Don't: `expression: function(x) { if ( ! x ) return; ... }`
+Do:    `return (some expression) || null;` — `null` is a real value and is cached
+Review asked: "'undefined' has a special meaning for factory and expression values that means they need to be computed. Returning undefined will cause them to be repeatedly calculated." (PR #5393)
 
 ### A server-created object never runs a JS hook
 `postSet` in JS runs in the browser; an object built by a Java rule never passes through it, and `find().then()` resolves after the read.

--- a/.claude/skills/foam-design-patterns/references/reflow.md
+++ b/.claude/skills/foam-design-patterns/references/reflow.md
@@ -1,0 +1,89 @@
+# Reflow
+
+A flow is a saved document of named blocks, not a script. Cites are `foam3/src/foam/core/reflow/<file>:<line>`.
+
+| Principle | One-line test |
+|---|---|
+| One DAO select per block, filtered in the DAO stage | any loop over rows that touches a DAO? |
+| Gate visibility with `reactions_`, never by assigning `shown` | is `shown` written anywhere? |
+| Derived state is `transient` | would this value appear in the saved script or undo history? |
+| Detach the value before the block | any listener without `onDetach`? |
+| A block script is a stateless helper | does a second block need anything defined here? |
+
+### Name every block you reference; never rename it afterwards
+The name is the scope variable and dependency detection is a substring match on it.
+Don't: an unnamed block another block reads; renaming `uploads` once `summary` uses it
+Do:    name it first; the value is `uploads`, the block is `uploads$block`
+Cite: `Block.js:81-85`, `Console.js:1536-1546`, `Console.js:1793-1821`
+
+### One select per block, through the agent; filter in the DAO stage
+The agent selects once into its sink; anything after the select pulls the table to the client and defeats indices.
+Don't: a script that loops rows and calls `dao.find` per row; filtering the sink's array in JS
+Do:    `where`/`aql` on the DAOPrompt; a `FilteredDAOAgent`; `=` not `:` in predicates so an index can serve it
+Cite: `AbstractDAOAgent.js:47-50`, `DAOPrompt.js:251-304`, foam3 `caf522b80f`
+
+### Prefer `aql`/`where` strings over a serialized predicate
+A predicate FObject bakes `forClass_` into the script and breaks when the class is not registered at load.
+Don't: `predicate: { class: 'foam.mlang.predicate.Eq', ... }` in the saved block
+Do:    `aql: 'status = OPEN'`
+Cite: `DAOPrompt.js:149-153` vs `311-325`
+
+### Gate visibility with a `reactions_` formula, never by assigning `shown`
+`shown` is persisted, so a runtime toggle is a document edit autosave writes back; a hidden block still runs.
+Don't: `summaryTable$block.shown = uploads.count > 0` in a script
+Do:    a `reactions_` entry on `summaryTable`: `shown: uploads$count > 0`; default `"shown": false` in the block JSON
+Cite: `Block.js:97-101,207-208`, `ReactiveDetailView.js:22-30,91-144`, `AbstractDAOAgent.js:64-68`
+
+### Derived state is `transient`
+A non-transient derived field enters the undo memento and the saved script, and bloats both.
+Don't: a computed `count` property without `transient: true` on an agent
+Do:    `{ name: 'count', transient: true, expression: function(array) { ... } }`
+Cite: foam3 `c2134c97ef`, `Console.js:1832`
+
+### Bump `version` after changing an agent property programmatically
+The view re-executes on `data` or `version` only.
+Don't: `agent.where = 'x = 1'` and expect a redraw
+Do:    `agent.where = 'x = 1'; agent.run();` (`run` is `version++`)
+Cite: `DAOPrompt.js:39,44,565-567`
+
+### A sink's output is a property; aggregation sinks run on both tiers
+Render-time computation cannot be referenced by another block; a JS-only sink cannot run server-side.
+Don't: build the JSON string inside `addToE`
+Do:    `{ name: 'json', transient: true, expression: function(array) {...} }`; `Serializable` with paired `code`/`javaCode`
+Cite: `JSONSink.js:13-25`, `GridBy.js:14-17`
+
+### Detach the value before the block; `onDetach` every listener
+The value owns the DAO listeners; a stale dynamic renders into a detached element.
+Don't: `block.detach()` alone; `dao.listen(...)` without `onDetach`
+Do:    `Flowable.detachFlowChild`; `this.onDetach(dao.listen(...))`; detach the previous dynamic before creating a new one
+Cite: `Flowable.js:93-103`, `DAOPrompt.js:520-521`, `AbstractDAOAgent.js:61-63`
+
+### No per-flow state on `globalThis`; no shared DAO across independent blocks
+Globals survive `clearFlow` and bleed into the next flow in the tab; a shared DAO cross-talks on refresh and purge.
+Don't: `window.currentBuffer = ...`; two previews sharing one DAO instance
+Do:    a property on the Console or the block; one DAO per block
+Cite: `Console.js:1091-1098`, foam3 `ac7d4b5ea3`
+
+### Commands and agents live in `cmds.jrl` and `agents.jrl`; check there first
+The registry is the journal, not the sibling class files; a second command with the same job is a parallel class.
+Don't: a new `button` command when `grep '"id": *"button"' cmd/cmds.jrl` already hits; a sink class with no `agents.jrl` row
+Do:    grep the id, extend the existing command's class; add the journal row for anything new
+Cite: `cmd/cmds.jrl`, `agents.jrl`, `SinkView.js:50-89`
+
+### Gate with permissions; set `accessLevel`
+An unpermitted command never enters scope; the flow default is `PUBLIC_RW`.
+Don't: a command hidden in the UI; `accessLevel` unset
+Do:    `permissionRequired` on the Command or SinkAgent; `accessLevel` chosen
+Cite: `SinkView.js:50-89`, `cmd/Commands.js:76-88`, `Flow.js:133-140`
+
+### Never hand-edit a saved flow's escaped script
+The script is JSON inside JSON inside a string; a literal `\n` terminates the enclosing literal and kills the block.
+Don't: a regex over `"script":"..."` in a `.jrl`
+Do:    `BadBlock.repair`, or lift the whole flow through export and re-import
+Cite: `Flow.js:205-210`, foam3 `069ad8903d`
+
+### A block script is a stateless helper
+Anything a second block needs belongs in a named block, a model, or `foam.core.reflow.lib`.
+Don't: a parser or a prompt string living inside a command's script
+Do:    a model or parser class; a FLOW document the command loads
+Cite: foam3 `39090d486f`, `24f3316d6c`, `lib.js:7-20`

--- a/.claude/skills/foam-design-patterns/references/review-checklist.md
+++ b/.claude/skills/foam-design-patterns/references/review-checklist.md
@@ -1,0 +1,77 @@
+# Review checklist
+
+Every principle as a question, ordered by how often it cost a review round. Walk the whole file,
+not the diff hunks. Finding shape: `<path:line> — <principle heading> — <do line>`, one per line,
+citing the reference file, never a person. Style nits go in one grouped line at the end.
+
+## 1. Defaults and reuse
+- `start('div')` where `start()` is the same? `addClass(this.myClass())` where `addClass()` is the same? Grep both; they hide in plain sight.
+- Any other restated default? (`implements Expressions` on a View, `value: false`, `after/async: false`, `factory: () => []` on an Array, `.select(new ArraySink())`)
+- A one-liner for this block? (`tag`, `show`, `enableClass`, `copyFrom`, `IN`)
+- A class with this job already exists? Extended, refined, or paralleled?
+- Every hunk traces to the ticket? No reformat, rename, or second feature riding along?
+- Any `console.log`, `println`, `debugger`, `///`, or commented-out block?
+
+## 2. Behaviour placement
+- Could `tag(PROP.__)` plus property config replace this view code?
+- A button is a declared `Action`, not a click listener?
+- A switch, ordinal chain, or colour table over an enum the value could own?
+- Logic in the layer its trigger belongs to? (hook / decorator / rule / service / FSM)
+- A subclass detail read by its parent? A feature-specific field on an abstract base?
+- A core class extended where a downstream refinement would do?
+- A flag the caller maintains that the structure could derive?
+
+## 3. Style
+- `if ( x )`, `! x`, two-space indent, sorted imports, no trailing commas, semicolons, single quotes, header year, axiom order, naming table. One grouped line.
+
+## 4. Property axioms
+- Hook name matches what the code does? Any `value:` holding an array or object?
+- Any factory, expression, or slot function that can return `undefined`?
+- Object created in Java while the hook is JS? Any `find().then()` inside a setter?
+- A number, date, code, or currency stored as `String`? `Float` for money?
+- A computed value persisted where a transient with `factory`/`javaFactory` would do?
+- `== null` on an Enum? `isSet_` on a factory-backed property?
+
+## 5. Context and DAO
+- `getX()` where an `x` was handed in? A user request touching a DAO without `inX(x)`?
+- Inside a decorator: bare `find(`, `put(`, `select(` on the delegate?
+- Inside a rule: a write through `x` instead of `ruler.getX()`? A re-put without `ruler.stop()`?
+- `XLocator.get()` outside a property hook?
+- `ArraySink` then `isEmpty()`/`size()` where `find` or `COUNT()` answers?
+- A loop of `EQ`s where `IN` fits? A scan where an index exists? A new cache where EasyDAO has a switch?
+- A decorator `cmd_` that throws? `imports: ['ctrl']`?
+
+## 6. Java server
+- An allocation (`new`, `Builder`, `substring`, `SimpleDateFormat`, collection copy) on a per-row path?
+- A shared collection or counter without synchronization? `notify()`?
+- `+` inside a log call? "error" in an error log? A payload at debug?
+- A catch that neither logs nor rethrows? A rethrow without the cause?
+- A setter on a DAO result without `fclone()`? `setX(null)` without `clearX()`?
+- Array-form `args:`? Boxed primitives? `else` after `return`?
+
+## 7. u2 views
+- A colour literal? An unscoped CSS class? A root `width`/`height` on a reusable view? `!important`?
+- `px` where `rem` fits? `<h3>` where a Fonts class fits?
+- `dynamic()` around structure that does not change? `slot()` returning a detached element?
+- `sub()` outside `onDetach`? Registered on the data instead of the view?
+- A property view rendering its own label or reading `controllerMode`? A shared axiom mutated?
+- An optional import without `?` and `?.`?
+
+## 8. Reflow
+- A block reading a DAO per row, or filtering after the select?
+- `shown` assigned anywhere? A serialized predicate instead of `aql`?
+- Derived agent state without `transient: true`?
+- A listener without `onDetach`? A block detached without its value?
+- Per-flow state on `globalThis`? A DAO shared across blocks?
+- A new sink without an `agents.jrl` row? A command without `permissionRequired`? `accessLevel` unset?
+
+## 9. foam3 core
+- A new Map, Set, or counter describing objects the class holds?
+- A concept understood by more than one class?
+- An early return that skips work silently? An interface default that fails open?
+- A hand-rolled timer where PM exists? A codegen hook beside one that already receives the value?
+- A perf claim without a like-for-like measurement?
+
+## 10. Tests
+- Test files under `test/` with `flags: 'test'` on the pom entry?
+- An assertion that cannot fail? An `async` test that awaits nothing?

--- a/.claude/skills/foam-design-patterns/references/style-mechanics.md
+++ b/.claude/skills/foam-design-patterns/references/style-mechanics.md
@@ -1,0 +1,56 @@
+# Style mechanics
+
+The cheapest comments to avoid and the most repeated in the corpus: over 200 spacing, sort, comma,
+and header nits in five years. Source: `foam3/doc/guides/StyleGuide.md` plus the review record.
+
+## Formatting
+
+| Rule | Example |
+|---|---|
+| One space inside `if`/`for`/`while`/`switch` parens | `if ( ! found )`, `for ( var i = 0 ; i < n ; i++ )` |
+| Space after `!` | `! obj.isFrozen()` |
+| `catch` keeps Java form | `} catch (Throwable t) {` |
+| Two-space indent, JS and Java | never four |
+| Single-statement bodies under 80 chars need no braces | `if ( x == null ) return;` |
+| No `else` after `return` | `if ( a ) return 1; return 2;` |
+| Sort `requires`, `imports`, `exports`, `javaImports`, pom entries | alphabetical within group |
+| No trailing commas | last property, last array item |
+| Semicolons present | every statement |
+| Single quotes unless interpolating | `'text'`, `` `${a}` `` only when needed |
+| Do not quote map keys unless necessary | `{ display: 'flex' }` |
+| Line length 80 unless splitting hurts readability | one char over beats a split |
+| Space after `//` | `// comment` |
+| Blank line after `package:`/`name:`; no runs of blank lines; final newline | |
+| Header with the current year | foam3: Apache `Copyright <year> The FOAM Authors`; app: its own confidential header |
+| Vertical alignment where it reveals structure | aligned `=` in declaration blocks, aligned mlang args, aligned pom columns |
+| Short property form when only `name` is set | `'data'` not `{ name: 'data' }` |
+| Formatting is its own commit | `Formatting.` / `Spacing.`, never mixed with behaviour |
+
+## Axiom order inside `foam.CLASS`
+
+`package`, `name`, blank line, `extends`/`implements`/`mixins`/`refines`, `requires`, `imports`,
+`exports`, `javaImports`, `documentation`, `tableColumns`/`searchColumns`, `sections`, `constants`,
+`messages`, `css`, `properties`, `methods`, `listeners`, `actions`.
+
+## Naming
+
+| Rule | Example |
+|---|---|
+| Models CamelCase; acronyms as one letter | `DAOWAO`, `IOSPush`, not `DaoWAO`, `iOSPush` |
+| Properties camelCase; constants and messages `UPPER_SNAKE` | `CANCEL_LABEL`, enum values `EDIT`, `VIEW` |
+| `_` suffix on non-public members only; never on a public one | `delimiter_` private field; a public JS property has no `_` |
+| Service pair is `Server<Name>Service` / `Client<Name>Service` behind one CSpec id | never `<Name>Impl` |
+| A `ContextAgent` run by a cron is an `Agent`, not a `Cron` | `UpdateGeoAgent` |
+| Refinements end in `Refinement` | `UserRefinement` |
+| A mixin is not a `Utils` | `Memorable`; a `FooUtils` mixin name is legacy |
+| No `model` package | put the model beside its views |
+| Rule ids package-qualified | `foam_core_so_TaskCleanupOnRemovalRule` |
+| File named after the model it defines | `Metric.js`, not `scenarios.js` |
+| Name the thing, not its one consumer | `amount`, not `displayAmount` |
+| Rename toward the domain word; keep a deprecated alias for persisted properties | `activity` → `activityType` with a hidden shim |
+
+## Commit and PR
+
+Subject is imperative, sentence case, one line under 72 characters, and carries the why when the
+change is not self-evident. Ticket reference at the end in the repo's convention. The PR body
+describes the diff against the target, not the commit history.

--- a/.claude/skills/foam-design-patterns/references/u2-views.md
+++ b/.claude/skills/foam-design-patterns/references/u2-views.md
@@ -1,0 +1,71 @@
+# u2 views
+
+Tokens, scoping, reactivity, and lifecycle. A view is reusable only if it sets its own internals
+and nothing about its host.
+
+| Principle | One-line test |
+|---|---|
+| Colours from CSS tokens, never a literal | `grep '#[0-9a-f]\{3,6\}' <view>` returns nothing |
+| Scope every class with `myClass()` | any bare `.class-name` in `css:`? |
+| Class toggle before slot before `dynamic()` | does the DOM structure change, or only a value? |
+| Wrap every `sub()` in `onDetach` | count `sub(` vs `onDetach(` |
+| PropertyBorder owns label, visibility, errors | does the view read `controllerMode` or render a label by hand? |
+
+### Colours come from tokens; never a literal
+A literal cannot be themed and does not follow dark mode; named colours (`blue`, `red`) are literals too.
+Don't: `color: #1e40af`, `color: blue`, `background: rgb(...)`, `.style({ color: 'red' })`
+Do:    `color: $primary500` or `$textBrand`; inside `style()`: `foam.CSS.returnTokenValue('$primary500', this.cls_, this.__subContext__)`
+Review asked: "Please use CSSTokens for all colors." (PR #3946); "You should always use colours as listed in foam.u2.CSSTokens"
+
+### Scope every class with `myClass()`; set internals, never footprint
+An unscoped class collides with `Fonts.js`; a root `height`/`width` on a reusable view forces every embedder to fight it.
+Don't: `.row { ... }`; `^ { width: 100%; height: 300px; }` on a shared view; `!important`
+Do:    `^row { ... }` with `addClass(this.myClass('row'))`; `^pos > * { height: 100% }`; the embedder sets the footprint
+
+### `rem` over `px`; Fonts classes over `h3`; ThemeGlyphs over a new SVG
+FOAM sets `1rem = 10px` so everything scales with font size; glyphs are already inlined.
+Don't: `width: 12px`; `<h3>` for a title; a new `icon.svg`
+Do:    `width: 1.2rem`; `addClass('h300')` from Fonts.js; `themeIcon: 'dropdown'`
+
+### Toggle a class or bind a slot before reaching for `dynamic()`
+Each step up the ladder rebuilds more DOM; `dynamic()` is for structure changes only, and it builds into `this`.
+Don't: `this.slot(function(x) { return this.E().add(x); })`; a `dynamic()` around a whole table when one cell changes; `add(function() {...})` without `dynamic`
+Do:    `.enableClass('open', this.open$)` · `.add(this.title$)` · `.show(cond$)` · `this.dynamic(function(items) { ... })` around the block whose children are replaced
+Review asked: "keep dynamic() only around the elements whose structure actually changes." (`doc/guides/ReactiveUI.md:212`)
+
+### Wrap every `sub()` in `onDetach`, on the view that made it
+A bare subscription outlives the view; registering it on the data it watches leaks when the data outlives the view.
+Don't: `this.data.x$.sub(this.onX)`; `data.onDetach(sub)`
+Do:    `this.onDetach(this.data.x$.sub(this.onX))`; or a `listeners:` axiom, which self-detaches
+Review asked: "Two bare sub() calls were the entire U3 leak" (foam3 `7d7feed235`)
+
+### PropertyBorder owns label, units, visibility, errors, help
+A property view that renders its own label or reads `controllerMode` duplicates the border and fights it.
+Don't: `start('label').add(prop.label)`; `if ( this.controllerMode == 'VIEW' ) ...` in a property view
+Do:    `tag(prop.__)`; `visibility:` on the property; `startContext({ controllerMode: ... })` in the container
+Review asked: "Never set controllerMode directly on a view as a property. It is context-driven." (`doc/guides/ControllerModeAndVisibility.md:125`)
+
+### Never mutate the shared Property axiom from a view
+`this.data.POSTAL_CODE` is one object for every instance of the class.
+Don't: `this.data.POSTAL_CODE.label = 'ZIP'`
+Do:    `.tag(this.data.POSTAL_CODE.__, { config: { label$: this.zipLabel$ } })`
+
+### Optional imports get `?`, a `?.` call, and a real default
+A framework view must render outside its usual host; a missing import must not throw or warn.
+Don't: `imports: ['stack']` then `this.stack.push(...)`
+Do:    `imports: ['stack?']` then `this.stack?.push(...)`; or a property with `factory: function() { return this.__context__.x || NullX.create(); }`
+
+### URL state is a `memorable: true` property; navigate through the router
+Hand-managed `memento.head` and hand-built `StackBlock` configs bypass the routing the framework already owns.
+Don't: `this.memento_.head = ...`; `stack.push(StackBlock.create({ view: {...} }))`
+Do:    `{ name: 'tab', memorable: true }`; `this.routeTo(...)` / `routeToDAO(...)`
+
+### Declare an action's confirmation
+A hand-rolled modal plus a second "confirm" action duplicates what `confirmationRequired` already does.
+Don't: `actions: [ delete, confirmDelete ]` with a custom popup
+Do:    `{ name: 'delete', confirmationRequired: true, code: ... }`
+
+### Import the exported function, never `ctrl`
+`ctrl` exists for debugging and only in apps with the standard controller.
+Don't: `imports: ['ctrl']`, `this.ctrl.pushMenu(...)`
+Do:    `imports: ['pushMenu', 'routeTo', 'notify', 'currentMenu?']`

--- a/.claude/skills/foam-design-patterns/references/where-behaviour-lives.md
+++ b/.claude/skills/foam-design-patterns/references/where-behaviour-lives.md
@@ -1,0 +1,64 @@
+# Where behaviour lives
+
+The approach rejections. A local defect costs a comment; a wrong layer costs the PR.
+
+| Principle | One-line test |
+|---|---|
+| Configure the property; do not write the view | could `tag(PROP.__)` render this? |
+| Choose the layer by trigger | own state → hook; served shape → decorator; after-write → rule; clock or I/O → service; named states → FSM |
+| Push the concept down until one class understands it | count the classes that changed |
+| A base class carries only what every subclass shares | does every subclass need this field? |
+| Refine downstream; keep the core minimal | would every FOAM app want this? |
+
+### Configure the property; do not write the view
+`tag(PROP.__)` gives label, validation, visibility, i18n, permissions, and mode awareness for free.
+Don't: `start('label').add('Format').end().start(this.FORMAT).end()`; a `text-muted` class for a hint
+Do:    `tag(this.FORMAT.__)` with `label:` and `supportingLabel:` on the property; `startContext({ data: this })` when the property belongs to the view
+Review asked: "You really shouldnt need to explictly write views a lot." (PR #3946)
+
+### An action is declared on the model; the ActionView calls it
+A hand-wired button loses i18n, a11y, theming, permissioning, debounce, and `isAvailable`/`isEnabled`.
+Don't: `start('button').on('click', () => this.doIt()).end()`
+Do:    `actions: [ { name: 'doIt', code: ... } ]` then `add(this.DO_IT)`
+
+### Enum values carry their presentation and their methods
+A switch on the enum, or a colour table in a view, breaks the moment a value is added.
+Don't: `switch ( op )`; `status != WON && status != LOST && ...`; `mode.name === 'PRESENTATION'`
+Do:    `op.createSink()` as a method on the value; `status.getIsTerminal()`; `mode == FlowMode.PRESENTATION`; `color`/`background` on the value, one generic view
+
+### Choose the layer by trigger
+Each mechanism owns one trigger; the wrong one duplicates the logic or runs it at the wrong time.
+Don't: business logic in a view; an `instanceof` ladder inside a rule action; a payload assembled in each UI action
+Do:    property hook → one object's own state · DAO decorator → stored shape differs from served · rule → cross-model propagation after a write, gated by an FScript predicate · `COREService` + `ContextAgent` → a clock or I/O boundary · FSM → operator- or partner-driven states, payload built in the transition
+Review asked: "All the payloads can be determine during FSM state transition, and could be added there. Rather than on the actions."
+
+### Interface plus `instanceof` over reflection or a type switch
+Reflection is slow and breaks on subclasses; an interface method is polymorphic and cheap.
+Don't: `getClass().getDeclaredField("delegateIsSet_")`; `sink instanceof A || sink instanceof B`
+Do:    `ProxyDAO.DELEGATE.isSet(ns)`; a `Reducable` interface the sinks implement
+
+### Push the concept down until one class understands it
+Logic above the seam every caller passes through must be re-implemented by each caller.
+Don't: a coverage check in `MDAO.addIndex`; a parent reading a subclass detail
+Do:    the check in `AltIndex`; a named method the subclass overrides
+Review asked: "would this be simpler if this code were moved into AltIndex? Then nobody outside of AltIndex would need to know?" (PR #5339)
+
+### A base class carries only what every subclass shares
+A feature-specific field on the abstract parent forces every other subclass to carry and serialize it.
+Don't: `attachmentIds`, `bulkFileIds` on an abstract base when one subclass bulk-uploads
+Do:    a `BulkUpload` model that references the record
+
+### Refine downstream; keep the core minimal
+A property on a core class loads for every app; a refinement loads with the feature that needs it.
+Don't: a table-column flag on `foam.lang.Property`; a global config DAO in foam3
+Do:    `refines: 'foam.lang.Property'` in the outputter's file; the config in the app
+
+### Derive it; do not ask the caller to declare it
+A flag the caller maintains is a second source of truth that drifts.
+Don't: `navStackBottom` with a clamping `preSet`; `visible` on a block the container already tracks
+Do:    `this.stack.slice(0, this.stack.pos).length < 1`; delete the property
+
+### Delete the abstraction that does not work
+A broken decorator kept "for later" collects a workaround in every caller.
+Don't: a guard at each call site around a DAO whose design failed
+Do:    delete the class and its config; name the replacement in the commit


### PR DESCRIPTION
A foam3 change comes back for the same handful of reasons: a restated default, a registry about objects that could answer for themselves, a hook one seam too high. This skill puts those reasons where an agent reads them before writing, one principle per four lines:

```markdown
### Ask the object; never keep a registry about it
Bookkeeping in a consumer goes stale; the structure already knows.
Don't: `Set<String>` of index signatures in `MDAO.addIndex`
Do:    `covers(Index)` on `Index`, implemented by `TreeIndex`, aggregated by `AltIndex`
Review asked: "better to use the index itself to have a method to know if it's redundant" (PR #5339)
```

`SKILL.md` carries the spine (four principles, ten questions, a task → reference-file table); ten `references/*.md` hold the principles by area, each quoting the review that asked for it.

Layout follows `.claude/skills/README.md`: a short `SKILL.md`, the catalogues in `references/`, loaded only when the task row names them.