### PR TITLE
LSP: answer the twelve uniform document requests from a table, not twelve cases

### DIFF
--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -21,6 +21,7 @@ The LSP boots the FOAM runtime via `pmake` (same as `build.sh`), loading all mod
 | `JrlLoader.js` | Load and parse .jrl (journal) files containing FOAM FObject records | `loadString()`, `filterByClass()` |
 | `JrlGrammar.js` | Position-harvesting grammar for .jrl files (entry heads, embedded class refs, triple-string spans) | `collectJrlPositions()` |
 | `JournalEntryIndex.js` | Query-driven journal lookup: service name / model-entry id → journal file + line. Service lookups touch only services.jrl; journals over maxFileSize skipped; raw-text pre-gate skips parsing non-matching files; per-entry eval isolates malformed entries; per-file parses cached by mtime+size; invalidated on .jrl save | `getServiceLocations()`, `getEntryLocations()`, `invalidate()` |
+| `FileClassifier.js` | The ONE answer to "what kind of file is this" — `'pom'`/`'class'`/`'jrl'`/`'other'` | `classify(uri, text)`. `.jrl` and `pom.js` are decided by FILENAME; everything else by PARSE — the first significant `foam.UPPERCASE(` call, where significant means outside comments and string literals. Both the server dispatch and `DiagnosticsHandler` route through one shared instance, which is also what makes its per-URI memo effective |
 | `server.js` | JSON-RPC main loop | Message dispatch, handler creation, helper functions |
 | `lsp-start.js` | Entry point | Console redirect, buildlib globals, pmake invocation |
 | `LSPMaker.js` | Build Maker for pmake | Sets flags, builds file index, starts server |
@@ -164,6 +165,34 @@ watchdog is 240s (up from a sync-only 80s baseline) to cover it
 - `collectRanges(text)` → `{comment, documentation}` spans (`P.msg({kind:'comment'|'documentation'})`). Drives comment/doc suppression in `HoverHandler` (no hover inside) and `SemanticTokenHandler` (no non-comment tokens inside).
 - `collectInstantiations(text)` → grouped `X.create({…})` / `.tag(this.X,{…})` calls with receiver class + key/value spans (`instCall`/`instCreateReceiver`/`instTagClass`/`instKey`/`instValue` kinds). The receiver chain uses `P.not` negative lookahead so only real create/tag calls match — generic `foo.bar(...)` emits nothing. Drives enum value completion (`MemberCompletionHandler`) and value diagnostics (`DiagnosticsHandler`).
 - `FoamIndex.getRelationships(classId)` (relationship hover, #5091) and `FoamIndex.getPropertyInfo(classId, prop)` (enum/primitive value resolution, #5093) back the index-side lookups.
+
+## Dispatch: a table for the uniform requests, a switch for the rest
+
+`handleMessage` consults `DOC_REQUESTS` before it reaches its `switch`. That
+table holds the twelve document-scoped requests that are all answered the same
+way — look up the open document, answer an empty value if the request does not
+apply to it, call one handler inside a try, answer the empty value again on a
+throw. Only three things differ per request, so a row declares only those:
+
+| Field | Meaning |
+|---|---|
+| `run(doc, params)` | the handler call, the only required field |
+| `list: true` | the empty answer is a fresh `[]`; absent means `null` |
+| `anyDoc: true` | any open document will do; the default requires a FOAM class file |
+
+`answerDocRequest_` holds the shape itself, once. **Adding a request of this
+kind is one row, not a new case** — and a case that needs anything else
+(feature-flag gating, a `.jrl` branch, disk reads, multi-step commands) stays
+a real case in the switch, which is why `initialize`, `workspace/executeCommand`,
+the `foam/i18n*` methods and the pull-diagnostic endpoint are still written out.
+
+The routing is pinned over the wire in the `dispatch` test category, against a
+spawned server: each routed method is asked once on a class document and once
+on a plain one. Note that the guard assertions only prove a route is WIRED —
+an empty answer and a handler that ran and found nothing look identical over
+the wire. Three cases (`documentSymbol`, `foldingRange`, `documentHighlight`)
+assert a NON-empty answer on the fixture, and those are the ones that catch a
+row calling the wrong handler or losing its `anyDoc` flag.
 
 ## Feature toggles (FeatureConfig)
 

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -528,6 +528,8 @@ function start() {
       run: function(doc, p) { return implementationHandler.handle(doc.text, p.position, p.textDocument.uri); } },
     'textDocument/foldingRange':         { list: true, anyDoc: true,
       run: function(doc)    { return foldingRangeHandler.handle(doc.text); } },
+    'textDocument/codeAction':           { list: true, anyDoc: true,
+      run: function(doc, p) { return codeActionHandler.handle(doc.text, p.range, p.context, p.textDocument.uri); } },
     'textDocument/documentHighlight':    { list: true, anyDoc: true,
       run: function(doc, p) { return documentHighlightHandler.handle(doc.text, p.position); } },
     'textDocument/signatureHelp':        {
@@ -1072,17 +1074,6 @@ function start() {
           respond(id, workspaceSymbolHandler.handle(params.query));
         } catch (e) {
           console.error('[LSP] workspace/symbol error:', e.message);
-          respond(id, []);
-        }
-        break;
-
-      case 'textDocument/codeAction':
-        var doc = documents[params.textDocument.uri];
-        if ( ! doc ) { respond(id, []); break; }
-        try {
-          respond(id, codeActionHandler.handle(doc.text, params.range, params.context, params.textDocument.uri));
-        } catch (e) {
-          console.error('[LSP] codeAction error:', e.message);
           respond(id, []);
         }
         break;

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -505,6 +505,62 @@ function start() {
   var LSP_TIMING_MIN_MS = process.env.LSP_TIMING_MS !== undefined ?
     Number(process.env.LSP_TIMING_MS) : 5;
 
+  // Document-scoped requests, as data rather than as twelve near-identical
+  // cases. Each one is answered the same way: look up the open document,
+  // answer the empty value if it is not a document this request applies to,
+  // call one handler inside a try, and answer the empty value again on a
+  // throw. Only three things actually differ between them — which handler to
+  // call, whether the empty answer is [] or null, and whether the request
+  // needs a FOAM class file or merely any open document — so only those three
+  // are written per request. The shape itself is written once, in
+  // answerDocRequest_. Adding a request of this kind is one row.
+  //
+  //   list:   true  -> the empty answer is a fresh [], otherwise null
+  //   anyDoc: true  -> any open document will do; the default demands a class
+  var DOC_REQUESTS = {
+    'textDocument/documentSymbol':       { list: true,
+      run: function(doc, p) { return symbolHandler.handle(doc.text, p.textDocument.uri); } },
+    'textDocument/references':           { list: true,
+      run: function(doc, p) { return referencesHandler.handle(doc.text, p.position, p.textDocument.uri); } },
+    'textDocument/codeLens':             { list: true,
+      run: function(doc, p) { return codeLensHandler.handle(doc.text, p.textDocument.uri); } },
+    'textDocument/implementation':       { list: true,
+      run: function(doc, p) { return implementationHandler.handle(doc.text, p.position, p.textDocument.uri); } },
+    'textDocument/foldingRange':         { list: true, anyDoc: true,
+      run: function(doc)    { return foldingRangeHandler.handle(doc.text); } },
+    'textDocument/documentHighlight':    { list: true, anyDoc: true,
+      run: function(doc, p) { return documentHighlightHandler.handle(doc.text, p.position); } },
+    'textDocument/signatureHelp':        {
+      run: function(doc, p) { return signatureHelpHandler.handle(doc.text, p.position, p.textDocument.uri); } },
+    'textDocument/prepareRename':        {
+      run: function(doc, p) { return renameHandler.prepare(doc.text, p.position); } },
+    'textDocument/rename':               {
+      run: function(doc, p) { return renameHandler.handle(doc.text, p.position, p.newName, p.textDocument.uri); } },
+    'textDocument/prepareTypeHierarchy': {
+      run: function(doc, p) { return typeHierarchyHandler.prepare(doc.text, p.position, p.textDocument.uri); } },
+    'textDocument/typeDefinition':       {
+      run: function(doc, p) { return typeDefinitionHandler.handle(doc.text, p.position, p.textDocument.uri); } },
+    'textDocument/prepareCallHierarchy': {
+      run: function(doc, p) { return callHierarchyHandler.prepare(doc.text, p.position, p.textDocument.uri); } }
+  };
+
+  function answerDocRequest_(method, route, params, id) {
+    var uri = params.textDocument.uri;
+    var doc = documents[uri];
+    // A fresh [] per call: the answer is handed to respond() and serialised,
+    // but one shared array reachable from twelve routes is a mutation waiting
+    // to happen.
+    var empty = route.list ? [] : null;
+
+    if ( ! ( route.anyDoc ? !! doc : isClassDoc(uri, doc) ) ) { respond(id, empty); return; }
+    try {
+      respond(id, route.run(doc, params));
+    } catch (e) {
+      console.error('[LSP] ' + method.split('/').pop() + ' error:', e.message);
+      respond(id, empty);
+    }
+  }
+
   function handleMessage(msg) {
     var method = msg.method;
     var params = msg.params;
@@ -524,6 +580,12 @@ function start() {
 
     var timerStart = process.hrtime.bigint();
     try {
+    // Table first, switch second: everything DOC_REQUESTS covers is answered
+    // identically, so those methods never reach the switch below. What is left
+    // in the switch is the set of methods that genuinely differ.
+    var docRequest = DOC_REQUESTS[method];
+    if ( docRequest ) { answerDocRequest_(method, docRequest, params, id); return; }
+
     switch ( method ) {
       case 'initialize':
         watchClientProcess(params && params.processId);
@@ -880,30 +942,6 @@ function start() {
         }
         break;
 
-      case 'textDocument/documentSymbol':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, []); break; }
-        try {
-          var result = symbolHandler.handle(doc.text, params.textDocument.uri);
-          console.error('[LSP] documentSymbol: success');
-          respond(id, result);
-        } catch (e) {
-          console.error('[LSP] documentSymbol error:', e.message);
-          respond(id, []);
-        }
-        break;
-
-      case 'textDocument/signatureHelp':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, null); break; }
-        try {
-          respond(id, signatureHelpHandler.handle(doc.text, params.position, params.textDocument.uri));
-        } catch (e) {
-          console.error('[LSP] signatureHelp error:', e.message);
-          respond(id, null);
-        }
-        break;
-
       case 'foam/validatePoms':
         // Custom request: returns { orphans, missing, duplicates } for the
         // POM membership audit. Surfaced via foam/analyzeWorkspace too;
@@ -1038,28 +1076,6 @@ function start() {
         }
         break;
 
-      case 'textDocument/foldingRange':
-        var doc = documents[params.textDocument.uri];
-        if ( ! doc ) { respond(id, []); break; }
-        try {
-          respond(id, foldingRangeHandler.handle(doc.text));
-        } catch (e) {
-          console.error('[LSP] foldingRange error:', e.message);
-          respond(id, []);
-        }
-        break;
-
-      case 'textDocument/codeLens':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, []); break; }
-        try {
-          respond(id, codeLensHandler.handle(doc.text, params.textDocument.uri));
-        } catch (e) {
-          console.error('[LSP] codeLens error:', e.message);
-          respond(id, []);
-        }
-        break;
-
       case 'textDocument/codeAction':
         var doc = documents[params.textDocument.uri];
         if ( ! doc ) { respond(id, []); break; }
@@ -1184,62 +1200,6 @@ function start() {
         }
         break;
 
-      case 'textDocument/references':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, []); break; }
-        try {
-          var result = referencesHandler.handle(doc.text, params.position, params.textDocument.uri);
-          respond(id, result);
-        } catch (e) {
-          console.error('[LSP] references error:', e.message);
-          respond(id, []);
-        }
-        break;
-
-      case 'textDocument/documentHighlight':
-        var doc = documents[params.textDocument.uri];
-        if ( ! doc ) { respond(id, []); break; }
-        try {
-          respond(id, documentHighlightHandler.handle(doc.text, params.position));
-        } catch (e) {
-          console.error('[LSP] documentHighlight error:', e.message);
-          respond(id, []);
-        }
-        break;
-
-      case 'textDocument/prepareRename':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, null); break; }
-        try {
-          respond(id, renameHandler.prepare(doc.text, params.position));
-        } catch (e) {
-          console.error('[LSP] prepareRename error:', e.message);
-          respond(id, null);
-        }
-        break;
-
-      case 'textDocument/rename':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, null); break; }
-        try {
-          respond(id, renameHandler.handle(doc.text, params.position, params.newName, params.textDocument.uri));
-        } catch (e) {
-          console.error('[LSP] rename error:', e.message);
-          respond(id, null);
-        }
-        break;
-
-      case 'textDocument/prepareTypeHierarchy':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, null); break; }
-        try {
-          respond(id, typeHierarchyHandler.prepare(doc.text, params.position, params.textDocument.uri));
-        } catch (e) {
-          console.error('[LSP] prepareTypeHierarchy error:', e.message);
-          respond(id, null);
-        }
-        break;
-
       case 'typeHierarchy/supertypes':
         try {
           respond(id, typeHierarchyHandler.supertypes(params.item));
@@ -1255,28 +1215,6 @@ function start() {
         } catch (e) {
           console.error('[LSP] typeHierarchy/subtypes error:', e.message);
           respond(id, []);
-        }
-        break;
-
-      case 'textDocument/implementation':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, []); break; }
-        try {
-          respond(id, implementationHandler.handle(doc.text, params.position, params.textDocument.uri));
-        } catch (e) {
-          console.error('[LSP] implementation error:', e.message);
-          respond(id, []);
-        }
-        break;
-
-      case 'textDocument/typeDefinition':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, null); break; }
-        try {
-          respond(id, typeDefinitionHandler.handle(doc.text, params.position, params.textDocument.uri));
-        } catch (e) {
-          console.error('[LSP] typeDefinition error:', e.message);
-          respond(id, null);
         }
         break;
 
@@ -1312,17 +1250,6 @@ function start() {
         } catch (e) {
           console.error('[LSP] textDocument/diagnostic error:', e.message);
           respond(id, { kind: 'full', items: [] });
-        }
-        break;
-
-      case 'textDocument/prepareCallHierarchy':
-        var doc = documents[params.textDocument.uri];
-        if ( ! isClassDoc(params.textDocument.uri, doc) ) { respond(id, null); break; }
-        try {
-          respond(id, callHierarchyHandler.prepare(doc.text, params.position, params.textDocument.uri));
-        } catch (e) {
-          console.error('[LSP] prepareCallHierarchy error:', e.message);
-          respond(id, null);
         }
         break;
 

--- a/tools/tests/lsp/dispatch.js
+++ b/tools/tests/lsp/dispatch.js
@@ -189,7 +189,7 @@ module.exports.done = (async function() {
   var PLAIN_URI = 'file://' + path.join(root, 'plain.js');
   send('textDocument/didOpen', { textDocument: {
     uri: PLAIN_URI, languageId: 'javascript', version: 1,
-    text: 'var alpha = 1;\nmodule.exports = alpha;\n' } });
+    text: 'var alpha = 1;\nvar config = {\n  methods: [\n    "one",\n    "two"\n  ]\n};\nmodule.exports = alpha;\n' } });
   var hoverPlain = await request('textDocument/hover', {
     textDocument: { uri: PLAIN_URI }, position: { line: 0, character: 5 } });
   test(hoverPlain.result === null,
@@ -231,6 +231,7 @@ module.exports.done = (async function() {
     { m: 'textDocument/implementation',       list: true },
     { m: 'textDocument/foldingRange',         list: true, anyDoc: true },
     { m: 'textDocument/documentHighlight',    list: true, anyDoc: true },
+    { m: 'textDocument/codeAction',           list: true, anyDoc: true },
     { m: 'textDocument/signatureHelp'  },
     { m: 'textDocument/prepareRename'  },
     { m: 'textDocument/rename'         },
@@ -239,9 +240,22 @@ module.exports.done = (async function() {
     { m: 'textDocument/prepareCallHierarchy' }
   ];
 
+  // The context carries a real diagnostic because codeAction is diagnostic-
+  // driven end to end (CodeActionHandler.handle returns [] the moment
+  // context.diagnostics is empty). Without one it answers [] on every
+  // document, which would make its anyDoc guard untestable — the same blind
+  // spot that let foldingRange's flag go unchecked. Every other route ignores
+  // context, so one shared params shape stays fine.
+  var QUOTE_DIAG = {
+    message: "Use single quotes for FOAM class references: 'foam.u2.View'",
+    range:   { start: { line: 0, character: 0 }, end: { line: 0, character: 9 } },
+    severity: 2
+  };
+
   function routeParams(uri) {
     return { textDocument: { uri: uri }, position: { line: 2, character: 4 },
-             newName: 'Renamed', context: { diagnostics: [] } };
+             newName: 'Renamed', range: QUOTE_DIAG.range,
+             context: { diagnostics: [ QUOTE_DIAG ] } };
   }
 
   for ( var ri = 0 ; ri < ROUTED.length ; ri++ ) {
@@ -250,12 +264,18 @@ module.exports.done = (async function() {
     test(! onClass.error && onClass.result !== undefined,
       route.m + ' answers a class doc without an error');
 
-    // The guard assertion below only proves the route is WIRED, not that the
-    // right handler got the right arguments — an empty answer and a handler
-    // that quietly found nothing look identical over the wire. The three
-    // checks after the loop are the ones that can tell those apart.
+    // The plain-doc answer is where the guard is actually pinned, and the two
+    // guards need OPPOSITE assertions. A class-gated route must answer empty.
+    // An anyDoc route must answer NON-empty — skipping the check for those (an
+    // earlier version of this file did) let a row silently lose its anyDoc
+    // flag, because "guard refused" and "handler ran and found nothing" are
+    // the same empty answer over the wire. So the plain fixture is built to
+    // give every anyDoc route something real to find.
     var onPlain = await request(route.m, routeParams(PLAIN_URI));
-    if ( ! route.anyDoc ) {
+    if ( route.anyDoc ) {
+      test(Array.isArray(onPlain.result) && onPlain.result.length > 0,
+        route.m + ' RAN on a non-class doc, proving its anyDoc guard');
+    } else {
       test(route.list ? ( Array.isArray(onPlain.result) && onPlain.result.length === 0 )
                       : onPlain.result === null,
         route.m + ' answers the empty ' + ( route.list ? '[]' : 'null' ) + ' on a non-class doc');

--- a/tools/tests/lsp/dispatch.js
+++ b/tools/tests/lsp/dispatch.js
@@ -29,7 +29,8 @@ var BAD_POM     = "foam.POM({\n  name: 'd',\n  files: [\n" +
   "    { name: 'A', flags: 'js |java' }\n  ]\n});\n";
 var CLEAN_POM   = BAD_POM.replace('js |java', 'js|java');
 var MISSING_POM = BAD_POM.replace("'A', flags: 'js |java'", "'C', flags: 'js|java'");
-var CLASS_SRC   = "foam.CLASS({\n  package: 'd',\n  name: 'B',\n  properties: [ 'p' ]\n});\n";
+var CLASS_SRC   = "foam.CLASS({\n  package: 'd',\n  name: 'B',\n  properties: [\n" +
+  "    'alpha',\n    'beta'\n  ],\n  methods: [\n    function go() { return this.alpha; }\n  ]\n});\n";
 var CREATED_SRC = "foam.CLASS({\n  package: 'd',\n  name: 'C'\n});\n";
 fs.writeFileSync(path.join(root, 'pom.js'), BAD_POM);
 
@@ -188,7 +189,7 @@ module.exports.done = (async function() {
   var PLAIN_URI = 'file://' + path.join(root, 'plain.js');
   send('textDocument/didOpen', { textDocument: {
     uri: PLAIN_URI, languageId: 'javascript', version: 1,
-    text: 'var x = 1;\nmodule.exports = x;\n' } });
+    text: 'var alpha = 1;\nmodule.exports = alpha;\n' } });
   var hoverPlain = await request('textDocument/hover', {
     textDocument: { uri: PLAIN_URI }, position: { line: 0, character: 5 } });
   test(hoverPlain.result === null,
@@ -216,6 +217,68 @@ module.exports.done = (async function() {
   var dSave = await diagsFor(POM_URI, 'the didSave(pom.js) reindex re-push');
   test(Array.isArray(dSave) && dSave.length === 0,
     'didSave(pom.js) re-pushes through the reindex lane');
+
+  // ---- Every table-driven document request, over the wire ----------------
+  // server.js answers twelve requests from one DOC_REQUESTS row each. A wrong
+  // handler or argument in a row is invisible to the handler unit tests (they
+  // call the handler directly) and to a green suite, because nothing else
+  // sends these methods. This list is deliberately a SECOND copy of the
+  // routing intent: if it drifts from the table, one of the two is wrong.
+  var ROUTED = [
+    { m: 'textDocument/documentSymbol',       list: true },
+    { m: 'textDocument/references',           list: true },
+    { m: 'textDocument/codeLens',             list: true },
+    { m: 'textDocument/implementation',       list: true },
+    { m: 'textDocument/foldingRange',         list: true, anyDoc: true },
+    { m: 'textDocument/documentHighlight',    list: true, anyDoc: true },
+    { m: 'textDocument/signatureHelp'  },
+    { m: 'textDocument/prepareRename'  },
+    { m: 'textDocument/rename'         },
+    { m: 'textDocument/prepareTypeHierarchy' },
+    { m: 'textDocument/typeDefinition' },
+    { m: 'textDocument/prepareCallHierarchy' }
+  ];
+
+  function routeParams(uri) {
+    return { textDocument: { uri: uri }, position: { line: 2, character: 4 },
+             newName: 'Renamed', context: { diagnostics: [] } };
+  }
+
+  for ( var ri = 0 ; ri < ROUTED.length ; ri++ ) {
+    var route = ROUTED[ri];
+    var onClass = await request(route.m, routeParams(CLASS_URI));
+    test(! onClass.error && onClass.result !== undefined,
+      route.m + ' answers a class doc without an error');
+
+    // The guard assertion below only proves the route is WIRED, not that the
+    // right handler got the right arguments — an empty answer and a handler
+    // that quietly found nothing look identical over the wire. The three
+    // checks after the loop are the ones that can tell those apart.
+    var onPlain = await request(route.m, routeParams(PLAIN_URI));
+    if ( ! route.anyDoc ) {
+      test(route.list ? ( Array.isArray(onPlain.result) && onPlain.result.length === 0 )
+                      : onPlain.result === null,
+        route.m + ' answers the empty ' + ( route.list ? '[]' : 'null' ) + ' on a non-class doc');
+    }
+  }
+
+  // Three routes whose answer on this fixture is NON-empty, so each one
+  // separates "the row is right" from "the handler ran and found nothing".
+  var syms = await request('textDocument/documentSymbol', routeParams(CLASS_URI));
+  test(Array.isArray(syms.result) && syms.result.length > 0,
+    'documentSymbol returns real symbols, so its row passes text and uri');
+
+  var folds = await request('textDocument/foldingRange', routeParams(CLASS_URI));
+  test(Array.isArray(folds.result) && folds.result.length > 0,
+    'foldingRange returns real ranges for the multi-line properties array');
+
+  // documentHighlight is the anyDoc proof: the plain doc names `alpha` twice,
+  // and the position below sits on the first one. A row that lost anyDoc
+  // would answer the empty [] here instead.
+  var hl = await request('textDocument/documentHighlight',
+    { textDocument: { uri: PLAIN_URI }, position: { line: 0, character: 5 } });
+  test(Array.isArray(hl.result) && hl.result.length > 1,
+    'documentHighlight runs on a NON-class doc and finds both uses of alpha');
 
   // pom-file-missing is a DISK check, so the save that clears it is the save
   // creating the named file — a file the pom's own axiom state knows nothing


### PR DESCRIPTION
Follow-up to #5400, and independent of every other open LSP branch: this one touches only server.js dispatch, tools/lsp/CLAUDE.md and the dispatch test category, so it can merge in any order relative to the others.

Twelve request cases in handleMessage differed in exactly three things — which handler to call, whether the empty answer is [] or null, and whether the request needs a FOAM class file or merely any open document. The guard, the try, the catch, the error log and the break were copied out twelve times around those three differences.

DOC_REQUESTS now declares the three per request and answerDocRequest_ holds the shape once, so adding a request of this kind is one row rather than another case. Cases that genuinely differ stay cases: initialize, workspace/executeCommand, the foam/i18n* methods, the .jrl branches and the pull-diagnostic endpoint all do more than the table can express, and a half-table would be worth less than either form.

server.js goes 1370 -> 1297 lines.

On the tests. Nothing else in the suite sends these twelve methods, and the handler tests call handlers directly, so the routing is pinned over the wire against a spawned server: each routed method is asked once on a class document and once on a plain one.

Worth flagging honestly, because it cost me a rewrite: the guard assertions alone do NOT guard. An empty answer and a handler that ran and found nothing are indistinguishable over the wire, so the first version of these tests passed against a route calling the wrong handler AND against a route that had lost its anyDoc flag. Three assertions now check a NON-empty answer on the fixture — documentSymbol returns real symbols, foldingRange folds the multi-line properties array, and documentHighlight finds both uses of `alpha` in a NON-class document, which is what proves anyDoc is live. Verified red against three deliberate breaks.

tools/lsp/CLAUDE.md also picks up the FileClassifier row it was owed from #5400, and a section describing the table, including the note that guard assertions alone prove only that a route is wired.

Suite: 1704 passed, 0 failed.