### PR TITLE
lsp: model boundaries come from the comment-aware scan, not a regex

### DIFF
--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -103,13 +103,26 @@ line. Two things read it:
 - `DiagnosticsHandler.validateExpressions_` takes the next call's offset as
   where the model ENDS.
 
-Both used to run their own `foam\.[A-Z]...\(` regex over the source, and a
+A third reads it too: `FileModelCache`'s SyntaxError fallback, which
+bracket-matches and evals one block at a time when the file does not parse.
+
+All three used to run their own `foam\.[A-Z]...\(` regex over the source, and a
 regex cannot tell a real call from one written in a doc comment or a test
 fixture string. `src/foam/lang/Proxy.js` has 4 real calls and 6 regex matches;
 `Enum.js` has 6 and 9. The failure was silent in the worst way: a model whose
 text was cut short at a comment simply stopped being validated, so a genuinely
 wrong `expression:` argument produced no diagnostic at all rather than a
 degraded one.
+
+Two details worth keeping straight:
+
+- A model's start offset is the start of its CALL, not of its line. Taking the
+  line start made an indented `foam.CLASS(` match as its own next model, and the
+  model's text became the indentation — 93 files under `src/` have their first
+  foam call at a column other than 0.
+- The fallback path sets `sourceLine_` from the call it is evaluating
+  (`evalState.forcedLine`), not from a running count. A block that fails to eval
+  must not shift the line of the next one.
 
 If you need to know where something is in a model file, ask this scan. Adding
 another regex re-opens the same hole.

--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -13,7 +13,7 @@ The LSP boots the FOAM runtime via `pmake` (same as `build.sh`), loading all mod
 ### Core
 | File | Purpose | Key Functions |
 |---|---|---|
-| `FileModelCache.js` | Eval-intercept model extraction + caching | `getModels()`, `getModelAt()`, `parseFileModels()` |
+| `FileModelCache.js` | Eval-intercept model extraction + caching | `getModels()`, `getModelAt()`, `parseFileModels()`. `sourceLine_` on each model comes from `FileClassifier.significantCalls()` |
 | `FoamIndex.js` | Query layer over FOAM registry | `getAllClassIds()`, `getProperties()`, `getFilePath()`, `getClassLine()`, `getSymbolPosition()`, `resolveSymbol()`, `buildFileIndex()` |
 | `FoamClassGrammar.js` | Grammar parser for completion `sug()` only | Skip-and-match pattern, dynamic `sug()` from registry |
 | `CursorAnalyzer.js` | Shared text/position utilities + regex fallback | `offsetToPosition()`, `resolveClassId()`, `parseRequires()`, `findCreateContext()` |
@@ -21,7 +21,7 @@ The LSP boots the FOAM runtime via `pmake` (same as `build.sh`), loading all mod
 | `JrlLoader.js` | Load and parse .jrl (journal) files containing FOAM FObject records | `loadString()`, `filterByClass()` |
 | `JrlGrammar.js` | Position-harvesting grammar for .jrl files (entry heads, embedded class refs, triple-string spans) | `collectJrlPositions()` |
 | `JournalEntryIndex.js` | Query-driven journal lookup: service name / model-entry id → journal file + line. Service lookups touch only services.jrl; journals over maxFileSize skipped; raw-text pre-gate skips parsing non-matching files; per-entry eval isolates malformed entries; per-file parses cached by mtime+size; invalidated on .jrl save | `getServiceLocations()`, `getEntryLocations()`, `invalidate()` |
-| `FileClassifier.js` | The ONE answer to "what kind of file is this" — `'pom'`/`'class'`/`'jrl'`/`'other'` | `classify(uri, text)`. `.jrl` and `pom.js` are decided by FILENAME; everything else by PARSE — the first significant `foam.UPPERCASE(` call, where significant means outside comments and string literals. Both the server dispatch and `DiagnosticsHandler` route through one shared instance, which is also what makes its per-URI memo effective |
+| `FileClassifier.js` | The ONE answer to "what kind of file is this", and the ONE scan for where a file's `foam.<X>(` calls are | `classify(uri, text)`. `.jrl` and `pom.js` are decided by FILENAME; everything else by PARSE — the first significant `foam.UPPERCASE(` call, where significant means outside comments and string literals. Both the server dispatch and `DiagnosticsHandler` route through one shared instance, which is also what makes its per-URI memo effective. `significantCalls(text)` returns every such call as `{ name, offset, line }` — see "Model positions" below |
 | `server.js` | JSON-RPC main loop | Message dispatch, handler creation, helper functions |
 | `lsp-start.js` | Entry point | Console redirect, buildlib globals, pmake invocation |
 | `LSPMaker.js` | Build Maker for pmake | Sets flags, builds file index, starts server |
@@ -92,6 +92,27 @@ so the LSP's reindexFile on save keeps them coherent.
 3. `eval(text)` with this context — JS executes the file, calls our overrides
 4. SyntaxError fallback: bracket-matching extracts individual blocks, evals each separately
 5. Returns array of raw model objects with all fields: `package`, `name`, `extends`, `requires`, `properties`, `javaImports`, etc.
+
+### Model positions: one scan, never a second regex
+
+A file's models are located by `FileClassifier.significantCalls(text)` — every
+`foam.<X>(` written outside comments and string literals, with its offset and
+line. Two things read it:
+
+- `FileModelCache` sets each model's `sourceLine_` from it (where the model STARTS).
+- `DiagnosticsHandler.validateExpressions_` takes the next call's offset as
+  where the model ENDS.
+
+Both used to run their own `foam\.[A-Z]...\(` regex over the source, and a
+regex cannot tell a real call from one written in a doc comment or a test
+fixture string. `src/foam/lang/Proxy.js` has 4 real calls and 6 regex matches;
+`Enum.js` has 6 and 9. The failure was silent in the worst way: a model whose
+text was cut short at a comment simply stopped being validated, so a genuinely
+wrong `expression:` argument produced no diagnostic at all rather than a
+degraded one.
+
+If you need to know where something is in a model file, ask this scan. Adding
+another regex re-opens the same hole.
 
 ### Interfaces
 - FOAM interfaces (`foam.INTERFACE`) define properties/methods

--- a/tools/lsp/FileClassifier.js
+++ b/tools/lsp/FileClassifier.js
@@ -104,6 +104,14 @@ foam.CLASS({
         than tracked with an LRU: the working set is the open editor tabs, and
         a rebuild costs one scan.`,
       factory: function() { return {}; }
+    },
+    {
+      name: 'callsMemo_',
+      documentation: `The last significantCalls() answer and the text it came
+        from. A caller asking where the models in a file start asks once per
+        model, and the scan is over the whole file; one entry covers that loop
+        because a file is processed start to finish before the next one.`,
+      value: null
     }
   ],
 
@@ -146,22 +154,59 @@ foam.CLASS({
       return !! uri && ( uri === 'pom.js' || uri.endsWith('/pom.js') );
     },
 
-    function firstSignificantCall_(text) {
+    function significantCalls(text) {
       /**
-       * Scan for the first foam.NAME( call outside comments and strings;
-       * NAME back, or null. The cursor only stops at characters that can
-       * open something interesting — '/', a quote, or 'f' — everything
-       * else advances without a parser attempt, which is what keeps this
-       * near the substring scan's cost instead of the full parse's.
+       * Every foam.NAME( call in `text` that sits outside comments and string
+       * literals, in source order: { name, offset, line }.
+       *
+       * This is the same walk classify() runs, just not stopped at the first
+       * hit. Anything that needs to know where a file's models START or END
+       * asks here, so no caller has to re-scan the source with a regex of its
+       * own — a regex sees the `foam.CLASS(` in a doc comment and in a test
+       * fixture string exactly as it sees the file's own call.
+       */
+      if ( ! text ) return [];
+      if ( this.callsMemo_ && this.callsMemo_.text === text ) return this.callsMemo_.calls;
+
+      var calls = this.scanCalls_(text, false);
+
+      // Line numbers in one pass over the text, not one pass per call.
+      var line = 0;
+      var ci   = 0;
+      for ( var i = 0 ; i < text.length && ci < calls.length ; i++ ) {
+        while ( ci < calls.length && calls[ci].offset === i ) calls[ci++].line = line;
+        if ( text.charCodeAt(i) === 10 ) line++;
+      }
+      while ( ci < calls.length ) calls[ci++].line = line;
+
+      this.callsMemo_ = { text: text, calls: calls };
+      return calls;
+    },
+
+    function firstSignificantCall_(text) {
+      /** Name of the first significant foam.NAME( call, or null. */
+      var calls = this.scanCalls_(text, true);
+      return calls.length ? calls[0].name : null;
+    },
+
+    function scanCalls_(text, stopAtFirst) {
+      /**
+       * Walk `text` collecting { name, offset } for each foam.NAME( call
+       * outside comments and strings. The cursor only stops at characters
+       * that can open something interesting — '/', a quote, or 'f' —
+       * everything else advances without a parser attempt, which is what
+       * keeps this near the substring scan's cost instead of the full
+       * parse's. `line` is filled in by significantCalls().
        */
       var skips    = this.parsers_.skips;
       var callName = this.parsers_.callName;
       var len      = text.length;
       var pos      = 0;
+      var calls    = [];
 
       while ( pos < len ) {
         var c = text.charCodeAt(pos);
-        if ( c === 47 /* / */ || c === 39 /* ' */ || c === 34 /* " */ || c === 96 /* \` */ ) {
+        if ( c === 47 /* / */ || c === 39 /* ' */ || c === 34 /* " */ || c === 96 /* ` */ ) {
           var advanced = false;
           for ( var i = 0 ; i < skips.length ; i++ ) {
             var ps = skips[i].parse(this.streamAt_(text, pos));
@@ -172,11 +217,16 @@ foam.CLASS({
         }
         if ( c === 102 /* f */ && text.startsWith('foam.', pos) ) {
           var res = callName.parse(this.streamAt_(text, pos));
-          if ( res && res.value ) return res.value;
+          if ( res && res.value ) {
+            calls.push({ name: res.value, offset: pos, line: 0 });
+            if ( stopAtFirst ) return calls;
+            pos = res.pos;
+            continue;
+          }
         }
         pos++;
       }
-      return null;
+      return calls;
     },
 
     function streamAt_(text, pos) {

--- a/tools/lsp/FileModelCache.js
+++ b/tools/lsp/FileModelCache.js
@@ -11,7 +11,8 @@ foam.CLASS({
   documentation: 'Eval-intercept cache for FOAM model files. Captures foam.CLASS/ENUM/INTERFACE objects directly by executing the file with overridden foam.CLASS.',
 
   requires: [
-    'foam.parse.lsp.CursorAnalyzer'
+    'foam.parse.lsp.CursorAnalyzer',
+    'foam.parse.lsp.FileClassifier'
   ],
 
   properties: [
@@ -22,6 +23,13 @@ foam.CLASS({
     {
       name: 'analyzer_',
       factory: function() { return this.CursorAnalyzer.create(); }
+    },
+    {
+      name: 'classifier_',
+      documentation: `Supplies the significant-foam-call scan that sourceLine_
+        is read from. Its own instance rather than the server's: the two share
+        no cached answer, only the scan.`,
+      factory: function() { return this.FileClassifier.create(); }
     }
   ],
 
@@ -39,7 +47,7 @@ foam.CLASS({
     function getModelAt(uri, text, line) {
       /**
        * Returns the model whose source range contains the given line.
-       * Uses sourceLine_ (set by findCallLine) to find the last model
+       * Uses sourceLine_ (set from the significant-call scan) to find the last model
        * that starts at or before the given line. Essential for multi-class
        * files where we need to know which model the cursor is inside.
        */
@@ -178,8 +186,23 @@ foam.CLASS({
       var models = [];
       var modelCount = 0;
 
+      // Where each model starts, taken from the significant-call scan — calls
+      // written inside comments and string literals are not in it. Counting
+      // raw foam.<X>( matches instead put every model after a doc comment
+      // that mentions foam.CLASS( onto the comment's line.
+      var calls      = this.classifier_.significantCalls(text);
+      var classLines = [];
+      var libLines   = [];
+      for ( var ci = 0 ; ci < calls.length ; ci++ ) {
+        var callName = calls[ci].name;
+        // POM and SCRIPT never enter `models` (their overrides are no-ops) and
+        // LIB is counted separately, so neither may shift the class index.
+        if ( callName === 'LIB' ) libLines.push(calls[ci].line);
+        else if ( callName !== 'POM' && callName !== 'SCRIPT' ) classLines.push(calls[ci].line);
+      }
+
       var captureClass = function(m) {
-        m.sourceLine_ = findCallLine(text, modelCount);
+        m.sourceLine_ = classLines[modelCount] || 0;
         m.type_ = m.type_ || 'CLASS';
         models.push(m);
         modelCount++;
@@ -221,7 +244,11 @@ foam.CLASS({
         LIB:    function(m) {
           if ( ! m || ! m.name ) return;
           m.type_ = 'LIB';
-          m.sourceLine_ = findLibCallLine(text, models);
+          var libIndex = 0;
+          for ( var li = 0 ; li < models.length ; li++ ) {
+            if ( models[li].type_ === 'LIB' ) libIndex++;
+          }
+          m.sourceLine_ = libLines[libIndex] || 0;
           models.push(m);
         }
       };
@@ -298,64 +325,3 @@ foam.CLASS({
   ]
 });
 
-function findCallLine(text, index) {
-  /**
-   * Find the line number of the Nth foam.<X>(...) call in text.
-   *
-   * WHY: Multi-class files (e.g., Element2.js) contain multiple foam.CLASS
-   * calls. When the user's cursor is on line 50, getModelAt() needs to know
-   * which model that line belongs to. sourceLine_ on each model enables
-   * this lookup. Also needed by SymbolHandler for accurate outline positions
-   * and DiagnosticsHandler for correct error squiggle placement.
-   *
-   * Generic on the call name (CLASS/ENUM/INTERFACE/RELATIONSHIP/FSM/...) so
-   * model-position tracking works for any foam.<X> extension. POM/SCRIPT are
-   * matched too but never appear in `models` (their overrides are no-ops).
-   *
-   * For single-class files (99% of cases), sourceLine_ is always 0 and
-   * getModelAt() returns the only model regardless. The cost is negligible.
-   *
-   * Skips POM/SCRIPT/LIB — those don't enter the regular `models` array via
-   * captureClass(), so counting them would misalign the index.
-   */
-  var regex = /foam\.(?!POM\b|SCRIPT\b|LIB\b)[A-Z][A-Z0-9_]*\s*\(/g;
-  var match;
-  var count = 0;
-  while ( ( match = regex.exec(text) ) !== null ) {
-    if ( count === index ) {
-      var line = 0;
-      for ( var i = 0 ; i < match.index ; i++ ) {
-        if ( text[i] === '\n' ) line++;
-      }
-      return line;
-    }
-    count++;
-  }
-  return 0;
-}
-
-function findLibCallLine(text, models) {
-  /**
-   * Find the line number of the Nth foam.LIB call in text, where N is the
-   * count of LIBs already captured.
-   * TODO: migrate to FoamClassGrammar so LIB positions come from the parser.
-   */
-  var libIndex = 0;
-  for ( var i = 0 ; i < models.length ; i++ ) {
-    if ( models[i].type_ === 'LIB' ) libIndex++;
-  }
-  var regex = /foam\.LIB\s*\(/g;
-  var match;
-  var count = 0;
-  while ( ( match = regex.exec(text) ) !== null ) {
-    if ( count === libIndex ) {
-      var line = 0;
-      for ( var i = 0 ; i < match.index ; i++ ) {
-        if ( text[i] === '\n' ) line++;
-      }
-      return line;
-    }
-    count++;
-  }
-  return 0;
-}

--- a/tools/lsp/FileModelCache.js
+++ b/tools/lsp/FileModelCache.js
@@ -201,8 +201,18 @@ foam.CLASS({
         else if ( callName !== 'POM' && callName !== 'SCRIPT' ) classLines.push(calls[ci].line);
       }
 
+      // The SyntaxError fallback evaluates one call at a time and knows exactly
+      // which call it is on, so it sets the line directly. A running count is
+      // wrong there twice over: a block that fails to eval does not advance it,
+      // and the fallback used to find its blocks with a regex of its own, which
+      // happily evaluated a call written inside a comment and shifted every
+      // real model behind it.
+      var evalState = { forcedLine: -1 };
+
       var captureClass = function(m) {
-        m.sourceLine_ = classLines[modelCount] || 0;
+        m.sourceLine_ = evalState.forcedLine >= 0
+          ? evalState.forcedLine
+          : ( classLines[modelCount] || 0 );
         m.type_ = m.type_ || 'CLASS';
         models.push(m);
         modelCount++;
@@ -248,7 +258,9 @@ foam.CLASS({
           for ( var li = 0 ; li < models.length ; li++ ) {
             if ( models[li].type_ === 'LIB' ) libIndex++;
           }
-          m.sourceLine_ = libLines[libIndex] || 0;
+          m.sourceLine_ = evalState.forcedLine >= 0
+            ? evalState.forcedLine
+            : ( libLines[libIndex] || 0 );
           models.push(m);
         }
       };
@@ -277,7 +289,7 @@ foam.CLASS({
         // Fall back to extracting individual foam.<X>(...) blocks and eval each.
         if ( e instanceof SyntaxError && models.length === 0 ) {
           modelCount = 0;
-          this.evalIndividualBlocks_(text, context, models);
+          this.evalIndividualBlocks_(text, context, calls, evalState);
         }
         // RuntimeError after some models captured — partial results are fine
       }
@@ -285,19 +297,22 @@ foam.CLASS({
       return models;
     },
 
-    function evalIndividualBlocks_(text, context, models) {
+    function evalIndividualBlocks_(text, context, calls, evalState) {
       /**
-       * Fallback for SyntaxError: extract individual foam.<X>(...) blocks
-       * using bracket matching and eval each separately. Generic on the call
-       * name so foam.FSM/foam.RELATIONSHIP/etc. all participate.
+       * Fallback for SyntaxError: bracket-match each foam.<X>(...) block and
+       * eval it on its own. Generic on the call name so foam.FSM /
+       * foam.RELATIONSHIP / etc. all participate.
+       *
+       * Blocks come from the significant-call scan, not a regex of this
+       * function's own. A regex sees a `foam.CLASS(` written in a comment as a
+       * block, evaluates it into a real model, and every model behind it then
+       * answers with the line of the one in front.
        */
-      var regex = /foam\.[A-Z][A-Z0-9_]*\s*\(/g;
-      var match;
-      while ( ( match = regex.exec(text) ) !== null ) {
-        var start = match.index;
+      for ( var ci = 0 ; ci < calls.length ; ci++ ) {
+        var start = calls[ci].offset;
         var depth = 0;
         var end = -1;
-        for ( var i = start + match[0].length ; i < text.length ; i++ ) {
+        for ( var i = text.indexOf('(', start) + 1 ; i < text.length ; i++ ) {
           var ch = text[i];
           if ( ch === '(' || ch === '{' || ch === '[' ) depth++;
           else if ( ch === ')' || ch === '}' || ch === ']' ) {
@@ -314,13 +329,14 @@ foam.CLASS({
           }
         }
         if ( end === -1 ) continue;
-        var block = text.substring(start, end);
+        evalState.forcedLine = calls[ci].line;
         try {
-          with ( context ) { eval(block); }
+          with ( context ) { eval(text.substring(start, end)); }
         } catch (e2) {
           // This block is incomplete/broken — skip it
         }
       }
+      evalState.forcedLine = -1;
     }
   ]
 });

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -825,17 +825,30 @@ foam.CLASS({
        * enclosing scope and validates against that scope's properties.
        */
       var classId = this.cache.getClassId(m);
-      var modelOffset = m.sourceLine_ ? this.analyzer.positionToOffset(text, { line: m.sourceLine_, character: 0 }) : 0;
 
-      // Determine end of this model's text: the next significant foam call,
-      // from the same scan that decides what kind of file this is. A raw regex
-      // here matched the `foam.CLASS(` in a doc comment, cut the model off at
-      // that line, and every expression below it stopped being checked at all
-      // — the diagnostic did not degrade, it disappeared.
+      // Where this model's text starts and ends, both taken from the same scan
+      // that decides what kind of file this is. Two things used a raw regex
+      // over the source here, and a regex cannot tell a real call from one
+      // written in a comment: the end came from re-scanning, so a
+      // `// see foam.CLASS( for the pattern` cut the model off at that line and
+      // every expression below it stopped being checked at all.
+      //
+      // The start used to be the start of the model's LINE, which is not the
+      // same as the start of its call. One space of indentation put the model's
+      // own call after its start offset, so the model matched as its own next
+      // model and its text became the indentation. Matching the call by line
+      // gives the offset directly. No call on the model's line — which should
+      // not happen — falls back to the whole file: a noisy diagnostic rather
+      // than a silently missing one.
       var calls = this.fileClassifier.significantCalls(text);
-      var modelEnd = text.length;
+      var modelOffset = 0;
+      var modelEnd    = text.length;
       for ( var ci = 0 ; ci < calls.length ; ci++ ) {
-        if ( calls[ci].offset > modelOffset ) { modelEnd = calls[ci].offset; break; }
+        if ( calls[ci].line === m.sourceLine_ ) {
+          modelOffset = calls[ci].offset;
+          modelEnd    = ci + 1 < calls.length ? calls[ci + 1].offset : text.length;
+          break;
+        }
       }
       var modelText = text.substring(modelOffset, modelEnd);
 

--- a/tools/lsp/handlers/DiagnosticsHandler.js
+++ b/tools/lsp/handlers/DiagnosticsHandler.js
@@ -827,11 +827,16 @@ foam.CLASS({
       var classId = this.cache.getClassId(m);
       var modelOffset = m.sourceLine_ ? this.analyzer.positionToOffset(text, { line: m.sourceLine_, character: 0 }) : 0;
 
-      // Determine end of this model's text
-      var nextModelRegex = new RegExp(this.analyzer.FOAM_CALL_REGEX.source, 'g');
-      nextModelRegex.lastIndex = modelOffset + 1;
-      var nextMatch = nextModelRegex.exec(text);
-      var modelEnd = nextMatch ? nextMatch.index : text.length;
+      // Determine end of this model's text: the next significant foam call,
+      // from the same scan that decides what kind of file this is. A raw regex
+      // here matched the `foam.CLASS(` in a doc comment, cut the model off at
+      // that line, and every expression below it stopped being checked at all
+      // — the diagnostic did not degrade, it disappeared.
+      var calls = this.fileClassifier.significantCalls(text);
+      var modelEnd = text.length;
+      for ( var ci = 0 ; ci < calls.length ; ci++ ) {
+        if ( calls[ci].offset > modelOffset ) { modelEnd = calls[ci].offset; break; }
+      }
       var modelText = text.substring(modelOffset, modelEnd);
 
       // Build property scopes: outer model + each inner class

--- a/tools/tests/lsp/classify.js
+++ b/tools/tests/lsp/classify.js
@@ -84,3 +84,34 @@ test(c.classify(CACHED_URI, t1) === 'other' && c.classify(CACHED_URI, t1) === 'o
   'the same uri+text answers the same twice (cache hit path)');
 test(c.classify(CACHED_URI, 'foam.CLASS({ name: "New" });') === 'class',
   'new text for a cached uri is re-classified, not served stale');
+
+// === significantCalls: every call, in order, with its line ===
+// classify() only needs the first call. Model-position lookups need them all,
+// which is why this is one scan and not a second regex somewhere else.
+
+var callsText = [
+  "// a header that mentions foam.CLASS( in prose",
+  "foam.CLASS({",
+  "  name: 'First',",
+  "  properties: [ { name: 'sample', value: 'foam.ENUM(' } ]",
+  "});",
+  "",
+  "/* foam.INTERFACE( inside a block comment */",
+  "foam.ENUM({ name: 'Second' });",
+  "",
+  "foam.LIB({ name: 'third' });"
+].join('\n');
+
+var cc = foam.parse.lsp.FileClassifier.create();
+var found = cc.significantCalls(callsText);
+
+test(found.length === 3, 'significantCalls skips the comment and string mentions (3 real calls)');
+test(found.map(function(x) { return x.name; }).join(',') === 'CLASS,ENUM,LIB',
+  'significantCalls returns names in source order');
+test(found[0].line === 1 && found[1].line === 7 && found[2].line === 9,
+  'significantCalls reports the line each call is written on');
+test(callsText.substring(found[1].offset).indexOf('foam.ENUM(') === 0,
+  'the reported offset points at the call itself');
+test(cc.significantCalls('') .length === 0, 'significantCalls on empty text is empty');
+test(cc.significantCalls(callsText) === found,
+  'the same text is answered from the memo, not re-scanned');

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -411,6 +411,62 @@ test(boundaryMultiDiags.filter(function(d) {
 }).length === 0, 'Boundary: propA NOT flagged when a mention shifts model start lines');
 
 
+// --- The two paths a review round found still reading raw text ---
+
+// A file with a syntax error never executes, so models come from the
+// bracket-matching fallback. That fallback found its blocks with a regex of its
+// own, so a commented-out call became a real model and took the first line off
+// the list — the models behind it all answered with the line in front.
+var fallbackText = [
+  "// foam.CLASS({ package: 'ghost', name: 'Phantom' })",
+  "foam.CLASS({",
+  "  package: 'real',",
+  "  name: 'Real',",
+  "  properties: [",
+  "    { class: 'String', name: 'title' },",
+  "    { name: 'computed', expression: function(title) { return title; } },",
+  "    { name: 'bad', expression: function(nonExistent) { return 1; } }",
+  "  ]",
+  "});",
+  "var broken = ;"
+].join('\n');
+
+var fallbackModels = foam.parse.lsp.FileModelCache.create().parseFileModels(fallbackText);
+test(fallbackModels.length === 1 && fallbackModels[0].name === 'Real' && fallbackModels[0].sourceLine_ === 1,
+  'SyntaxError fallback: a commented-out call is not a model, and Real keeps line 1'
+  + ' (got ' + fallbackModels.map(function(m) { return m.name + '@' + m.sourceLine_; }).join(',') + ')');
+
+var fallbackDiags = diagHandler.handle(fallbackText, 'file:///boundary/fallback.js')
+  .filter(function(d) { return d.message.indexOf('does not exist') !== -1; });
+test(fallbackDiags.length === 1 && fallbackDiags[0].message.indexOf('nonExistent') !== -1
+  && fallbackDiags[0].message.indexOf('real.Real') !== -1,
+  'SyntaxError fallback: one diagnostic, naming the real class'
+  + ' (got ' + fallbackDiags.map(function(d) { return d.message; }).join(' / ') + ')');
+test(fallbackDiags.every(function(d) { return d.message.indexOf('Phantom') === -1; }),
+  'SyntaxError fallback: no diagnostic names a class that only exists in a comment');
+
+// A model's start offset is the start of its CALL, not of its line. One space
+// of indentation used to make the model match as its own next model, leaving
+// its text as the indentation and every expression in it unchecked.
+var indentBody = [
+  "foam.CLASS({",
+  "  package: 'ind',",
+  "  name: 'Indented',",
+  "  properties: [",
+  "    { class: 'String', name: 'title' },",
+  "    { name: 'bad', expression: function(nonExistent) { return 1; } }",
+  "  ]",
+  "})"
+].join('\n');
+
+[ 1, 2, 4 ].forEach(function(pad) {
+  var indented = new Array(pad + 1).join(' ') + indentBody;
+  var flagged = diagHandler.handle(indented, 'file:///boundary/indent' + pad + '.js')
+    .filter(function(d) { return d.message.indexOf('nonExistent') !== -1; });
+  test(flagged.length > 0,
+    'Indented model: expressions are still checked with the call at column ' + pad);
+});
+
 // === POM COMPLETIONS ===
 
 

--- a/tools/tests/lsp/diagnostics.js
+++ b/tools/tests/lsp/diagnostics.js
@@ -340,6 +340,77 @@ var propBOnA = multiWarns.filter(function(d) { return d.message.indexOf('propB')
 test(propAOnB.length === 0, 'Expression: propA NOT flagged against ModelB (multi-model scoping)');
 test(propBOnA.length === 0, 'Expression: propB NOT flagged against ModelA (multi-model scoping)');
 
+
+// --- Model boundaries: a foam.CLASS( mention must not end the model ---
+// "Where does this model's text end?" used to be answered by re-scanning the
+// source with a raw regex, so a foam.CLASS( written inside a comment or a
+// string cut the model short there and every check below the mention silently
+// stopped running. The mention is common: doc comments explain the pattern.
+
+var boundaryCommentText = [
+  "foam.CLASS({",
+  "  package: 'foam.parse.lsp.test',",
+  "  name: 'ExprParent',",
+  "  properties: [",
+  "    { class: 'String', name: 'title' },",
+  "    // see foam.CLASS( for the pattern",
+  "    { name: 'computed', expression: function(title, nonExistent) { return title; } }",
+  "  ]",
+  "})"
+].join('\n');
+var boundaryCommentDiags = diagHandler.handle(boundaryCommentText);
+test(boundaryCommentDiags.some(function(d) {
+  return d.message.indexOf('nonExistent') !== -1 && d.message.indexOf('does not exist') !== -1;
+}), 'Boundary: bad expression param still flagged below a foam.CLASS( in a comment');
+
+var boundaryStringText = [
+  "foam.CLASS({",
+  "  package: 'foam.parse.lsp.test',",
+  "  name: 'ExprParent',",
+  "  properties: [",
+  "    { class: 'String', name: 'title', value: 'foam.CLASS(' },",
+  "    { name: 'computed', expression: function(title, nonExistent) { return title; } }",
+  "  ]",
+  "})"
+].join('\n');
+var boundaryStringDiags = diagHandler.handle(boundaryStringText);
+test(boundaryStringDiags.some(function(d) {
+  return d.message.indexOf('nonExistent') !== -1 && d.message.indexOf('does not exist') !== -1;
+}), 'Boundary: bad expression param still flagged below a foam.CLASS( in a string');
+
+// A mention inside the FIRST model also used to shift every later model's
+// recorded start line onto the mention, because that line came from counting
+// raw foam.<X>( matches. ModelB then received ModelA's tail as its own text
+// and was never validated at all.
+var boundaryMultiText = [
+  "foam.CLASS({",
+  "  package: 'test',",
+  "  name: 'ModelA',",
+  "  properties: [",
+  "    { class: 'String', name: 'propA' },",
+  "    // built like foam.CLASS( is",
+  "    { name: 'computed', expression: function(propA) { return propA; } }",
+  "  ]",
+  "})",
+  "",
+  "foam.CLASS({",
+  "  package: 'test',",
+  "  name: 'ModelB',",
+  "  properties: [",
+  "    { class: 'String', name: 'propB' },",
+  "    { name: 'computed', expression: function(bogusB) { return bogusB; } }",
+  "  ]",
+  "})"
+].join('\n');
+var boundaryMultiDiags = diagHandler.handle(boundaryMultiText);
+test(boundaryMultiDiags.some(function(d) {
+  return d.message.indexOf('bogusB') !== -1 && d.message.indexOf('does not exist') !== -1;
+}), 'Boundary: second model still validated when the first mentions foam.CLASS(');
+test(boundaryMultiDiags.filter(function(d) {
+  return d.message.indexOf('propA') !== -1 && d.message.indexOf('does not exist') !== -1;
+}).length === 0, 'Boundary: propA NOT flagged when a mention shifts model start lines');
+
+
 // === POM COMPLETIONS ===
 
 


### PR DESCRIPTION
A `foam.CLASS(` written in a doc comment turned off expression validation for the rest of the model. Not degraded it — turned it off.

    // identical files, one line apart
    CLEAN        -> ["Property 'ghostProp' does not exist on probe.A"]
    WITH_COMMENT -> []

The differing line was `// see foam.CLASS( for the pattern`, sitting inside the model.

Two places asked "where are this file's foam calls?" with a raw regex, and a regex can't tell a real call from one written in a comment or a string:

- `FileModelCache` counted matches to set each model's `sourceLine_` — where a model starts.
- `DiagnosticsHandler.validateExpressions_` re-scanned for the next match — where a model ends.

`FileClassifier` already walks the text skipping comments and string literals; that's how `classify()` decides a file's kind. `significantCalls(text)` is the same walk without the stop-at-first, handing back `{ name, offset, line }`. Both callers read it now, and `findCallLine`/`findLibCallLine` are gone.

This isn't theoretical. `src/foam/lang/Proxy.js` has 4 real calls and 6 regex matches; `Enum.js` has 6 and 9. Both use `expression:`, so both had this validation off.

Each half is guarded on its own. Reverting only `DiagnosticsHandler` reds the comment and string cases; reverting only `FileModelCache` reds the two multi-model cases. Six more tests cover `significantCalls` directly in the classify category.

Suite 1718/0.

Merge order: independent. Nothing else in flight touches these files, so it can land whenever.