### PR TITLE
PT-FIXES:DOS-4798 javaSparse: store a class's reference properties in one values array behind a shared shape

### DIFF
--- a/src/foam/java/Field.js
+++ b/src/foam/java/Field.js
@@ -27,6 +27,11 @@ foam.CLASS({
     'final',
     { class: 'Boolean', name: 'includeInHash', value: true },
     {
+      class: 'String',
+      name: 'hashExpr',
+      documentation: 'Expression hashCode() folds in for this field; the field itself when empty.'
+    },
+    {
       class: 'Int',
       name: 'order',
       value: 0

--- a/src/foam/java/PropertyInfo.js
+++ b/src/foam/java/PropertyInfo.js
@@ -214,7 +214,9 @@ foam.CLASS({
             visibility: 'public',
             type: 'boolean',
             args: [{ name: 'o', type: 'Object' }],
-            body: `return ((${fullName}) o).${this.propName}IsSet_;`
+            body: 'return ' + ( this.property.javaIsSetReadOn_
+              ? this.property.javaIsSetReadOn_('((' + fullName + ') o)')
+              : '((' + fullName + ') o).' + this.propName + 'IsSet_' ) + ';'
           }
         ];
 

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -526,19 +526,17 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
       // field. The expressions carry that choice into the getter, the setter, clear and the
       // PropertyInfo.
       if ( sparse ) {
+        // The class generates isSparseSet_(ord), sparse_(ord), setSparse_(ord, val) and
+        // clearSparse_(ord) over its shape and values fields (buildSparseStore_ on the FObject LIB).
         var ord = cls.sparseOrdinals_++;
-        var sh  = cls.sparseShapeField_, vs = cls.sparseValuesField_;
-        var slot = sh + '.slotOf(' + ord + ')';
-        this.javaIsSetRead_   = '( ' + slot + ' >= 0 )';
-        this.javaIsSetTrue_   = '';   // the inner setter records presence
-        this.javaIsSetFalse_  = '{ int i = ' + slot + '; if ( i >= 0 ) { ' + vs + ' = foam.lang.SparseShape.removeAt(' + vs + ', i); ' +
-          sh + ' = ' + sh + '.without(' + ord + '); } }';
-        this.javaIsSetReadOn_ = function(obj) { return '( ' + obj + '.' + slot + ' >= 0 )'; };
-        this.javaValueExpr_   = '((' + this.javaType + ') ' + vs + '[' + slot + '])';
+        this.javaIsSetRead_   = 'isSparseSet_(' + ord + ')';
+        this.javaIsSetTrue_   = '';   // setSparse_ records presence
+        this.javaIsSetFalse_  = 'clearSparse_(' + ord + ');';
+        this.javaIsSetReadOn_ = function(obj) { return obj + '.isSparseSet_(' + ord + ')'; };
+        this.javaValueExpr_   = '((' + this.javaType + ') sparse_(' + ord + '))';
         this.javaHashExpr_    = '( ' + this.javaIsSetRead_ + ' ? ' + this.javaValueExpr_ + ' : null )';
         this.javaInnerGetter  = 'return ' + this.javaValueExpr_ + ';';
-        this.javaInnerSetter  = '{ int i = ' + slot + '; if ( i < 0 ) { ' + sh + ' = ' + sh + '.with(' + ord + '); ' +
-          vs + ' = foam.lang.SparseShape.insertAt(' + vs + ', ' + slot + ', val); } else ' + vs + '[i] = val; }';
+        this.javaInnerSetter  = 'setSparse_(' + ord + ', val);';
       } else if ( cls.packIsSet ) {
         var bit = cls.isSetBits_++;
         this.javaIsSetRead_   = 'isSet_(' + bit + ')';
@@ -698,6 +696,75 @@ foam.CLASS({
 foam.LIB({
   name: 'foam.lang.FObject',
   methods: [
+    function buildSparseStore_(cls, modelName) {
+      // javaSparse storage: the shared shape, the values array, and four helpers over them.
+      // A set or clear replaces both fields, so the writers take the object's monitor; the
+      // readers stay plain, as field reads are for every other property. The writers order
+      // their two stores so a plain reader never indexes past the values array: a set grows
+      // values before it publishes the shape, a clear shrinks the shape before the values.
+      var rootName = 'SHAPE_ROOT_' + modelName + '_';
+      var sh = cls.sparseShapeField_, vs = cls.sparseValuesField_;
+
+      cls.
+        field({
+          name: rootName,
+          type: 'foam.lang.SparseShape',
+          visibility: 'private',
+          static: true,
+          final: true,
+          initializer: 'foam.lang.SparseShape.root(' + cls.sparseOrdinals_ + ');'
+        }).
+        field({
+          name: sh,
+          type: 'foam.lang.SparseShape',
+          visibility: 'protected',
+          initializer: rootName + ';'
+        }).
+        field({
+          name: vs,
+          type: 'Object[]',
+          visibility: 'protected',
+          initializer: 'foam.lang.SparseShape.EMPTY;'
+        }).
+        method({
+          name: 'isSparseSet_',
+          type: 'boolean',
+          visibility: 'protected',
+          args: [ { name: 'ord', type: 'int' } ],
+          body: 'return ' + sh + '.slotOf(ord) >= 0;'
+        }).
+        method({
+          name: 'sparse_',
+          type: 'Object',
+          visibility: 'protected',
+          args: [ { name: 'ord', type: 'int' } ],
+          body: 'return ' + vs + '[' + sh + '.slotOf(ord)];'
+        }).
+        method({
+          name: 'setSparse_',
+          type: 'void',
+          visibility: 'protected',
+          synchronized: true,
+          args: [ { name: 'ord', type: 'int' }, { name: 'val', type: 'Object' } ],
+          body: 'int i = ' + sh + '.slotOf(ord);\n' +
+            'if ( i >= 0 ) { ' + vs + '[i] = val; return; }\n' +
+            'foam.lang.SparseShape s = ' + sh + '.with(ord);\n' +
+            vs + ' = foam.lang.SparseShape.insertAt(' + vs + ', s.slotOf(ord), val);\n' +
+            sh + ' = s;'
+        }).
+        method({
+          name: 'clearSparse_',
+          type: 'void',
+          visibility: 'protected',
+          synchronized: true,
+          args: [ { name: 'ord', type: 'int' } ],
+          body: 'int i = ' + sh + '.slotOf(ord);\n' +
+            'if ( i < 0 ) return;\n' +
+            sh + ' = ' + sh + '.without(ord);\n' +
+            vs + ' = foam.lang.SparseShape.removeAt(' + vs + ', i);'
+        });
+    },
+
     function buildPackedIsSet_(cls) {
       // javaPackIsSet storage: one long per 64 properties, and three helpers over them. Per-
       // property booleans are independent fields, so setters on different properties never
@@ -808,29 +875,7 @@ foam.LIB({
 
       if ( cls.packIsSet && cls.isSetBits_ > 0 ) this.buildPackedIsSet_(cls);
 
-      if ( cls.sparse && cls.sparseOrdinals_ > 0 ) {
-        var rootName = 'SHAPE_ROOT_' + this.model_.name + '_';
-        cls.field({
-          name: rootName,
-          type: 'foam.lang.SparseShape',
-          visibility: 'private',
-          static: true,
-          final: true,
-          initializer: 'foam.lang.SparseShape.root(' + cls.sparseOrdinals_ + ');'
-        });
-        cls.field({
-          name: cls.sparseShapeField_,
-          type: 'foam.lang.SparseShape',
-          visibility: 'protected',
-          initializer: rootName + ';'
-        });
-        cls.field({
-          name: cls.sparseValuesField_,
-          type: 'Object[]',
-          visibility: 'protected',
-          initializer: 'foam.lang.SparseShape.EMPTY;'
-        });
-      }
+      if ( cls.sparse && cls.sparseOrdinals_ > 0 ) this.buildSparseStore_(cls, this.model_.name);
 
       // TODO: instead of doing this here, we should walk all Axioms
       // and introduce a new buildJavaAncestorClass() method
@@ -2818,7 +2863,10 @@ foam.CLASS({
         instance with the same set, instead of one field per declared property. Primitive
         properties, and properties with their own javaGetter, javaSetter or inner accessors,
         keep a field. The property API is unchanged; hand-written javaCode on an opted-in model
-        must not read the x_ or xIsSet_ fields, which no longer exist for sparse properties.`
+        must not read the x_ or xIsSet_ fields, which no longer exist for sparse properties; the
+        class's isSparseSet_(ord), sparse_(ord), setSparse_(ord, val) and clearSparse_(ord)
+        helpers are the store's only readers and writers, and the writers are synchronized on the
+        object so setters on different properties never interfere.`
     },
     {
       class: 'AxiomArray',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -211,6 +211,30 @@ foam.CLASS({
         return this.javaType
       }
     },
+    // How the generated class records that this property is set. buildJavaClass fills these
+    // once it knows whether the owning model packs its flags (javaPackIsSet): either the
+    // property's own boolean field, or one bit of the class's long[]. The getter, setter,
+    // clearX() and the PropertyInfo all read them, so the choice lives in one place.
+    {
+      class: 'String',
+      name: 'javaIsSetRead_',
+      documentation: 'Java boolean expression, valid inside the owning class, true when the property is set.'
+    },
+    {
+      class: 'String',
+      name: 'javaIsSetTrue_',
+      documentation: 'Java statement, inside the owning class, that marks the property set.'
+    },
+    {
+      class: 'String',
+      name: 'javaIsSetFalse_',
+      documentation: 'Java statement, inside the owning class, that marks the property unset.'
+    },
+    {
+      class: 'Function',
+      name: 'javaIsSetReadOn_',
+      documentation: 'Given a Java expression for an instance of the owning class, returns the boolean expression true when the property is set on it. Used by the PropertyInfo, which reads another object.'
+    },
     {
       class: 'String',
       name: 'javaJSONParser',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -237,6 +237,24 @@ foam.CLASS({
     },
     {
       class: 'String',
+      name: 'javaValueExpr_',
+      documentation: 'Java expression, inside the owning class, for the stored value when it is not a plain x_ field (javaSparse). Empty when the value lives in its own field.'
+    },
+    {
+      class: 'String',
+      name: 'javaHashExpr_',
+      documentation: 'Java expression the generated hashCode() folds in for this property when the value is not a plain x_ field (javaSparse). Empty when the value lives in its own field.'
+    },
+    {
+      class: 'Boolean',
+      name: 'javaSparse',
+      value: true,
+      documentation: `Whether this property may live in the class's sparse store when the model sets
+        javaSparse. Primitive property types keep a field (boxing would cost more than the slot
+        saves), as do types that generate their own accessors; those refinements declare false.`
+    },
+    {
+      class: 'String',
       name: 'javaJSONParser',
       // Set to the String literal 'null' if no JSONParser desired
       value: 'foam.lib.json.AnyParser.instance()'
@@ -466,10 +484,12 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
       // set value
       // Don't include oldVal if not used
       if ( this.javaPostSet && this.javaPostSet.indexOf('oldVal') != -1 ) {
-        setter += `${this.javaType} oldVal = ${this.name}_;\n`;
+        setter += this.javaValueExpr_
+          ? `${this.javaType} oldVal = ${this.javaIsSetRead_} ? ${this.javaValueExpr_} : ${this.javaValue};\n`
+          : `${this.javaType} oldVal = ${this.name}_;\n`;
       }
       setter += this.javaInnerSetter + '\n';
-      setter += ( this.javaIsSetTrue_ || `${this.name}IsSet_ = true;` ) + '\n';
+      setter += ( this.javaIsSetTrue_ != null ? this.javaIsSetTrue_ : `${this.name}IsSet_ = true;` ) + '\n';
 
       // add post-set function
       if ( this.javaPostSet ) {
@@ -495,10 +515,29 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
       var isSet       = this.name + 'IsSet_';
       var factoryName = capitalized + 'Factory_';
 
-      // How this property records "set": its own boolean field, or one bit of the class's
-      // long[] when the model opted into javaPackIsSet. The expressions carry that choice
-      // into the getter, the setter, clear and the PropertyInfo.
-      if ( cls.packIsSet ) {
+      // javaSparse: a property that declares itself sparse-capable and generates no accessor of
+      // its own lives in the class's values array at the slot its shape assigns, and "set"
+      // means "present in the shape". Everything else keeps a field.
+      var sparse = cls.sparse && this.javaSparse && ! this.javaGetter && ! this.javaSetter;
+
+      // How this property records "set": present in the sparse shape, one bit of the class's
+      // long[] when the model opted into javaPackIsSet, or its own boolean field. The
+      // expressions carry that choice into the getter, the setter, clear and the PropertyInfo.
+      if ( sparse ) {
+        var ord = cls.sparseOrdinals_++;
+        var sh  = cls.sparseShapeField_, vs = cls.sparseValuesField_;
+        var slot = sh + '.slotOf(' + ord + ')';
+        this.javaIsSetRead_   = '( ' + slot + ' >= 0 )';
+        this.javaIsSetTrue_   = '';   // the inner setter records presence
+        this.javaIsSetFalse_  = '{ int i = ' + slot + '; if ( i >= 0 ) { ' + vs + ' = foam.lang.SparseShape.removeAt(' + vs + ', i); ' +
+          sh + ' = ' + sh + '.without(' + ord + '); } }';
+        this.javaIsSetReadOn_ = function(obj) { return '( ' + obj + '.' + slot + ' >= 0 )'; };
+        this.javaValueExpr_   = '((' + this.javaType + ') ' + vs + '[' + slot + '])';
+        this.javaHashExpr_    = '( ' + this.javaIsSetRead_ + ' ? ' + this.javaValueExpr_ + ' : null )';
+        this.javaInnerGetter  = 'return ' + this.javaValueExpr_ + ';';
+        this.javaInnerSetter  = '{ int i = ' + slot + '; if ( i < 0 ) { ' + sh + ' = ' + sh + '.with(' + ord + '); ' +
+          vs + ' = foam.lang.SparseShape.insertAt(' + vs + ', ' + slot + ', val); } else ' + vs + '[i] = val; }';
+      } else if ( cls.packIsSet ) {
         var bit  = cls.isSetBits_++;
         var word = cls.isSetField_ + '[' + ( bit >> 6 ) + ']';
         var mask = '(1L << ' + ( bit & 63 ) + ')';
@@ -513,12 +552,14 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
         this.javaIsSetReadOn_ = function(obj) { return obj + '.' + isSet; };
       }
 
-      cls.field({
-        name: privateName,
-        type: this.javaFieldType,
-        visibility: 'protected'
-      });
-      if ( ! cls.packIsSet ) {
+      if ( ! sparse ) {
+        cls.field({
+          name: privateName,
+          type: this.javaFieldType,
+          visibility: 'protected'
+        });
+      }
+      if ( ! sparse && ! cls.packIsSet ) {
         cls.field({
           name: isSet,
           type: 'boolean',
@@ -682,6 +723,13 @@ foam.LIB({
       cls.isSetBits_  = 0;
       cls.isSetField_ = 'isSet' + this.model_.name + '_';
 
+      // javaSparse: reference-typed properties take an ordinal each as they build; the shared
+      // root shape and the two instance fields are added once the count is known.
+      cls.sparse             = !! this.model_.javaSparse;
+      cls.sparseOrdinals_    = 0;
+      cls.sparseShapeField_  = 'shape' + this.model_.name + '_';
+      cls.sparseValuesField_ = 'values' + this.model_.name + '_';
+
       cls.fields.push(foam.java.ClassInfo.create({ id: this.id }));
 
       cls.method({
@@ -717,6 +765,30 @@ foam.LIB({
         });
       }
 
+      if ( cls.sparse && cls.sparseOrdinals_ > 0 ) {
+        var rootName = 'SHAPE_ROOT_' + this.model_.name + '_';
+        cls.field({
+          name: rootName,
+          type: 'foam.lang.SparseShape',
+          visibility: 'private',
+          static: true,
+          final: true,
+          initializer: 'foam.lang.SparseShape.root(' + cls.sparseOrdinals_ + ');'
+        });
+        cls.field({
+          name: cls.sparseShapeField_,
+          type: 'foam.lang.SparseShape',
+          visibility: 'protected',
+          initializer: rootName + ';'
+        });
+        cls.field({
+          name: cls.sparseValuesField_,
+          type: 'Object[]',
+          visibility: 'protected',
+          initializer: 'foam.lang.SparseShape.EMPTY;'
+        });
+      }
+
       // TODO: instead of doing this here, we should walk all Axioms
       // and introduce a new buildJavaAncestorClass() method
       var flagFilter = foam.util.flagFilter(['java']);
@@ -726,7 +798,7 @@ foam.LIB({
         .filter(p => !! p.javaType && p.javaInfoType && p.generateJava);
 
       cls.allProperties = properties
-        .map(p => foam.java.Field.create({ name: p.name, type: p.javaType, includeInHash: p.includeInHash }));
+        .map(p => foam.java.Field.create({ name: p.name, type: p.javaType, includeInHash: p.includeInHash, hashExpr: p.javaHashExpr_ }));
 
       var javaFactoryProperties = properties.filter(p => p.javaFactory);
 
@@ -889,7 +961,7 @@ return sb.toString();`
           body:
             ['int hash = 1'].concat(props.filter(function(p) {
               return p.includeInHash; }).map(function(f) {
-              return 'hash = hash * 31 + foam.util.SafetyUtil.hashCode(' + f.name + '_)';
+              return 'hash = hash * 31 + foam.util.SafetyUtil.hashCode(' + ( f.hashExpr || f.name + '_' ) + ')';
             })).join(';\n') + ';\n'
             +'return hash;\n'
         });
@@ -1394,6 +1466,7 @@ foam.CLASS({
 
   properties: [
     ['javaType',     'int'],
+    ['javaSparse',   false],
     ['javaInfoType', 'foam.lang.AbstractIntPropertyInfo']
   ]
 });
@@ -1408,6 +1481,7 @@ foam.CLASS({
 
   properties: [
     ['javaType',       'byte'],
+    ['javaSparse',     false],
     ['javaInfoType',   'foam.lang.AbstractBytePropertyInfo']
   ]
 });
@@ -1422,6 +1496,7 @@ foam.CLASS({
 
   properties: [
     ['javaType',       'short'],
+    ['javaSparse',     false],
     ['javaInfoType',   'foam.lang.AbstractShortPropertyInfo']
   ]
 });
@@ -1436,6 +1511,7 @@ foam.CLASS({
 
   properties: [
     ['javaType',     'long'],
+    ['javaSparse',   false],
     ['javaInfoType', 'foam.lang.AbstractLongPropertyInfo']
   ]
 });
@@ -1450,6 +1526,7 @@ foam.CLASS({
 
   properties: [
     ['javaType',     'double'],
+    ['javaSparse',   false],
     ['javaInfoType', 'foam.lang.AbstractDoublePropertyInfo']
   ]
 });
@@ -1464,6 +1541,7 @@ foam.CLASS({
 
   properties: [
     ['javaType',     'float'],
+    ['javaSparse',   false],
     ['javaInfoType', 'foam.lang.AbstractFloatPropertyInfo']
   ]
 });
@@ -1774,6 +1852,7 @@ foam.CLASS({
   properties: [
     ['javaType',        'java.util.Date' ],
     ['javaFieldType',   'long' ],
+    ['javaSparse',      false ],
     ['javaInfoType',    'foam.lang.AbstractDatePropertyInfo'],
     ['javaJSONParser',  'foam.lib.json.DateParser.instance()'],
     ['sqlType',         'TIMESTAMP WITHOUT TIME ZONE'],
@@ -1815,6 +1894,7 @@ foam.CLASS({
   properties: [
     ['javaType',        'java.util.Date' ],
     ['javaFieldType',   'long' ],
+    ['javaSparse',      false ],
     ['javaInfoType',    'foam.lang.AbstractDatePropertyInfo'],
     ['javaJSONParser',  'foam.lib.json.DateParser.instance()'],
     ['sqlType',         'DATE'],
@@ -2013,6 +2093,7 @@ foam.CLASS({
   `,
 
   properties: [
+    ['javaSparse', false],
     {
       name: 'javaSetter',
       factory: function() {
@@ -2391,6 +2472,7 @@ foam.CLASS({
 //  // flags: ['java'],
   properties: [
     ['javaType',       'boolean'],
+    ['javaSparse',     false],
     ['javaInfoType',   'foam.lang.AbstractBooleanPropertyInfo'],
     ['javaCompare',    ''],
     ['javaJSONParser',  'foam.lib.json.BooleanParser.instance()']
@@ -2578,6 +2660,7 @@ foam.CLASS({
   refines: 'foam.lang.IDAlias',
   // flags: ['java'],
   properties: [
+    ['javaSparse', false],
     { name: 'type',            factory: function() { return this.targetProperty.type; } },
     { name: 'javaType',        factory: function() { return this.targetProperty.javaType; } },
     { name: 'javaJSONParser',  factory: function() { return this.targetProperty.javaJSONParser; } },
@@ -2607,6 +2690,7 @@ foam.CLASS({
 
   properties: [
     ['javaJSONParser', 'foam.lib.json.ExprParser.instance()'],
+    ['javaSparse',     false],
     {
       name: 'javaGetter',
       factory: function() {
@@ -2679,6 +2763,16 @@ foam.CLASS({
         (PropertyInfo.isSet, clearX(), getters and setters); only the storage differs, so
         hand-written javaCode on an opted-in model must not read the xIsSet_ fields, which no
         longer exist.`
+    },
+    {
+      class: 'Boolean',
+      name: 'javaSparse',
+      documentation: `Store this class's reference-typed properties in one Object[] sized to the
+        properties actually set, plus a reference to a foam.lang.SparseShape shared by every
+        instance with the same set, instead of one field per declared property. Primitive
+        properties, and properties with their own javaGetter, javaSetter or inner accessors,
+        keep a field. The property API is unchanged; hand-written javaCode on an opted-in model
+        must not read the x_ or xIsSet_ fields, which no longer exist for sparse properties.`
     },
     {
       class: 'AxiomArray',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -495,21 +495,17 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
       var isSet       = this.name + 'IsSet_';
       var factoryName = capitalized + 'Factory_';
 
-      // How this property records "set": its own boolean field, or one bit of one of the
-      // class's long words when the model opted into javaPackIsSet. The expressions carry
-      // that choice into the getter, the setter, clear and the PropertyInfo.
-      //
-      // Per-property booleans are independent fields, so setters on different properties
-      // never interact. A shared word makes |= a read-modify-write, so the write takes the
-      // object's monitor; reads stay plain, as they are for the booleans.
+      // How this property records "set": its own boolean field, or one bit of the class's
+      // long words when the model opted into javaPackIsSet, reached through the isSet_(bit),
+      // setIsSet_(bit) and clearIsSet_(bit) helpers the class generates (buildPackedIsSet_ on
+      // the FObject LIB). The expressions carry that choice into the getter, the setter, clear
+      // and the PropertyInfo.
       if ( cls.packIsSet ) {
-        var bit  = cls.isSetBits_++;
-        var word = cls.isSetField_ + ( bit >> 6 );
-        var mask = '(1L << ' + ( bit & 63 ) + ')';
-        this.javaIsSetRead_   = '( ( ' + word + ' & ' + mask + ' ) != 0 )';
-        this.javaIsSetTrue_   = 'synchronized ( this ) { ' + word + ' |= ' + mask + '; }';
-        this.javaIsSetFalse_  = 'synchronized ( this ) { ' + word + ' &= ~' + mask + '; }';
-        this.javaIsSetReadOn_ = function(obj) { return '( ( ' + obj + '.' + word + ' & ' + mask + ' ) != 0 )'; };
+        var bit = cls.isSetBits_++;
+        this.javaIsSetRead_   = 'isSet_(' + bit + ')';
+        this.javaIsSetTrue_   = 'setIsSet_(' + bit + ');';
+        this.javaIsSetFalse_  = 'clearIsSet_(' + bit + ');';
+        this.javaIsSetReadOn_ = function(obj) { return obj + '.isSet_(' + bit + ')'; };
       } else {
         this.javaIsSetRead_   = isSet;
         this.javaIsSetTrue_   = isSet + ' = true;';
@@ -661,6 +657,55 @@ foam.CLASS({
 foam.LIB({
   name: 'foam.lang.FObject',
   methods: [
+    function buildPackedIsSet_(cls) {
+      // javaPackIsSet storage: one long per 64 properties, and three helpers over them. Per-
+      // property booleans are independent fields, so setters on different properties never
+      // interact; a shared word makes |= a read-modify-write, so the writers take the object's
+      // monitor. Reads stay plain, as they are for the booleans. Java masks a shift distance to
+      // 0..63, so 1L << bit selects within the word without a mask of its own.
+      var words = Math.ceil(cls.isSetBits_ / 64);
+      var word  = function(w) { return cls.isSetField_ + w; };
+
+      for ( var w = 0 ; w < words ; w++ ) {
+        cls.field({ name: word(w), type: 'long', visibility: 'protected' });
+      }
+
+      // One statement per word, dispatched on bit >> 6; a single word needs no switch.
+      var perWord = function(stmt) {
+        if ( words == 1 ) return stmt(word(0));
+        var body = 'switch ( bit >> 6 ) {\n';
+        for ( var w = 0 ; w < words ; w++ ) {
+          body += ( w == words - 1 ? '  default: ' : '  case ' + w + ': ' ) + stmt(word(w)) + '\n';
+        }
+        return body + '}';
+      };
+
+      cls.
+        method({
+          name: 'isSet_',
+          type: 'boolean',
+          visibility: 'protected',
+          args: [ { name: 'bit', type: 'int' } ],
+          body: perWord(function(f) { return 'return ( ' + f + ' & (1L << bit) ) != 0;'; })
+        }).
+        method({
+          name: 'setIsSet_',
+          type: 'void',
+          visibility: 'protected',
+          synchronized: true,
+          args: [ { name: 'bit', type: 'int' } ],
+          body: perWord(function(f) { return f + ' |= (1L << bit);' + ( words == 1 ? '' : ' break;' ); })
+        }).
+        method({
+          name: 'clearIsSet_',
+          type: 'void',
+          visibility: 'protected',
+          synchronized: true,
+          args: [ { name: 'bit', type: 'int' } ],
+          body: perWord(function(f) { return f + ' &= ~(1L << bit);' + ( words == 1 ? '' : ' break;' ); })
+        });
+    },
+
     function buildJavaClass(cls) {
       // TODO Generate getX() and setX() if contextAware
       cls = cls || foam.java.Class.create();
@@ -681,8 +726,8 @@ foam.LIB({
         cls.extends = this.model_.javaExtends;
 
       // javaPackIsSet: the properties allocate one bit each as they build; the long words
-      // that hold them, one per 64 properties, are added once they are all in (below the
-      // axiom loop).
+      // that hold them, one per 64 properties, and the helpers that read and write a bit are
+      // added once they are all in (below the axiom loop).
       cls.packIsSet   = !! this.model_.javaPackIsSet;
       cls.isSetBits_  = 0;
       cls.isSetField_ = 'isSet' + this.model_.name + '_';
@@ -713,13 +758,7 @@ foam.LIB({
         axioms[i].buildJavaClass && axioms[i].buildJavaClass(cls, this);
       }
 
-      for ( var w = 0 ; cls.packIsSet && w * 64 < cls.isSetBits_ ; w++ ) {
-        cls.field({
-          name: cls.isSetField_ + w,
-          type: 'long',
-          visibility: 'protected'
-        });
-      }
+      if ( cls.packIsSet && cls.isSetBits_ > 0 ) this.buildPackedIsSet_(cls);
 
       // TODO: instead of doing this here, we should walk all Axioms
       // and introduce a new buildJavaAncestorClass() method
@@ -2682,9 +2721,10 @@ foam.CLASS({
         Saves a byte per declared property per instance, which on a wide model is most of what
         an empty column costs. The isSet API is unchanged (PropertyInfo.isSet, clearX(), getters
         and setters); only the storage differs, so hand-written javaCode on an opted-in model
-        must not read the xIsSet_ fields, which no longer exist. The flag write is synchronized
-        on the object, so setters on different properties keep the independence the separate
-        boolean fields gave them.`
+        must not read the xIsSet_ fields, which no longer exist; the class's isSet_(bit),
+        setIsSet_(bit) and clearIsSet_(bit) helpers are the storage's only readers and writers.
+        The writers are synchronized on the object, so setters on different properties keep the
+        independence the separate boolean fields gave them.`
     },
     {
       class: 'AxiomArray',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -495,16 +495,20 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
       var isSet       = this.name + 'IsSet_';
       var factoryName = capitalized + 'Factory_';
 
-      // How this property records "set": its own boolean field, or one bit of the class's
-      // long[] when the model opted into javaPackIsSet. The expressions carry that choice
-      // into the getter, the setter, clear and the PropertyInfo.
+      // How this property records "set": its own boolean field, or one bit of one of the
+      // class's long words when the model opted into javaPackIsSet. The expressions carry
+      // that choice into the getter, the setter, clear and the PropertyInfo.
+      //
+      // Per-property booleans are independent fields, so setters on different properties
+      // never interact. A shared word makes |= a read-modify-write, so the write takes the
+      // object's monitor; reads stay plain, as they are for the booleans.
       if ( cls.packIsSet ) {
         var bit  = cls.isSetBits_++;
-        var word = cls.isSetField_ + '[' + ( bit >> 6 ) + ']';
+        var word = cls.isSetField_ + ( bit >> 6 );
         var mask = '(1L << ' + ( bit & 63 ) + ')';
         this.javaIsSetRead_   = '( ( ' + word + ' & ' + mask + ' ) != 0 )';
-        this.javaIsSetTrue_   = word + ' |= ' + mask + ';';
-        this.javaIsSetFalse_  = word + ' &= ~' + mask + ';';
+        this.javaIsSetTrue_   = 'synchronized ( this ) { ' + word + ' |= ' + mask + '; }';
+        this.javaIsSetFalse_  = 'synchronized ( this ) { ' + word + ' &= ~' + mask + '; }';
         this.javaIsSetReadOn_ = function(obj) { return '( ( ' + obj + '.' + word + ' & ' + mask + ' ) != 0 )'; };
       } else {
         this.javaIsSetRead_   = isSet;
@@ -676,8 +680,9 @@ foam.LIB({
       if ( this.model_.javaExtends )
         cls.extends = this.model_.javaExtends;
 
-      // javaPackIsSet: the properties allocate one bit each as they build; the long[] that
-      // holds them is sized and added once they are all in (below the axiom loop).
+      // javaPackIsSet: the properties allocate one bit each as they build; the long words
+      // that hold them, one per 64 properties, are added once they are all in (below the
+      // axiom loop).
       cls.packIsSet   = !! this.model_.javaPackIsSet;
       cls.isSetBits_  = 0;
       cls.isSetField_ = 'isSet' + this.model_.name + '_';
@@ -708,12 +713,11 @@ foam.LIB({
         axioms[i].buildJavaClass && axioms[i].buildJavaClass(cls, this);
       }
 
-      if ( cls.packIsSet && cls.isSetBits_ > 0 ) {
+      for ( var w = 0 ; cls.packIsSet && w * 64 < cls.isSetBits_ ; w++ ) {
         cls.field({
-          name: cls.isSetField_,
-          type: 'long[]',
-          visibility: 'protected',
-          initializer: 'new long[' + Math.ceil(cls.isSetBits_ / 64) + '];'
+          name: cls.isSetField_ + w,
+          type: 'long',
+          visibility: 'protected'
         });
       }
 
@@ -2673,12 +2677,14 @@ foam.CLASS({
     {
       class: 'Boolean',
       name: 'javaPackIsSet',
-      documentation: `Keep this class's per-property set flags in one long[] bitset instead of a
-        boolean field per property. Saves a byte per declared property per instance, which on a
-        wide model is most of what an empty column costs. The isSet API is unchanged
-        (PropertyInfo.isSet, clearX(), getters and setters); only the storage differs, so
-        hand-written javaCode on an opted-in model must not read the xIsSet_ fields, which no
-        longer exist.`
+      documentation: `Keep this class's per-property set flags in long fields, one bit per
+        property and one field per 64 properties, instead of a boolean field per property.
+        Saves a byte per declared property per instance, which on a wide model is most of what
+        an empty column costs. The isSet API is unchanged (PropertyInfo.isSet, clearX(), getters
+        and setters); only the storage differs, so hand-written javaCode on an opted-in model
+        must not read the xIsSet_ fields, which no longer exist. The flag write is synchronized
+        on the object, so setters on different properties keep the independence the separate
+        boolean fields gave them.`
     },
     {
       class: 'AxiomArray',

--- a/src/foam/java/refinements.js
+++ b/src/foam/java/refinements.js
@@ -445,7 +445,7 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
         setter += `${this.javaType} oldVal = ${this.name}_;\n`;
       }
       setter += this.javaInnerSetter + '\n';
-      setter += `${this.name}IsSet_ = true;\n`;
+      setter += ( this.javaIsSetTrue_ || `${this.name}IsSet_ = true;` ) + '\n';
 
       // add post-set function
       if ( this.javaPostSet ) {
@@ -471,25 +471,46 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
       var isSet       = this.name + 'IsSet_';
       var factoryName = capitalized + 'Factory_';
 
-      cls.
-        field({
-          name: privateName,
-          type: this.javaFieldType,
-          visibility: 'protected'
-        }).
-        field({
+      // How this property records "set": its own boolean field, or one bit of the class's
+      // long[] when the model opted into javaPackIsSet. The expressions carry that choice
+      // into the getter, the setter, clear and the PropertyInfo.
+      if ( cls.packIsSet ) {
+        var bit  = cls.isSetBits_++;
+        var word = cls.isSetField_ + '[' + ( bit >> 6 ) + ']';
+        var mask = '(1L << ' + ( bit & 63 ) + ')';
+        this.javaIsSetRead_   = '( ( ' + word + ' & ' + mask + ' ) != 0 )';
+        this.javaIsSetTrue_   = word + ' |= ' + mask + ';';
+        this.javaIsSetFalse_  = word + ' &= ~' + mask + ';';
+        this.javaIsSetReadOn_ = function(obj) { return '( ( ' + obj + '.' + word + ' & ' + mask + ' ) != 0 )'; };
+      } else {
+        this.javaIsSetRead_   = isSet;
+        this.javaIsSetTrue_   = isSet + ' = true;';
+        this.javaIsSetFalse_  = isSet + ' = false;';
+        this.javaIsSetReadOn_ = function(obj) { return obj + '.' + isSet; };
+      }
+
+      cls.field({
+        name: privateName,
+        type: this.javaFieldType,
+        visibility: 'protected'
+      });
+      if ( ! cls.packIsSet ) {
+        cls.field({
           name: isSet,
           type: 'boolean',
           visibility: 'protected',
           initializer: 'false;'
-        }).
+        });
+      }
+
+      cls.
         method({
           name: 'get' + capitalized,
           type: this.javaType,
           visibility: 'public',
           synchronized: this.synchronized,
           forceJavaOutputter: true,
-          body: this.javaGetter || ('if ( ! ' + isSet + ' ) {\n' +
+          body: this.javaGetter || ('if ( ! ' + this.javaIsSetRead_ + ' ) {\n' +
             ( this.javaFactory ?
                 '  set' + capitalized + '(' + factoryName + '());\n' :
                 ' return ' + this.javaValue + ';\n' ) + '}\n' + this.javaInnerGetter )
@@ -517,7 +538,7 @@ if ( ! ((foam.mlang.predicate.Predicate) parser.parse(sps,px).value()).f(obj) ) 
           type: 'void',
           forceJavaOutputter: true,
           body: `assertNotFrozen();
-${isSet} = false;`
+${this.javaIsSetFalse_}`
         });
 
       if ( this.javaFactory ) {
@@ -631,6 +652,12 @@ foam.LIB({
       if ( this.model_.javaExtends )
         cls.extends = this.model_.javaExtends;
 
+      // javaPackIsSet: the properties allocate one bit each as they build; the long[] that
+      // holds them is sized and added once they are all in (below the axiom loop).
+      cls.packIsSet   = !! this.model_.javaPackIsSet;
+      cls.isSetBits_  = 0;
+      cls.isSetField_ = 'isSet' + this.model_.name + '_';
+
       cls.fields.push(foam.java.ClassInfo.create({ id: this.id }));
 
       cls.method({
@@ -655,6 +682,15 @@ foam.LIB({
 
       for ( var i = 0 ; i < axioms.length ; i++ ) {
         axioms[i].buildJavaClass && axioms[i].buildJavaClass(cls, this);
+      }
+
+      if ( cls.packIsSet && cls.isSetBits_ > 0 ) {
+        cls.field({
+          name: cls.isSetField_,
+          type: 'long[]',
+          visibility: 'protected',
+          initializer: 'new long[' + Math.ceil(cls.isSetBits_ / 64) + '];'
+        });
       }
 
       // TODO: instead of doing this here, we should walk all Axioms
@@ -2609,6 +2645,16 @@ foam.CLASS({
       class: 'Boolean',
       name: 'javaGenerateConvenienceConstructor',
       value: true
+    },
+    {
+      class: 'Boolean',
+      name: 'javaPackIsSet',
+      documentation: `Keep this class's per-property set flags in one long[] bitset instead of a
+        boolean field per property. Saves a byte per declared property per instance, which on a
+        wide model is most of what an empty column costs. The isSet API is unchanged
+        (PropertyInfo.isSet, clearX(), getters and setters); only the storage differs, so
+        hand-written javaCode on an opted-in model must not read the xIsSet_ fields, which no
+        longer exist.`
     },
     {
       class: 'AxiomArray',

--- a/src/foam/lang/PackIsSetTest.js
+++ b/src/foam/lang/PackIsSetTest.js
@@ -1,0 +1,124 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.lang',
+  name: 'PackIsSetTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: 'javaPackIsSet: one long per 64 properties holds the isSet flags, behind the unchanged isSet API.',
+
+  javaImports: [
+    'java.lang.reflect.Field',
+    'java.util.concurrent.CyclicBarrier',
+    'java.util.concurrent.ExecutorService',
+    'java.util.concurrent.Executors',
+    'java.util.concurrent.Future',
+    'java.util.concurrent.atomic.AtomicInteger'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        testStorageShape();
+        testIsSetApi();
+        testConcurrentSetters();
+      `
+    },
+    {
+      name: 'testStorageShape',
+      javaCode: `
+        test(declaredField("p0IsSet_") == null, "no boolean isSet field per property");
+        Field w0 = declaredField("isSetPackIsSetTestModel_0");
+        Field w1 = declaredField("isSetPackIsSetTestModel_1");
+        Field w2 = declaredField("isSetPackIsSetTestModel_2");
+        test(w0 != null && w0.getType() == long.class, "first 64 properties share one long field");
+        test(w1 != null && w1.getType() == long.class, "properties 65..70 get a second long field");
+        test(w2 == null, "no third word for 70 properties");
+      `
+    },
+    {
+      name: 'declaredField',
+      type: 'Field',
+      args: 'String name',
+      javaCode: `
+        try {
+          return PackIsSetTestModel.class.getDeclaredField(name);
+        } catch ( NoSuchFieldException e ) {
+          return null;
+        }
+      `
+    },
+    {
+      name: 'testIsSetApi',
+      javaCode: `
+        PackIsSetTestModel o = new PackIsSetTestModel();
+        test(! PackIsSetTestModel.P0.isSet(o), "unset property reports unset");
+        test(o.getP0() == 0L, "unset Long reads its default");
+
+        o.setP0(7L);
+        o.setP64(9L);
+        test(PackIsSetTestModel.P0.isSet(o), "set property in word 0 reports set");
+        test(PackIsSetTestModel.P64.isSet(o), "set property in word 1 reports set");
+        test(! PackIsSetTestModel.P1.isSet(o), "neighbour bit in word 0 untouched");
+        test(! PackIsSetTestModel.P65.isSet(o), "neighbour bit in word 1 untouched");
+
+        PackIsSetTestModel c = (PackIsSetTestModel) o.fclone();
+        test(PackIsSetTestModel.P0.isSet(c) && PackIsSetTestModel.P64.isSet(c), "fclone carries the flags");
+
+        o.clearP0();
+        test(! PackIsSetTestModel.P0.isSet(o), "clearX() drops the flag");
+        test(o.getP0() == 0L, "cleared property reads its default again");
+        test(PackIsSetTestModel.P64.isSet(o), "clearing one bit leaves the other word alone");
+      `
+    },
+    {
+      name: 'testConcurrentSetters',
+      documentation: 'Eight threads each set a different property of one object, all bits in the same word. A plain |= is a read-modify-write and drops flags; the flag write must not.',
+      javaCode: `
+        final PropertyInfo[] props = {
+          PackIsSetTestModel.P0, PackIsSetTestModel.P1, PackIsSetTestModel.P2, PackIsSetTestModel.P3,
+          PackIsSetTestModel.P4, PackIsSetTestModel.P5, PackIsSetTestModel.P6, PackIsSetTestModel.P7
+        };
+        final int threads = props.length;
+        final int rounds  = 20000;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        AtomicInteger lost = new AtomicInteger();
+        try {
+          for ( int r = 0 ; r < rounds ; r++ ) {
+            final PackIsSetTestModel o = new PackIsSetTestModel();
+            final CyclicBarrier go = new CyclicBarrier(threads);
+            Future<?>[] done = new Future<?>[threads];
+            for ( int t = 0 ; t < threads ; t++ ) {
+              final int i = t;
+              done[t] = pool.submit(() -> {
+                try { go.await(); } catch ( java.lang.Exception e ) { throw new RuntimeException(e); }
+                switch ( i ) {
+                  case 0: o.setP0(0L);  break;
+                  case 1: o.setP1("1"); break;
+                  case 2: o.setP2(2L);  break;
+                  case 3: o.setP3("3"); break;
+                  case 4: o.setP4(4L);  break;
+                  case 5: o.setP5("5"); break;
+                  case 6: o.setP6(6L);  break;
+                  default: o.setP7("7");
+                }
+              });
+            }
+            for ( Future<?> f : done ) {
+              try { f.get(); } catch ( java.lang.Exception e ) { throw new RuntimeException(e); }
+            }
+            for ( PropertyInfo p : props ) if ( ! p.isSet(o) ) lost.incrementAndGet();
+          }
+        } finally {
+          pool.shutdown();
+        }
+        test(lost.get() == 0, "concurrent setters on different properties keep every flag (lost " + lost.get() + " of " + (rounds * threads) + ")");
+      `
+    }
+  ]
+});

--- a/src/foam/lang/PackIsSetTestModel.js
+++ b/src/foam/lang/PackIsSetTestModel.js
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// 70 properties, so the flags need a second word (bits 64..69).
+var packIsSetTestProperties = [];
+for ( var i = 0 ; i < 70 ; i++ ) {
+  packIsSetTestProperties.push({ class: i % 2 ? 'String' : 'Long', name: 'p' + i });
+}
+
+foam.CLASS({
+  package: 'foam.lang',
+  name: 'PackIsSetTestModel',
+  javaPackIsSet: true,
+  properties: packIsSetTestProperties
+});

--- a/src/foam/lang/SparseShape.java
+++ b/src/foam/lang/SparseShape.java
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.lang;
+
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Shared layout for a class generated with javaSparse: which property ordinals an
+ * instance has set, and the slot each one occupies in the instance's values array.
+ *
+ * One shape per distinct set of ordinals, canonical per class, so every instance with
+ * the same set of properties points at the same shape and owns only its values array.
+ * A first-time set moves an instance to the shape with that ordinal added (cached per
+ * transition); a clear moves it to the shape without it.
+ */
+public final class SparseShape {
+  public static final Object[] EMPTY = new Object[0];
+
+  private final short[]      slotOf_;    // ordinal -> slot in values, -1 when absent
+  private final short[]      ordinals_;  // sorted ordinals present
+  private final SparseShape[] with_;     // transition cache, indexed by ordinal
+
+  // Every shape reachable from one root, keyed by its ordinal set, so insertion order
+  // never produces two shapes for the same set.
+  private final ConcurrentHashMap<Key, SparseShape> canonical_;
+
+  /** The empty shape for a class with propertyCount sparse properties. */
+  public static SparseShape root(int propertyCount) {
+    ConcurrentHashMap<Key, SparseShape> canonical = new ConcurrentHashMap<>();
+    SparseShape root = new SparseShape(propertyCount, new short[0], canonical);
+    canonical.put(new Key(root.ordinals_), root);
+    return root;
+  }
+
+  private SparseShape(int propertyCount, short[] ordinals, ConcurrentHashMap<Key, SparseShape> canonical) {
+    slotOf_ = new short[propertyCount];
+    Arrays.fill(slotOf_, (short) -1);
+    for ( short i = 0 ; i < ordinals.length ; i++ ) slotOf_[ordinals[i]] = i;
+    ordinals_  = ordinals;
+    with_      = new SparseShape[propertyCount];
+    canonical_ = canonical;
+  }
+
+  /** Slot of the ordinal in the values array, or -1 when the property is not set. */
+  public int slotOf(int ordinal) {
+    return slotOf_[ordinal];
+  }
+
+  public int size() {
+    return ordinals_.length;
+  }
+
+  /** The shape with this ordinal present; this shape when it already is. */
+  public SparseShape with(int ordinal) {
+    if ( slotOf_[ordinal] >= 0 ) return this;
+    SparseShape s = with_[ordinal];
+    if ( s != null ) return s;
+    short[] next = new short[ordinals_.length + 1];
+    int i = 0;
+    while ( i < ordinals_.length && ordinals_[i] < ordinal ) { next[i] = ordinals_[i]; i++; }
+    next[i] = (short) ordinal;
+    System.arraycopy(ordinals_, i, next, i + 1, ordinals_.length - i);
+    s = canonical_.computeIfAbsent(new Key(next), k -> new SparseShape(slotOf_.length, next, canonical_));
+    with_[ordinal] = s; // a racing writer stores the same canonical instance
+    return s;
+  }
+
+  /** The shape with this ordinal absent; this shape when it already is. */
+  public SparseShape without(int ordinal) {
+    int slot = slotOf_[ordinal];
+    if ( slot < 0 ) return this;
+    short[] next = new short[ordinals_.length - 1];
+    System.arraycopy(ordinals_, 0, next, 0, slot);
+    System.arraycopy(ordinals_, slot + 1, next, slot, ordinals_.length - slot - 1);
+    return canonical_.computeIfAbsent(new Key(next), k -> new SparseShape(slotOf_.length, next, canonical_));
+  }
+
+  public static Object[] insertAt(Object[] a, int i, Object v) {
+    Object[] b = new Object[a.length + 1];
+    System.arraycopy(a, 0, b, 0, i);
+    b[i] = v;
+    System.arraycopy(a, i, b, i + 1, a.length - i);
+    return b;
+  }
+
+  public static Object[] removeAt(Object[] a, int i) {
+    Object[] b = new Object[a.length - 1];
+    System.arraycopy(a, 0, b, 0, i);
+    System.arraycopy(a, i + 1, b, i, a.length - i - 1);
+    return b;
+  }
+
+  private static final class Key {
+    private final short[] ordinals_;
+
+    Key(short[] ordinals) { ordinals_ = ordinals; }
+
+    @Override public int hashCode() { return Arrays.hashCode(ordinals_); }
+
+    @Override public boolean equals(Object o) {
+      return o instanceof Key && Arrays.equals(ordinals_, ((Key) o).ordinals_);
+    }
+  }
+}

--- a/src/foam/lang/SparseTest.js
+++ b/src/foam/lang/SparseTest.js
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.lang',
+  name: 'SparseTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: 'javaSparse: set reference properties live in one values array behind a shape shared by every instance with the same set, behind the unchanged property API.',
+
+  javaImports: [
+    'java.lang.reflect.Field',
+    'java.util.concurrent.CyclicBarrier',
+    'java.util.concurrent.ExecutorService',
+    'java.util.concurrent.Executors',
+    'java.util.concurrent.Future',
+    'java.util.concurrent.atomic.AtomicInteger'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        testStorageShape();
+        testPropertyApi();
+        testSharedShape();
+        testCloneEqualsFreeze();
+        testConcurrentSetters();
+      `
+    },
+    {
+      name: 'declaredField',
+      type: 'Field',
+      args: 'String name',
+      javaCode: `
+        try {
+          return SparseTestModel.class.getDeclaredField(name);
+        } catch ( NoSuchFieldException e ) {
+          return null;
+        }
+      `
+    },
+    {
+      name: 'read',
+      type: 'Object',
+      args: 'SparseTestModel o, String field',
+      javaCode: `
+        try {
+          Field f = declaredField(field);
+          f.setAccessible(true);
+          return f.get(o);
+        } catch ( java.lang.Exception e ) {
+          throw new RuntimeException(e);
+        }
+      `
+    },
+    {
+      name: 'testStorageShape',
+      javaCode: `
+        test(declaredField("s0_") == null && declaredField("s0IsSet_") == null, "sparse property has no value or isSet field");
+        Field shape  = declaredField("shapeSparseTestModel_");
+        Field values = declaredField("valuesSparseTestModel_");
+        test(shape != null && shape.getType() == SparseShape.class, "class holds one shape reference");
+        test(values != null && values.getType() == Object[].class, "class holds one values array");
+        Field n0 = declaredField("n0_");
+        test(n0 != null && n0.getType() == long.class && declaredField("n0IsSet_") != null, "primitive property keeps its own field and flag");
+      `
+    },
+    {
+      name: 'testPropertyApi',
+      javaCode: `
+        SparseTestModel o = new SparseTestModel();
+        test(! SparseTestModel.S0.isSet(o) && "".equals(o.getS0()), "unset sparse property reports unset and reads its default");
+        test(((Object[]) read(o, "valuesSparseTestModel_")).length == 0, "fresh instance holds no values");
+
+        o.setS3("three");
+        o.setS7("seven");
+        test(SparseTestModel.S3.isSet(o) && "three".equals(o.getS3()), "set property reads back");
+        test("seven".equals(SparseTestModel.S7.get(o)), "PropertyInfo.get reads the stored value");
+        test(! SparseTestModel.S4.isSet(o), "neighbour stays unset");
+        test(((Object[]) read(o, "valuesSparseTestModel_")).length == 2, "values array holds only the set properties");
+
+        o.setS3("three again");
+        test("three again".equals(o.getS3()) && ((Object[]) read(o, "valuesSparseTestModel_")).length == 2, "re-setting a property overwrites its slot");
+
+        o.clearS3();
+        test(! SparseTestModel.S3.isSet(o) && "".equals(o.getS3()), "clearX() drops the property");
+        test("seven".equals(o.getS7()) && ((Object[]) read(o, "valuesSparseTestModel_")).length == 1, "clearing one property leaves the other in place");
+      `
+    },
+    {
+      name: 'testSharedShape',
+      javaCode: `
+        SparseTestModel a = new SparseTestModel();
+        a.setS3("x"); a.setS7("y");
+        SparseTestModel b = new SparseTestModel();
+        b.setS7("p"); b.setS3("q");
+        test(read(a, "shapeSparseTestModel_") == read(b, "shapeSparseTestModel_"), "same set of properties shares one shape, whatever the set order");
+        test("q".equals(b.getS3()) && "p".equals(b.getS7()), "values land in the slot their ordinal owns, not in set order");
+
+        SparseTestModel c = new SparseTestModel();
+        c.setS3("z");
+        test(read(a, "shapeSparseTestModel_") != read(c, "shapeSparseTestModel_"), "different set gets a different shape");
+        c.setS7("w");
+        test(read(a, "shapeSparseTestModel_") == read(c, "shapeSparseTestModel_"), "adding a property moves the instance onto the shared shape");
+        c.clearS7();
+        SparseTestModel d = new SparseTestModel();
+        d.setS3("only");
+        test(read(c, "shapeSparseTestModel_") == read(d, "shapeSparseTestModel_"), "clearing moves back to the shape without it");
+      `
+    },
+    {
+      name: 'testCloneEqualsFreeze',
+      javaCode: `
+        SparseTestModel o = new SparseTestModel();
+        o.setS1("one"); o.setS8("eight"); o.setN0(5L);
+
+        SparseTestModel c = (SparseTestModel) o.fclone();
+        test("one".equals(c.getS1()) && "eight".equals(c.getS8()) && c.getN0() == 5L, "fclone carries sparse and fixed values");
+        test(o.equals(c) && o.hashCode() == c.hashCode(), "clone equals the original with the same hashCode");
+        c.setS8("changed");
+        c.setS9("new");
+        test("eight".equals(o.getS8()) && ! SparseTestModel.S9.isSet(o), "writing the clone leaves the original alone");
+        test(! o.equals(c), "differing sparse value breaks equality");
+
+        o.freeze();
+        boolean threw = false;
+        try { o.setS1("frozen"); } catch ( java.lang.Exception e ) { threw = true; }
+        test(threw && "one".equals(o.getS1()), "setter on a frozen instance throws and changes nothing");
+      `
+    },
+    {
+      name: 'testConcurrentSetters',
+      documentation: 'Eight threads each set a different sparse property of one object. Each set moves the shape and rebuilds the values array, so an unsynchronized setter loses values or indexes past the array.',
+      javaCode: `
+        final int threads = 8;
+        final int rounds  = 20000;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        AtomicInteger lost = new AtomicInteger();
+        try {
+          for ( int r = 0 ; r < rounds ; r++ ) {
+            final SparseTestModel o = new SparseTestModel();
+            final CyclicBarrier go = new CyclicBarrier(threads);
+            Future<?>[] done = new Future<?>[threads];
+            for ( int t = 0 ; t < threads ; t++ ) {
+              final int i = t;
+              done[t] = pool.submit(() -> {
+                try { go.await(); } catch ( java.lang.Exception e ) { throw new RuntimeException(e); }
+                switch ( i ) {
+                  case 0: o.setS0("0"); break;
+                  case 1: o.setS1("1"); break;
+                  case 2: o.setS2("2"); break;
+                  case 3: o.setS3("3"); break;
+                  case 4: o.setS4("4"); break;
+                  case 5: o.setS5("5"); break;
+                  case 6: o.setS6("6"); break;
+                  default: o.setS7("7");
+                }
+              });
+            }
+            boolean failed = false;
+            for ( Future<?> f : done ) {
+              try { f.get(); } catch ( java.lang.Exception e ) { failed = true; }
+            }
+            if ( failed
+              || ! "0".equals(o.getS0()) || ! "1".equals(o.getS1()) || ! "2".equals(o.getS2()) || ! "3".equals(o.getS3())
+              || ! "4".equals(o.getS4()) || ! "5".equals(o.getS5()) || ! "6".equals(o.getS6()) || ! "7".equals(o.getS7()) ) {
+              lost.incrementAndGet();
+            }
+          }
+        } finally {
+          pool.shutdown();
+        }
+        test(lost.get() == 0, "concurrent setters on different sparse properties keep every value (" + lost.get() + " of " + rounds + " rounds lost one)");
+      `
+    }
+  ]
+});

--- a/src/foam/lang/SparseTestModel.js
+++ b/src/foam/lang/SparseTestModel.js
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+// Ten reference properties that live in the sparse store, one primitive that keeps its field.
+var sparseTestProperties = [];
+for ( var i = 0 ; i < 10 ; i++ ) sparseTestProperties.push({ class: 'String', name: 's' + i });
+sparseTestProperties.push({ class: 'Long', name: 'n0' });
+
+foam.CLASS({
+  package: 'foam.lang',
+  name: 'SparseTestModel',
+  javaSparse: true,
+  properties: sparseTestProperties
+});

--- a/src/foam/lang/tests.jrl
+++ b/src/foam/lang/tests.jrl
@@ -9,3 +9,4 @@ p({"class":"foam.lang.test.SlotlessValidationTest","id":"SlotlessValidationTest"
 p({"class":"foam.lang.test.DatePropertyBench","id":"DatePropertyBench","description":"Per-operation heap/CPU benchmark for date-typed properties"})
 p({"class":"foam.lang.test.DatePropertyOpsTest","id":"DatePropertyOpsTest","description":"Date property behaviour across GROUP_BY, range, ordering, clone, JSON and the unset path"})
 p({"class":"foam.lang.PackIsSetTest","id":"PackIsSetTest","description":"javaPackIsSet flag storage and isSet API"})
+p({"class":"foam.lang.SparseTest","id":"SparseTest","description":"javaSparse shared-shape storage and property API"})

--- a/src/foam/lang/tests.jrl
+++ b/src/foam/lang/tests.jrl
@@ -8,3 +8,4 @@ p({"class":"foam.lang.test.JSONEscapeTest","id":"JSONEscapeTest","description":"
 p({"class":"foam.lang.test.SlotlessValidationTest","id":"SlotlessValidationTest","description":"getErrors() slotless validation matches reactive errors_ and preserves reactivity", language: 0})
 p({"class":"foam.lang.test.DatePropertyBench","id":"DatePropertyBench","description":"Per-operation heap/CPU benchmark for date-typed properties"})
 p({"class":"foam.lang.test.DatePropertyOpsTest","id":"DatePropertyOpsTest","description":"Date property behaviour across GROUP_BY, range, ordering, clone, JSON and the unset path"})
+p({"class":"foam.lang.PackIsSetTest","id":"PackIsSetTest","description":"javaPackIsSet flag storage and isSet API"})

--- a/src/pom.js
+++ b/src/pom.js
@@ -962,6 +962,8 @@ foam.POM({
     { name: "foam/lang/FObjectTest",                                  flags: "js&test|java&test" },
     { name: "foam/lang/PackIsSetTestModel",                           flags: "js&test|java&test" },
     { name: "foam/lang/PackIsSetTest",                                flags: "js&test|java&test" },
+    { name: "foam/lang/SparseTestModel",                              flags: "js&test|java&test" },
+    { name: "foam/lang/SparseTest",                                   flags: "js&test|java&test" },
     { name: "foam/flow/Document",                                     flags: "js|java" },
     { name: "foam/flow/DocumentMenu",                                 flags: "js|java" },
     { name: "foam/flow/MarkupEditor",                                 flags: "js" },

--- a/src/pom.js
+++ b/src/pom.js
@@ -960,6 +960,8 @@ foam.POM({
     { name: "foam/test/TestObj",                                      flags: "js|java&test" },
     { name: "foam/test/IdentifiedStringHolder",                       flags: "js|java&test" },
     { name: "foam/lang/FObjectTest",                                  flags: "js&test|java&test" },
+    { name: "foam/lang/PackIsSetTestModel",                           flags: "js&test|java&test" },
+    { name: "foam/lang/PackIsSetTest",                                flags: "js&test|java&test" },
     { name: "foam/flow/Document",                                     flags: "js|java" },
     { name: "foam/flow/DocumentMenu",                                 flags: "js|java" },
     { name: "foam/flow/MarkupEditor",                                 flags: "js" },

--- a/src/pom.js
+++ b/src/pom.js
@@ -1329,6 +1329,7 @@ foam.POM({
     { name: "foam/lang/AbstractDoublePropertyInfo" },
     { name: "foam/lang/AbstractFObjectArrayPropertyInfo" },
     { name: "foam/lang/FObject" },
+    { name: "foam/lang/SparseShape" },
     { name: "foam/lang/XFactory" },
     { name: "foam/lang/OrX" },
     { name: "foam/lang/ProxyAgency" },


### PR DESCRIPTION
Stacked on #5396.

A declared property costs an instance a field whether or not the object sets it, so a 530-property model with 70 set per row spends most of each instance on empty slots. Opt-in per model: reference-typed properties live in one `Object[]` sized to what is set, indexed through a `foam.lang.SparseShape` shared by every instance with the same set of properties. Primitives, and types that generate their own accessors, keep a field (`javaSparse: false` on their refinements).

```js
foam.CLASS({ name: 'WideRecord', javaSparse: true, properties: [ ... ] });
```

```java
private static final foam.lang.SparseShape SHAPE_ROOT_WideRecord_ = foam.lang.SparseShape.root(521);
protected foam.lang.SparseShape shapeWideRecord_  = SHAPE_ROOT_WideRecord_;
protected Object[]              valuesWideRecord_ = foam.lang.SparseShape.EMPTY;

protected boolean isSparseSet_(int ord) { return shapeWideRecord_.slotOf(ord) >= 0; }
protected Object  sparse_(int ord)      { return valuesWideRecord_[shapeWideRecord_.slotOf(ord)]; }
protected synchronized void setSparse_(int ord, Object val) {   // first set moves to the shape with ord
  int i = shapeWideRecord_.slotOf(ord);
  if ( i >= 0 ) { valuesWideRecord_[i] = val; return; }
  foam.lang.SparseShape s = shapeWideRecord_.with(ord);
  valuesWideRecord_ = foam.lang.SparseShape.insertAt(valuesWideRecord_, s.slotOf(ord), val);
  shapeWideRecord_ = s;
}
protected synchronized void clearSparse_(int ord) { ... }        // moves to the shape without ord

public String getAmount()           { if ( ! isSparseSet_(5) ) return ""; return ((String) sparse_(5)); }
public void   setAmount(String val) { assertNotFrozen(); setSparse_(5, val); }
public void   clearAmount()         { assertNotFrozen(); clearSparse_(5); }
```

`isSet` is "ordinal present in the shape". One shape per distinct set of ordinals, canonical per class, transitions cached. `PropertyInfo.isSet/get/set`, `fclone`, `freeze`, `hashCode` all go through the four helpers.

Retained heap per record, 200K rows in an MDAO, best of 2 rounds:

| model | layout | compressed oops | uncompressed |
|---|---|---|---|
| 530 properties, ~70 set | fields | 2944–3068 B | 5136–5302 B |
| | bitset (#5396) | 2605–2765 B | 4814–5018 B |
| | sparse | 492–657 B | 631–859 B |
| 78 properties, ~45 set | fields | 557–573 B | 851–873 B |
| | bitset (#5396) | 596–623 B | 885–924 B |
| | sparse | 428–459 B | 552–592 B |

Instance shell alone: 530-property model 4912 → 88 B, 78-property model 696 → 192 B; the rest of a record is its values array and its strings, which do not move.

- Journal unchanged.
- `setSparse_` and `clearSparse_` are synchronized: a set replaces both the shape and the values array, so unsynchronized setters on different properties of one object lose values. `SparseTest` has eight threads set eight properties of one object for 20000 rounds: unsynchronized lost a value in 125 rounds, synchronized in none. Reads stay plain; a set grows the values array before it publishes the shape and a clear shrinks the shape before the array, so a plain reader never indexes past the array.
- `SparseTest` also covers the field shape, default and set reads, `clearX()`, shape sharing across instances and set order, `fclone` independence, `equals`/`hashCode`, and the frozen setter.
- Parse and put stay within noise of the field layout in paired runs: 530-property model 13–16 µs parse and 15–17 µs put against 15–17 / 15–17; 78-property model 7 / 3 µs against 7 / 2–3. Each first-time set is a shape transition plus an array copy, which the transition cache and the small per-row set count absorb.
- A subclass keeps fields for its own properties unless it opts in too; inherited sparse properties stay sparse.
- `javaCode` on an opted-in model must not read `x_` or `xIsSet_` fields of sparse properties.
- Only opted-in classes and their subclasses generate differently; every other generated file is byte-identical.

Closes #5395 once merged; the design and the measurements behind it are there.

DOS-4798


