### PR TITLE
LSP: css token map records every declaring class; suite fully green

### DIFF
--- a/tools/lsp/CSSTokenResolver.js
+++ b/tools/lsp/CSSTokenResolver.js
@@ -21,7 +21,11 @@ foam.CLASS({
       name: 'tokenMap_',
       documentation: `Map of tokenName to
         { default_: { value, resolved }, themes: { themeId: { value, resolved } },
-          variants: { variantName: { value, resolved } }, type, source }`,
+          variants: { variantName: { value, resolved } }, type, source, sources }.
+        source is the LAST installing class (its value wins the flat map);
+        sources lists EVERY declaring class — per-class tokens may share a
+        name across sibling classes with different defaults (Tabs vs
+        SegmentedTabs tabActiveColor), and that is legal FOAM, not a clash.`,
       factory: function() { return {}; }
     },
     {
@@ -98,7 +102,13 @@ foam.CLASS({
       entries.sort(function(a, b) {
         var aRoot = a.sourceCls.id === 'foam.u2.CSSTokens' ? 1 : 0;
         var bRoot = b.sourceCls.id === 'foam.u2.CSSTokens' ? 1 : 0;
-        return aRoot - bRoot;
+        if ( aRoot !== bRoot ) return aRoot - bRoot;
+        // Secondary sort by class id: the registry cache iterates in
+        // insertion order, so without this, which sibling's duplicate
+        // token wins the flat map depends on load order — the entry's
+        // `source` flapped between foam.u2.Tabs and foam.u2.SegmentedTabs.
+        return a.sourceCls.id < b.sourceCls.id ? -1 :
+               a.sourceCls.id > b.sourceCls.id ?  1 : 0;
       });
 
       for ( var i = 0 ; i < entries.length ; i++ ) {
@@ -134,13 +144,21 @@ foam.CLASS({
         ? this.functionValueRepr_(rawValue)
         : ( rawValue || '' );
 
+      // A same-named token from another class is a sibling declaration,
+      // not an overwrite target: keep every declaring class in `sources`
+      // while the rest of the entry keeps last-writer-wins semantics.
+      var prev    = this.tokenMap_[axiom.name];
+      var sources = ( prev && prev.sources ) ? prev.sources : [];
+      if ( sources.indexOf(sourceCls.id) === -1 ) sources.push(sourceCls.id);
+
       var entry = {
         default_: { value: displayValue, resolved: null },
         themes:   {},
         variants: {},
         type:     ( axiom.cls_ && axiom.cls_.id === 'foam.u2.ColorToken' )
                     ? 'ColorToken' : 'CSSToken',
-        source:   sourceCls.id
+        source:   sourceCls.id,
+        sources:  sources
       };
 
       if ( axiom.variants ) {

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -83,13 +83,20 @@ test(implementors.length > 0, 'getImplementors finds classes implementing Create
 // === Per-class cssTokens loaded into the resolver (issue #5032) ===
 section('CSSTokenResolver — per-class cssTokens (issue #5032)');
 
-// Tabs.js defines its own ColorToken cssTokens — they should be in the
-// resolver's map and report Tabs as their source.
+// Tabs.js declares `tabActiveColor` in BOTH sibling classes (Tabs and
+// SegmentedTabs, deliberately different defaults since 088b7d9d6a) — legal
+// per-class FOAM tokens sharing a name. The flat map's `source` is the
+// last installer under the deterministic sort (foam.u2.Tabs), and
+// `sources` must record every declaring class.
 test(cssTokenResolver.tokenExists('tabActiveColor'),
   'Per-class token `tabActiveColor` (Tabs.js) is loaded');
 var tabInfo = cssTokenResolver.getTokenInfo('tabActiveColor');
 test(tabInfo && tabInfo.source === 'foam.u2.Tabs',
-  'Per-class token `tabActiveColor` source is foam.u2.Tabs');
+  'Per-class token `tabActiveColor` flat-map source is foam.u2.Tabs (deterministic sort)');
+test(tabInfo && Array.isArray(tabInfo.sources) &&
+  tabInfo.sources.indexOf('foam.u2.Tabs') !== -1 &&
+  tabInfo.sources.indexOf('foam.u2.SegmentedTabs') !== -1,
+  'sources records BOTH sibling declaring classes');
 test(tabInfo && tabInfo.type === 'ColorToken',
   'Per-class token `tabActiveColor` type is ColorToken');
 


### PR DESCRIPTION
The suite has carried one permanent failure since 088b7d9d6a: tabActiveColor is deliberately declared by BOTH Tabs and SegmentedTabs (sibling per-class tokens with different defaults — brand vs neutral — so themes can override each dark variant). That is legal FOAM the resolver's flat name->source map could not represent: which sibling won depended on registry iteration order, and the test asserting foam.u2.Tabs passed or failed by luck.

Fix in the LSP, not in Tabs.js — the duplicate is intentional:
- token entries gain sources[] recording EVERY declaring class
- source stays last-writer-wins, but under a new deterministic sort (root foam.u2.CSSTokens last, then class id) so it can never flap again
- the test now asserts the real contract: sources contains both siblings

With this the LSP suite is fully green (1609 passed, 0 failed) for the first time — every future failure is a real regression.