### PR TITLE
PT-FIXES:DOS-1580 Allow re-running an interrupted script

### DIFF
--- a/src/foam/core/script/Script.js
+++ b/src/foam/core/script/Script.js
@@ -673,7 +673,8 @@ p({class:"foam.core.auth.GroupPermissionJunction",sourceId:"example-group",targe
         return enabled
          &&
           ( status == this.ScriptStatus.UNSCHEDULED ||
-            status == this.ScriptStatus.ERROR );
+            status == this.ScriptStatus.ERROR ||
+            status == this.ScriptStatus.INTERRUPTED );
       },
       code: function() {
         var self = this;

--- a/src/foam/core/script/ScriptRunnerDAO.js
+++ b/src/foam/core/script/ScriptRunnerDAO.js
@@ -45,6 +45,10 @@ foam.CLASS({
         Script script = (Script) obj;
         if ( script.getStatus() == ScriptStatus.SCHEDULED ) {
           if ( script.canRun(x) ) {
+            // A run scheduled over an interrupted script must not leave the
+            // previous execution behind, since setThreadExecution() below
+            // replaces the only reference to its Future.
+            cancelThreadExecution(x, script);
             script.setStatus(ScriptStatus.RUNNING);
             script = (Script) getDelegate().put_(x, script);
             script = runScript(x, (Script) script.fclone());
@@ -53,12 +57,27 @@ foam.CLASS({
             script = (Script) getDelegate().put_(x, script);
           }
         } else {
-          if ( script.getStatus() == ScriptStatus.INTERRUPTED && script.getThreadExecution() != null ) {
-            script.getThreadExecution().cancel(true);
+          if ( script.getStatus() == ScriptStatus.INTERRUPTED ) {
+            cancelThreadExecution(x, script);
           }
           script = (Script) getDelegate().put_(x, script);
         }
         return script;
+      `
+    },
+    {
+      name: 'cancelThreadExecution',
+      documentation: `Interrupts the thread running script, if one is still running.
+
+        threadExecution is transient, so the script handed to put_ never carries
+        the Future: a client cannot hold one, and it is not marshalled. Only the
+        stored script has it, so take it from there.`,
+      args: 'Context x, foam.core.script.Script script',
+      javaCode: `
+        Script current = (Script) getDelegate().find_(x, script.getId());
+        if ( current != null && current.getThreadExecution() != null ) {
+          current.getThreadExecution().cancel(true);
+        }
       `
     },
     {

--- a/src/foam/core/script/test/ScriptInterruptTest.js
+++ b/src/foam/core/script/test/ScriptInterruptTest.js
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.script.test',
+  name: 'ScriptInterruptTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `
+    Proves ScriptRunnerDAO stops the thread behind an interrupted script, and
+    that a re-run does not orphan a live one.
+
+    threadExecution holds a java.util.concurrent.Future and is transient, so the
+    script handed to put_ never carries it: a client cannot hold a Future, and
+    it is not marshalled. The stored script is the only place it lives.
+
+    Before the fix, put_ read the Future off the incoming script, so the
+    Interrupt button wrote the INTERRUPTED label and cancelled nothing - the
+    thread ran on, and (with INTERRUPTED excluded from the run action's status
+    set) the script could not be started again either.
+  `,
+
+  javaImports: [
+    'foam.core.script.Script',
+    'foam.core.script.ScriptRunnerDAO',
+    'foam.core.script.ScriptStatus',
+    'foam.dao.DAO',
+    'foam.dao.MDAO',
+    'foam.lang.X',
+    'java.util.concurrent.Callable',
+    'java.util.concurrent.CountDownLatch',
+    'java.util.concurrent.FutureTask',
+    'java.util.concurrent.TimeUnit'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      javaCode: `
+        interruptCancelsStoredExecution(x);
+        rerunCancelsStoredExecution(x);
+      `
+    },
+    {
+      // The stored script is what a running agent leaves behind: it carries the
+      // Future. The incoming script is what a client sends: it cannot.
+      name: 'interruptCancelsStoredExecution',
+      args: 'X x',
+      javaCode: `
+        MDAO mdao = new MDAO(Script.getOwnClassInfo());
+        DAO runner = new ScriptRunnerDAO(mdao);
+
+        CountDownLatch started = new CountDownLatch(1);
+        FutureTask task = parkedTask(started);
+        new Thread(task, "ScriptInterruptTest-interrupt").start();
+        test(awaitStart(started), "parked execution reached its blocking call");
+
+        Script stored = new Script.Builder(x).setId("interrupt-cancel").build();
+        stored.setStatus(ScriptStatus.RUNNING);
+        stored.setThreadExecution(task);
+        mdao.put_(x, stored);
+
+        Script incoming = new Script.Builder(x).setId("interrupt-cancel").build();
+        incoming.setStatus(ScriptStatus.INTERRUPTED);
+        test(incoming.getThreadExecution() == null,
+          "an interrupt arriving from a client carries no Future "
+          + "- threadExecution is transient (Script.js threadExecution)");
+
+        runner.put_(x, incoming);
+        test(task.isCancelled(),
+          "FIX: interrupt cancels the execution taken from the STORED script "
+          + "- before the fix the incoming null Future short-circuited the guard");
+      `
+    },
+    {
+      // Running a script that is still parked must not leave the old execution
+      // behind: setThreadExecution replaces the only reference to its Future.
+      name: 'rerunCancelsStoredExecution',
+      args: 'X x',
+      javaCode: `
+        MDAO mdao = new MDAO(Script.getOwnClassInfo());
+        DAO runner = new ScriptRunnerDAO(mdao);
+        X sx = x.put("scriptInterruptTestDAO", runner);
+
+        CountDownLatch started = new CountDownLatch(1);
+        FutureTask task = parkedTask(started);
+        new Thread(task, "ScriptInterruptTest-rerun").start();
+        test(awaitStart(started), "parked execution reached its blocking call");
+
+        Script stored = new Script.Builder(sx).setId("interrupt-rerun").build();
+        stored.setStatus(ScriptStatus.INTERRUPTED);
+        stored.setDaoKey("scriptInterruptTestDAO");
+        stored.setThreadExecution(task);
+        mdao.put_(sx, stored);
+
+        // What the run action sends: same id, SCHEDULED, no Future.
+        Script incoming = new Script.Builder(sx).setId("interrupt-rerun").build();
+        incoming.setStatus(ScriptStatus.SCHEDULED);
+        incoming.setDaoKey("scriptInterruptTestDAO");
+        incoming.setCode("");
+        try {
+          runner.put_(sx, incoming);
+        } catch ( Throwable t ) {
+          // The run itself needs an agency and writes events; neither is what
+          // this case asserts, and both may be unavailable in this harness.
+          print("re-run put_ threw (run side effects only): " + t);
+        }
+        test(task.isCancelled(),
+          "FIX: scheduling a run over a parked execution cancels it first "
+          + "- no thread left running with its Future unreachable");
+      `
+    },
+    {
+      // Blocks interruptibly, so cancel(true) is observable via isCancelled().
+      name: 'parkedTask',
+      args: [ { name: 'started', javaType: 'java.util.concurrent.CountDownLatch' } ],
+      javaType: 'java.util.concurrent.FutureTask',
+      javaCode: `
+        return new FutureTask(new Callable() {
+          public Object call() throws Exception {
+            started.countDown();
+            Thread.sleep(60000);
+            return null;
+          }
+        });
+      `
+    },
+    {
+      name: 'awaitStart',
+      args: [ { name: 'started', javaType: 'java.util.concurrent.CountDownLatch' } ],
+      javaType: 'boolean',
+      javaCode: `
+        try {
+          return started.await(5, TimeUnit.SECONDS);
+        } catch ( InterruptedException e ) {
+          Thread.currentThread().interrupt();
+          return false;
+        }
+      `
+    }
+  ]
+});

--- a/src/foam/core/script/test/ScriptInterruptTest.js
+++ b/src/foam/core/script/test/ScriptInterruptTest.js
@@ -30,6 +30,7 @@ foam.CLASS({
     'foam.dao.DAO',
     'foam.dao.MDAO',
     'foam.lang.X',
+    'java.util.Date',
     'java.util.concurrent.Callable',
     'java.util.concurrent.CountDownLatch',
     'java.util.concurrent.FutureTask',
@@ -94,6 +95,9 @@ foam.CLASS({
         stored.setStatus(ScriptStatus.INTERRUPTED);
         stored.setDaoKey("scriptInterruptTestDAO");
         stored.setThreadExecution(task);
+        // A bare MDAO has no LastModifiedAware decorator to stamp this, and the
+        // run's finally block compares it against the stored script's.
+        stored.setLastModified(new Date());
         mdao.put_(sx, stored);
 
         // What the run action sends: same id, SCHEDULED, no Future.
@@ -101,6 +105,7 @@ foam.CLASS({
         incoming.setStatus(ScriptStatus.SCHEDULED);
         incoming.setDaoKey("scriptInterruptTestDAO");
         incoming.setCode("");
+        incoming.setLastModified(new Date());
         try {
           runner.put_(sx, incoming);
         } catch ( Throwable t ) {

--- a/src/foam/core/script/test/tests.jrl
+++ b/src/foam/core/script/test/tests.jrl
@@ -1,1 +1,2 @@
 p({"class":"foam.core.script.test.ScriptInterpreterLifecycleTest","id":"ScriptInterpreterLifecycleTest","description":"Proves BeanShell releases its namespace (no leak) and JShell pins the X context in a static (leak)"})
+p({"class":"foam.core.script.test.ScriptInterruptTest","id":"ScriptInterruptTest","description":"Proves an interrupt cancels the thread via the stored script's Future, and a re-run does not orphan a live one"})

--- a/src/pom.js
+++ b/src/pom.js
@@ -490,6 +490,7 @@ foam.POM({
     { name: "foam/net/CIDR",                                          flags: "js|java" },
     { name: "foam/net/test/CIDRTest",                                 flags: "js&test|java&test" },
     { name: "foam/core/script/test/ScriptInterpreterLifecycleTest",   flags: "js&test|java&test" },
+    { name: "foam/core/script/test/ScriptInterruptTest",              flags: "js&test|java&test" },
     { name: "foam/net/Host",                                          flags: "js|java" },
     { name: "foam/net/Port",                                          flags: "js|java" },
     { name: "foam/net/NetworkException",                              flags: "js" },


### PR DESCRIPTION
Interrupting a script writes the `INTERRUPTED` label and leaves the thread running, and the run action then accepts no status it can start from, so nothing brings the script back.

Cause: `threadExecution` is transient, so the script handed to `put_` never carries the run's Future — a client cannot hold one, and it is not marshalled. The cancel guard read it off that incoming script:

```java
if ( script.getStatus() == ScriptStatus.INTERRUPTED && script.getThreadExecution() != null ) {
  script.getThreadExecution().cancel(true);   // never reached from a client interrupt
}
```

The timeout sweep in `CronScheduler` clones the stored cron, so that path does cancel; an interrupt sent from a client does not.

Fix:

- take the Future from the stored script instead of the incoming one, so an interrupt reaches the thread

- cancel a still-parked execution before scheduling a new run, since `setThreadExecution` replaces the only reference to its Future

- add `INTERRUPTED` to the run action's status set

The scheduler's own `UNSCHEDULED`/`ERROR` filters stay as they are. Automatic re-runs are bounded by reattempt/maxReattempts, and a cron that keeps hitting its thread timeout would otherwise re-schedule itself with no counter.

`ScriptInterruptTest` parks a real execution, stores it the way the running agent leaves it, then puts the client-shaped interrupt. Both cancel assertions fail without the fix.