### PR TITLE
PT-FIXES:DOS-4797 javaPackIsSet: one long per 64 properties holds the isSet flags instead of a boolean each

### DIFF
--- a/src/foam/java/PropertyInfo.js
+++ b/src/foam/java/PropertyInfo.js
@@ -214,7 +214,9 @@ foam.CLASS({
             visibility: 'public',
             type: 'boolean',
             args: [{ name: 'o', type: 'Object' }],
-            body: `return ((${fullName}) o).${this.propName}IsSet_;`
+            body: 'return ' + ( this.property.javaIsSetReadOn_
+              ? this.property.javaIsSetReadOn_('((' + fullName + ') o)')
+              : '((' + fullName + ') o).' + this.propName + 'IsSet_' ) + ';'
           }
         ];
 

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -211,6 +211,30 @@ foam.CLASS({
         return this.javaType
       }
     },
+    // How the generated class records that this property is set. buildJavaClass fills these
+    // once it knows whether the owning model packs its flags (javaPackIsSet): either the
+    // property's own boolean field, or one bit of the class's long[]. The getter, setter,
+    // clearX() and the PropertyInfo all read them, so the choice lives in one place.
+    {
+      class: 'String',
+      name: 'javaIsSetRead_',
+      documentation: 'Java boolean expression, valid inside the owning class, true when the property is set.'
+    },
+    {
+      class: 'String',
+      name: 'javaIsSetTrue_',
+      documentation: 'Java statement, inside the owning class, that marks the property set.'
+    },
+    {
+      class: 'String',
+      name: 'javaIsSetFalse_',
+      documentation: 'Java statement, inside the owning class, that marks the property unset.'
+    },
+    {
+      class: 'Function',
+      name: 'javaIsSetReadOn_',
+      documentation: 'Given a Java expression for an instance of the owning class, returns the boolean expression true when the property is set on it. Used by the PropertyInfo, which reads another object.'
+    },
     {
       class: 'String',
       name: 'javaJSONParser',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -495,21 +495,17 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
       var isSet       = this.name + 'IsSet_';
       var factoryName = capitalized + 'Factory_';
 
-      // How this property records "set": its own boolean field, or one bit of one of the
-      // class's long words when the model opted into javaPackIsSet. The expressions carry
-      // that choice into the getter, the setter, clear and the PropertyInfo.
-      //
-      // Per-property booleans are independent fields, so setters on different properties
-      // never interact. A shared word makes |= a read-modify-write, so the write takes the
-      // object's monitor; reads stay plain, as they are for the booleans.
+      // How this property records "set": its own boolean field, or one bit of the class's
+      // long words when the model opted into javaPackIsSet, reached through the isSet_(bit),
+      // setIsSet_(bit) and clearIsSet_(bit) helpers the class generates (buildPackedIsSet_ on
+      // the FObject LIB). The expressions carry that choice into the getter, the setter, clear
+      // and the PropertyInfo.
       if ( cls.packIsSet ) {
-        var bit  = cls.isSetBits_++;
-        var word = cls.isSetField_ + ( bit >> 6 );
-        var mask = '(1L << ' + ( bit & 63 ) + ')';
-        this.javaIsSetRead_   = '( ( ' + word + ' & ' + mask + ' ) != 0 )';
-        this.javaIsSetTrue_   = 'synchronized ( this ) { ' + word + ' |= ' + mask + '; }';
-        this.javaIsSetFalse_  = 'synchronized ( this ) { ' + word + ' &= ~' + mask + '; }';
-        this.javaIsSetReadOn_ = function(obj) { return '( ( ' + obj + '.' + word + ' & ' + mask + ' ) != 0 )'; };
+        var bit = cls.isSetBits_++;
+        this.javaIsSetRead_   = 'isSet_(' + bit + ')';
+        this.javaIsSetTrue_   = 'setIsSet_(' + bit + ');';
+        this.javaIsSetFalse_  = 'clearIsSet_(' + bit + ');';
+        this.javaIsSetReadOn_ = function(obj) { return obj + '.isSet_(' + bit + ')'; };
       } else {
         this.javaIsSetRead_   = isSet;
         this.javaIsSetTrue_   = isSet + ' = true;';
@@ -661,6 +657,55 @@ foam.CLASS({
 foam.LIB({
   name: 'foam.lang.FObject',
   methods: [
+    function buildPackedIsSet_(cls) {
+      // javaPackIsSet storage: one long per 64 properties, and three helpers over them. Per-
+      // property booleans are independent fields, so setters on different properties never
+      // interact; a shared word makes |= a read-modify-write, so the writers take the object's
+      // monitor. Reads stay plain, as they are for the booleans. Java masks a shift distance to
+      // 0..63, so 1L << bit selects within the word without a mask of its own.
+      var words = Math.ceil(cls.isSetBits_ / 64);
+      var word  = function(w) { return cls.isSetField_ + w; };
+
+      for ( var w = 0 ; w < words ; w++ ) {
+        cls.field({ name: word(w), type: 'long', visibility: 'protected' });
+      }
+
+      // One statement per word, dispatched on bit >> 6; a single word needs no switch.
+      var perWord = function(stmt) {
+        if ( words == 1 ) return stmt(word(0));
+        var body = 'switch ( bit >> 6 ) {\n';
+        for ( var w = 0 ; w < words ; w++ ) {
+          body += ( w == words - 1 ? '  default: ' : '  case ' + w + ': ' ) + stmt(word(w)) + '\n';
+        }
+        return body + '}';
+      };
+
+      cls.
+        method({
+          name: 'isSet_',
+          type: 'boolean',
+          visibility: 'protected',
+          args: [ { name: 'bit', type: 'int' } ],
+          body: perWord(function(f) { return 'return ( ' + f + ' & (1L << bit) ) != 0;'; })
+        }).
+        method({
+          name: 'setIsSet_',
+          type: 'void',
+          visibility: 'protected',
+          synchronized: true,
+          args: [ { name: 'bit', type: 'int' } ],
+          body: perWord(function(f) { return f + ' |= (1L << bit);' + ( words == 1 ? '' : ' break;' ); })
+        }).
+        method({
+          name: 'clearIsSet_',
+          type: 'void',
+          visibility: 'protected',
+          synchronized: true,
+          args: [ { name: 'bit', type: 'int' } ],
+          body: perWord(function(f) { return f + ' &= ~(1L << bit);' + ( words == 1 ? '' : ' break;' ); })
+        });
+    },
+
     function buildJavaClass(cls) {
       // TODO Generate getX() and setX() if contextAware
       cls = cls || foam.java.Class.create();
@@ -681,8 +726,8 @@ foam.LIB({
         cls.extends = this.model_.javaExtends;
 
       // javaPackIsSet: the properties allocate one bit each as they build; the long words
-      // that hold them, one per 64 properties, are added once they are all in (below the
-      // axiom loop).
+      // that hold them, one per 64 properties, and the helpers that read and write a bit are
+      // added once they are all in (below the axiom loop).
       cls.packIsSet   = !! this.model_.javaPackIsSet;
       cls.isSetBits_  = 0;
       cls.isSetField_ = 'isSet' + this.model_.name + '_';
@@ -713,13 +758,7 @@ foam.LIB({
         axioms[i].buildJavaClass && axioms[i].buildJavaClass(cls, this);
       }
 
-      for ( var w = 0 ; cls.packIsSet && w * 64 < cls.isSetBits_ ; w++ ) {
-        cls.field({
-          name: cls.isSetField_ + w,
-          type: 'long',
-          visibility: 'protected'
-        });
-      }
+      if ( cls.packIsSet && cls.isSetBits_ > 0 ) this.buildPackedIsSet_(cls);
 
       // TODO: instead of doing this here, we should walk all Axioms
       // and introduce a new buildJavaAncestorClass() method
@@ -2682,9 +2721,10 @@ foam.CLASS({
         Saves a byte per declared property per instance, which on a wide model is most of what
         an empty column costs. The isSet API is unchanged (PropertyInfo.isSet, clearX(), getters
         and setters); only the storage differs, so hand-written javaCode on an opted-in model
-        must not read the xIsSet_ fields, which no longer exist. The flag write is synchronized
-        on the object, so setters on different properties keep the independence the separate
-        boolean fields gave them.`
+        must not read the xIsSet_ fields, which no longer exist; the class's isSet_(bit),
+        setIsSet_(bit) and clearIsSet_(bit) helpers are the storage's only readers and writers.
+        The writers are synchronized on the object, so setters on different properties keep the
+        independence the separate boolean fields gave them.`
     },
     {
       class: 'AxiomArray',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -495,16 +495,20 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
       var isSet       = this.name + 'IsSet_';
       var factoryName = capitalized + 'Factory_';
 
-      // How this property records "set": its own boolean field, or one bit of the class's
-      // long[] when the model opted into javaPackIsSet. The expressions carry that choice
-      // into the getter, the setter, clear and the PropertyInfo.
+      // How this property records "set": its own boolean field, or one bit of one of the
+      // class's long words when the model opted into javaPackIsSet. The expressions carry
+      // that choice into the getter, the setter, clear and the PropertyInfo.
+      //
+      // Per-property booleans are independent fields, so setters on different properties
+      // never interact. A shared word makes |= a read-modify-write, so the write takes the
+      // object's monitor; reads stay plain, as they are for the booleans.
       if ( cls.packIsSet ) {
         var bit  = cls.isSetBits_++;
-        var word = cls.isSetField_ + '[' + ( bit >> 6 ) + ']';
+        var word = cls.isSetField_ + ( bit >> 6 );
         var mask = '(1L << ' + ( bit & 63 ) + ')';
         this.javaIsSetRead_   = '( ( ' + word + ' & ' + mask + ' ) != 0 )';
-        this.javaIsSetTrue_   = word + ' |= ' + mask + ';';
-        this.javaIsSetFalse_  = word + ' &= ~' + mask + ';';
+        this.javaIsSetTrue_   = 'synchronized ( this ) { ' + word + ' |= ' + mask + '; }';
+        this.javaIsSetFalse_  = 'synchronized ( this ) { ' + word + ' &= ~' + mask + '; }';
         this.javaIsSetReadOn_ = function(obj) { return '( ( ' + obj + '.' + word + ' & ' + mask + ' ) != 0 )'; };
       } else {
         this.javaIsSetRead_   = isSet;
@@ -676,8 +680,9 @@ foam.LIB({
       if ( this.model_.javaExtends )
         cls.extends = this.model_.javaExtends;
 
-      // javaPackIsSet: the properties allocate one bit each as they build; the long[] that
-      // holds them is sized and added once they are all in (below the axiom loop).
+      // javaPackIsSet: the properties allocate one bit each as they build; the long words
+      // that hold them, one per 64 properties, are added once they are all in (below the
+      // axiom loop).
       cls.packIsSet   = !! this.model_.javaPackIsSet;
       cls.isSetBits_  = 0;
       cls.isSetField_ = 'isSet' + this.model_.name + '_';
@@ -708,12 +713,11 @@ foam.LIB({
         axioms[i].buildJavaClass && axioms[i].buildJavaClass(cls, this);
       }
 
-      if ( cls.packIsSet && cls.isSetBits_ > 0 ) {
+      for ( var w = 0 ; cls.packIsSet && w * 64 < cls.isSetBits_ ; w++ ) {
         cls.field({
-          name: cls.isSetField_,
-          type: 'long[]',
-          visibility: 'protected',
-          initializer: 'new long[' + Math.ceil(cls.isSetBits_ / 64) + '];'
+          name: cls.isSetField_ + w,
+          type: 'long',
+          visibility: 'protected'
         });
       }
 
@@ -2673,12 +2677,14 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'javaPackIsSet',
-      documentation: `Keep this class's per-property set flags in one long[] bitset instead of a
-        boolean field per property. Saves a byte per declared property per instance, which on a
-        wide model is most of what an empty column costs. The isSet API is unchanged
-        (PropertyInfo.isSet, clearX(), getters and setters); only the storage differs, so
-        hand-written javaCode on an opted-in model must not read the xIsSet_ fields, which no
-        longer exist.`
+      documentation: `Keep this class's per-property set flags in long fields, one bit per
+        property and one field per 64 properties, instead of a boolean field per property.
+        Saves a byte per declared property per instance, which on a wide model is most of what
+        an empty column costs. The isSet API is unchanged (PropertyInfo.isSet, clearX(), getters
+        and setters); only the storage differs, so hand-written javaCode on an opted-in model
+        must not read the xIsSet_ fields, which no longer exist. The flag write is synchronized
+        on the object, so setters on different properties keep the independence the separate
+        boolean fields gave them.`
     },
     {
       class: 'AxiomArray',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -445,7 +445,7 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
         setter += `${this.javaType} oldVal = ${this.name}_;\n`;
       }
       setter += this.javaInnerSetter + '\n';
-      setter += `${this.name}IsSet_ = true;\n`;
+      setter += ( this.javaIsSetTrue_ || `${this.name}IsSet_ = true;` ) + '\n';
 
       // add post-set function
       if ( this.javaPostSet ) {
@@ -471,25 +471,46 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
       var isSet       = this.name + 'IsSet_';
       var factoryName = capitalized + 'Factory_';
 
-      cls.
-        field({
-          name: privateName,
-          type: this.javaFieldType,
-          visibility: 'protected'
-        }).
-        field({
+      // How this property records "set": its own boolean field, or one bit of the class's
+      // long[] when the model opted into javaPackIsSet. The expressions carry that choice
+      // into the getter, the setter, clear and the PropertyInfo.
+      if ( cls.packIsSet ) {
+        var bit  = cls.isSetBits_++;
+        var word = cls.isSetField_ + '[' + ( bit >> 6 ) + ']';
+        var mask = '(1L << ' + ( bit & 63 ) + ')';
+        this.javaIsSetRead_   = '( ( ' + word + ' & ' + mask + ' ) != 0 )';
+        this.javaIsSetTrue_   = word + ' |= ' + mask + ';';
+        this.javaIsSetFalse_  = word + ' &= ~' + mask + ';';
+        this.javaIsSetReadOn_ = function(obj) { return '( ( ' + obj + '.' + word + ' & ' + mask + ' ) != 0 )'; };
+      } else {
+        this.javaIsSetRead_   = isSet;
+        this.javaIsSetTrue_   = isSet + ' = true;';
+        this.javaIsSetFalse_  = isSet + ' = false;';
+        this.javaIsSetReadOn_ = function(obj) { return obj + '.' + isSet; };
+      }
+
+      cls.field({
+        name: privateName,
+        type: this.javaFieldType,
+        visibility: 'protected'
+      });
+      if ( ! cls.packIsSet ) {
+        cls.field({
           name: isSet,
           type: 'boolean',
           visibility: 'protected',
           initializer: 'false;'
-        }).
+        });
+      }
+
+      cls.
         method({
           name: 'get' + capitalized,
           type: this.javaType,
           visibility: 'public',
           synchronized: this.synchronized,
           forceJavaOutputter: true,
-          body: this.javaGetter || ('if ( ! ' + isSet + ' ) {\n' +
+          body: this.javaGetter || ('if ( ! ' + this.javaIsSetRead_ + ' ) {\n' +
             ( this.javaFactory ?
                 '  set' + capitalized + '(' + factoryName + '());\n' :
                 ' return ' + this.javaValue + ';\n' ) + '}\n' + this.javaInnerGetter )
@@ -517,7 +538,7 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
           type: 'void',
           forceJavaOutputter: true,
           body: `assertNotFrozen();
-${isSet} = false;`
+${this.javaIsSetFalse_}`
         });
 
       if ( this.javaFactory ) {
@@ -631,6 +652,12 @@ foam.LIB({
       if ( this.model_.javaExtends )
         cls.extends = this.model_.javaExtends;
 
+      // javaPackIsSet: the properties allocate one bit each as they build; the long[] that
+      // holds them is sized and added once they are all in (below the axiom loop).
+      cls.packIsSet   = !! this.model_.javaPackIsSet;
+      cls.isSetBits_  = 0;
+      cls.isSetField_ = 'isSet' + this.model_.name + '_';
+
       cls.fields.push(foam.java.ClassInfo.create({ id: this.id }));
 
       cls.method({
@@ -655,6 +682,15 @@ foam.LIB({
 
       for ( var i = 0 ; i < axioms.length ; i++ ) {
         axioms[i].buildJavaClass && axioms[i].buildJavaClass(cls, this);
+      }
+
+      if ( cls.packIsSet && cls.isSetBits_ > 0 ) {
+        cls.field({
+          name: cls.isSetField_,
+          type: 'long[]',
+          visibility: 'protected',
+          initializer: 'new long[' + Math.ceil(cls.isSetBits_ / 64) + '];'
+        });
       }
 
       // TODO: instead of doing this here, we should walk all Axioms
@@ -2609,6 +2645,16 @@ foam.CLASS({
       class: 'Boolean',
       name: 'javaGenerateConvenienceConstructor',
       value: true
+    },
+    {
+      class: 'Boolean',
+      name: 'javaPackIsSet',
+      documentation: `Keep this class's per-property set flags in one long[] bitset instead of a
+        boolean field per property. Saves a byte per declared property per instance, which on a
+        wide model is most of what an empty column costs. The isSet API is unchanged
+        (PropertyInfo.isSet, clearX(), getters and setters); only the storage differs, so
+        hand-written javaCode on an opted-in model must not read the xIsSet_ fields, which no
+        longer exist.`
     },
     {
       class: 'AxiomArray',

--- a/src/foam/lang/PackIsSetTest.js
+++ b/src/foam/lang/PackIsSetTest.js
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.lang',
+  name: 'PackIsSetTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: 'javaPackIsSet: one long per 64 properties holds the isSet flags, behind the unchanged isSet API.',
+
+  javaImports: [
+    'java.lang.reflect.Field',
+    'java.util.concurrent.CyclicBarrier',
+    'java.util.concurrent.ExecutorService',
+    'java.util.concurrent.Executors',
+    'java.util.concurrent.Future',
+    'java.util.concurrent.atomic.AtomicInteger'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        testStorageShape();
+        testIsSetApi();
+        testConcurrentSetters();
+      `
+    },
+    {
+      name: 'testStorageShape',
+      javaCode: `
+        test(declaredField("p0IsSet_") == null, "no boolean isSet field per property");
+        Field w0 = declaredField("isSetPackIsSetTestModel_0");
+        Field w1 = declaredField("isSetPackIsSetTestModel_1");
+        Field w2 = declaredField("isSetPackIsSetTestModel_2");
+        test(w0 != null && w0.getType() == long.class, "first 64 properties share one long field");
+        test(w1 != null && w1.getType() == long.class, "properties 65..70 get a second long field");
+        test(w2 == null, "no third word for 70 properties");
+      `
+    },
+    {
+      name: 'declaredField',
+      type: 'Field',
+      args: 'String name',
+      javaCode: `
+        try {
+          return PackIsSetTestModel.class.getDeclaredField(name);
+        } catch ( NoSuchFieldException e ) {
+          return null;
+        }
+      `
+    },
+    {
+      name: 'testIsSetApi',
+      javaCode: `
+        PackIsSetTestModel o = new PackIsSetTestModel();
+        test(! PackIsSetTestModel.P0.isSet(o), "unset property reports unset");
+        test(o.getP0() == 0L, "unset Long reads its default");
+
+        o.setP0(7L);
+        o.setP64(9L);
+        test(PackIsSetTestModel.P0.isSet(o), "set property in word 0 reports set");
+        test(PackIsSetTestModel.P64.isSet(o), "set property in word 1 reports set");
+        test(! PackIsSetTestModel.P1.isSet(o), "neighbour bit in word 0 untouched");
+        test(! PackIsSetTestModel.P65.isSet(o), "neighbour bit in word 1 untouched");
+
+        PackIsSetTestModel c = (PackIsSetTestModel) o.fclone();
+        test(PackIsSetTestModel.P0.isSet(c) && PackIsSetTestModel.P64.isSet(c), "fclone carries the flags");
+
+        o.clearP0();
+        test(! PackIsSetTestModel.P0.isSet(o), "clearX() drops the flag");
+        test(o.getP0() == 0L, "cleared property reads its default again");
+        test(PackIsSetTestModel.P64.isSet(o), "clearing one bit leaves the other word alone");
+      `
+    },
+    {
+      name: 'testConcurrentSetters',
+      documentation: 'Eight threads each set a different property of one object, all bits in the same word. A plain |= is a read-modify-write and drops flags; the flag write must not.',
+      javaCode: `
+        final PropertyInfo[] props = {
+          PackIsSetTestModel.P0, PackIsSetTestModel.P1, PackIsSetTestModel.P2, PackIsSetTestModel.P3,
+          PackIsSetTestModel.P4, PackIsSetTestModel.P5, PackIsSetTestModel.P6, PackIsSetTestModel.P7
+        };
+        final int threads = props.length;
+        final int rounds  = 20000;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        AtomicInteger lost = new AtomicInteger();
+        try {
+          for ( int r = 0 ; r < rounds ; r++ ) {
+            final PackIsSetTestModel o = new PackIsSetTestModel();
+            final CyclicBarrier go = new CyclicBarrier(threads);
+            Future<?>[] done = new Future<?>[threads];
+            for ( int t = 0 ; t < threads ; t++ ) {
+              final int i = t;
+              done[t] = pool.submit(() -> {
+                try { go.await(); } catch ( java.lang.Exception e ) { throw new RuntimeException(e); }
+                switch ( i ) {
+                  case 0: o.setP0(0L);  break;
+                  case 1: o.setP1("1"); break;
+                  case 2: o.setP2(2L);  break;
+                  case 3: o.setP3("3"); break;
+                  case 4: o.setP4(4L);  break;
+                  case 5: o.setP5("5"); break;
+                  case 6: o.setP6(6L);  break;
+                  default: o.setP7("7");
+                }
+              });
+            }
+            for ( Future<?> f : done ) {
+              try { f.get(); } catch ( java.lang.Exception e ) { throw new RuntimeException(e); }
+            }
+            for ( PropertyInfo p : props ) if ( ! p.isSet(o) ) lost.incrementAndGet();
+          }
+        } finally {
+          pool.shutdown();
+        }
+        test(lost.get() == 0, "concurrent setters on different properties keep every flag (lost " + lost.get() + " of " + (rounds * threads) + ")");
+      `
+    }
+  ]
+});

--- a/src/foam/lang/PackIsSetTestModel.js
+++ b/src/foam/lang/PackIsSetTestModel.js
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// 70 properties, so the flags need a second word (bits 64..69).
+var packIsSetTestProperties = [];
+for ( var i = 0 ; i < 70 ; i++ ) {
+  packIsSetTestProperties.push({ class: i % 2 ? 'String' : 'Long', name: 'p' + i });
+}
+
+foam.CLASS({
+  package: 'foam.lang',
+  name: 'PackIsSetTestModel',
+  javaPackIsSet: true,
+  properties: packIsSetTestProperties
+});

--- a/src/foam/lang/tests.jrl
+++ b/src/foam/lang/tests.jrl
@@ -8,3 +8,4 @@ p({"class":"foam.lang.test.JSONEscapeTest","id":"JSONEscapeTest","description":"
 p({"class":"foam.lang.test.SlotlessValidationTest","id":"SlotlessValidationTest","description":"getErrors() slotless validation matches reactive errors_ and preserves reactivity", language: 0})
 p({"class":"foam.lang.test.DatePropertyBench","id":"DatePropertyBench","description":"Per-operation heap/CPU benchmark for date-typed properties"})
 p({"class":"foam.lang.test.DatePropertyOpsTest","id":"DatePropertyOpsTest","description":"Date property behaviour across GROUP_BY, range, ordering, clone, JSON and the unset path"})
+p({"class":"foam.lang.PackIsSetTest","id":"PackIsSetTest","description":"javaPackIsSet flag storage and isSet API"})

--- a/src/pom.js
+++ b/src/pom.js
@@ -960,6 +960,8 @@ foam.POM({
     { name: "foam/test/TestObj",                                      flags: "js|java&test" },
     { name: "foam/test/IdentifiedStringHolder",                       flags: "js|java&test" },
     { name: "foam/lang/FObjectTest",                                  flags: "js&test|java&test" },
+    { name: "foam/lang/PackIsSetTestModel",                           flags: "js&test|java&test" },
+    { name: "foam/lang/PackIsSetTest",                                flags: "js&test|java&test" },
     { name: "foam/flow/Document",                                     flags: "js|java" },
     { name: "foam/flow/DocumentMenu",                                 flags: "js|java" },
     { name: "foam/flow/MarkupEditor",                                 flags: "js" },


### PR DESCRIPTION
Every property costs a value field plus a `boolean xIsSet_`, set or not. Opt-in per model; the `isSet` API (getters, setters, `clearX()`, `PropertyInfo.isSet`) is unchanged.

```js
foam.CLASS({ name: 'WideRecord', javaPackIsSet: true, properties: [ ... ] });
```

```java
protected long isSetWideRecord_0, isSetWideRecord_1;             // one field per 64 properties

protected boolean isSet_(int bit) {                              // plus setIsSet_ and clearIsSet_,
  switch ( bit >> 6 ) {                                          // both synchronized
    case 0:  return ( isSetWideRecord_0 & (1L << bit) ) != 0;
    default: return ( isSetWideRecord_1 & (1L << bit) ) != 0;
  }
}

if ( ! isSet_(5) ) ...                                           // getter
setIsSet_(5);                                                    // setter
clearIsSet_(5);                                                  // clearX()
```

Instance bytes, 200K rows in an MDAO, `jmap -histo:live`:

| model | compressed oops | uncompressed |
|---|---|---|
| 530 properties | 2760 → 2288 B (−17%) | 4912 → 4440 B (−10%) |
| 78 properties | 424 → 368 B (−13%) | 696 → 632 B (−9%) |

- Journal unchanged; parse and put timings within run-to-run noise.
- `setIsSet_` and `clearIsSet_` are synchronized. Per-property booleans are independent fields, so setters on different properties never interact; a shared word makes `|=` a read-modify-write. `PackIsSetTest` has eight threads set different properties of one object, 20000 rounds: a plain write lost 4 of 160000 flags, the synchronized write none. `isSet_` stays plain, as the boolean reads were.
- Class file shrinks with the monitor in two methods instead of every setter and clear: 530 properties 381 → 310 KB, 78 properties 150 → 140 KB.
- `PackIsSetTest` also covers the field shape (70 properties, two words, no boolean fields), isSet, `clearX()`, `fclone()` and `PropertyInfo.isSet` across both words.
- Only opted-in classes' generated Java changes; every other generated file is byte-identical.
- `javaCode` on an opted-in class must not read `xIsSet_` fields; none of the 35 such reads in this repo are on one.
- The 4–8 B reference per declared property remains, set or not; that is the larger cost, see #5395.


## Why opt-in and not the default

Existing classes are untouched: only opted-in classes generate differently, everything else is byte-identical. Making it the default is blocked by hand-written `javaCode` that reads the generated fields directly, 35 sites in 19 files here (`Renewable`, `CronSchedule`, `EasyDAO`, `EventRecord`, `User`, `Subject`, ...), for example:

```java
if ( ! codeIsSet_ ) { ... }      // ReferralCode
notationIsSet_ = true;           // CIDR
```

Path to default-on: rewrite those reads as `CODE.isSet(this)` / `clearCode()`, then flip the default. Separate PR; until then, opt in per wide model.

DOS-4797
