### PR TITLE
AppConfig - explicit copyFrom

### DIFF
--- a/src/foam/core/app/AppConfig.js
+++ b/src/foam/core/app/AppConfig.js
@@ -117,20 +117,41 @@ foam.CLASS({
       // A Template method which can be overridden in a sub-class or refined from another
       // package that uses FOAM.
       name: 'configure',
-      args: [
-        {
-          name: 'x',
-          type: 'Context'
-        },
-        {
-          name: 'url',
-          type: 'String'
-        }
-      ],
+      args: 'Context x, String url',
       type: 'foam.core.app.AppConfig',
       javaCode: `
       return this;
       `
+    },
+    {
+      documentation: `AppConfig is copyied for theme overrides,
+only copy properties relevant to the client or to the system when
+running under the user's context`,
+      name: 'copyFrom',
+      args: 'foam.core.app.AppConfig from',
+      type: 'foam.core.app.AppConfig',
+      javaCode: `
+        setPrivacy(from.getPrivacy());
+        setPrivacyUrl(from.getPrivacyUrl());
+        setCopyright(from.getCopyright());
+        setUrl(from.getUrl());
+        setUrlLabel(from.getUrlLabel());
+        setTermsAndCondLabel(from.getTermsAndCondLabel());
+        setTermsAndCondLink(from.getTermsAndCondLink());
+        setExternalUrl(from.getExternalUrl());
+        return this;
+      `,
+      code: function(from) {
+        this.privacy = from.privacy;
+        this.privacyUrl = from.privacyUrl;
+        this.copyright = from.copyright;
+        this.url = from.url;
+        this.urlLabel = from.urlLabel;
+        this.termsAndCondLabel = from.termsAndCondLabel;
+        this.termsAndCondLink = from.termsAndCondLink;
+        this.externalUrl = from.externalUrl;
+        return this;
+      }
     }
   ]
 });

--- a/src/foam/core/app/AppConfig.js
+++ b/src/foam/core/app/AppConfig.js
@@ -124,7 +124,7 @@ foam.CLASS({
       `
     },
     {
-      documentation: `AppConfig is copyied for theme overrides,
+      documentation: `AppConfig is copied for theme overrides,
 only copy properties relevant to the client or to the system when
 running under the user's context`,
       name: 'copyFrom',

--- a/src/foam/core/app/AppConfig.js
+++ b/src/foam/core/app/AppConfig.js
@@ -131,6 +131,7 @@ running under the user's context`,
       args: 'foam.core.app.AppConfig from',
       type: 'foam.core.app.AppConfig',
       javaCode: `
+        if ( from == null) return this;
         setPrivacy(from.getPrivacy());
         setPrivacyUrl(from.getPrivacyUrl());
         setCopyright(from.getCopyright());
@@ -142,6 +143,7 @@ running under the user's context`,
         return this;
       `,
       code: function(from) {
+        if ( ! from ) return this;
         this.privacy = from.privacy;
         this.privacyUrl = from.privacyUrl;
         this.copyright = from.copyright;

--- a/src/foam/core/app/pom.js
+++ b/src/foam/core/app/pom.js
@@ -5,6 +5,11 @@
  */
 foam.POM({
   name: "app",
+
+  projects: [
+    { name: 'test/pom',                             flags: "test"}
+  ],
+
   files: [
     { name: "AppBadgeView",                         flags: "web" },
     { name: "AppConfig",                            flags: "js|java" },

--- a/src/foam/core/app/test/AppConfigCopyFromJavaTest.java
+++ b/src/foam/core/app/test/AppConfigCopyFromJavaTest.java
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package foam.core.app.test;
+
+import foam.core.app.*;
+import foam.lang.X;
+
+public class AppConfigCopyFromJavaTest
+  extends foam.core.test.JavaTest {
+
+  public void runTest(X x) {
+    AppConfig to = new AppConfig();
+    to.setMode(Mode.PRODUCTION);
+    to.setUrl("http://to-url");
+
+    AppConfig from = new AppConfig();
+    from.setMode(Mode.TEST);
+    from.setUrl("http://from-url");
+
+    to.copyFrom(from);
+    test ( to.getMode() == Mode.PRODUCTION, "Mode not copied");
+    test ( to.getUrl().equals("http://from-url"), "Url copied");
+  }
+}

--- a/src/foam/core/app/test/pom.js
+++ b/src/foam/core/app/test/pom.js
@@ -1,0 +1,7 @@
+foam.POM({
+  name: 'test',
+
+  javaFiles: [
+    { name: "AppConfigCopyFromJavaTest" }
+  ]
+});

--- a/src/foam/core/app/test/tests.jrl
+++ b/src/foam/core/app/test/tests.jrl
@@ -1,0 +1,4 @@
+p({
+  "class":"foam.core.app.test.AppConfigCopyFromJavaTest"
+  "id":"AppConfigCopyFromJavaTest",
+})


### PR DESCRIPTION
Explicit copyFrom as not all properties are relevant to the client and/or should not be overwritten on the server