### PR TITLE
lsp: a property's hover type says which class it is of

### DIFF
--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -31,7 +31,7 @@ The LSP boots the FOAM runtime via `pmake` (same as `build.sh`), loading all mod
 |---|---|---|
 | `CompletionHandler.js` | `textDocument/completion` | Grammar-based + context fallback for partial values |
 | `MemberCompletionHandler.js` | (routed from completion) | `this.` members, `.create({})` properties, requires/imports |
-| `HoverHandler.js` | `textDocument/hover` | Class docs, method signatures, property types, create info |
+| `HoverHandler.js` | `textDocument/hover` | Class docs, method signatures, property types, create info. A property's type carries its `of:` target — `` `Enum<ButtonStyle>` `` — except the primitive `of:` an array class already implies (`StringArray of: 'String'`) |
 | `DefinitionHandler.js` | `textDocument/definition` | File index lookup for class → file path |
 | `DiagnosticsHandler.js` | `textDocument/{publishDiagnostics,diagnostic}` | Push + pull diagnostic models |
 | `JavaBlockValidator.js` | (called by Diagnostics) | Java import validation, getter/setter validation via model fields |

--- a/tools/lsp/handlers/HoverHandler.js
+++ b/tools/lsp/handlers/HoverHandler.js
@@ -743,8 +743,39 @@ foam.CLASS({
     },
 
     function propTypeName_(p) {
-      /** Short, readable property type name. */
-      return p.cls_ && p.cls_.model_ ? p.cls_.model_.name : 'Property';
+      /**
+       * Short, readable property type name, carrying the `of:` target when the
+       * property has one: `Enum<ButtonStyle>`, `FObjectProperty<Glyph>`,
+       * `Reference<User>`.
+       *
+       * The bare class name alone is the one thing about such a property
+       * nobody needs told — every enum property reads `Enum`, and which enum
+       * it is was the actual question. Rendered inside a code span because
+       * `<Name>` in a markdown table cell is read as an HTML tag and dropped.
+       */
+      var name = p.cls_ && p.cls_.model_ ? p.cls_.model_.name : 'Property';
+      var of   = this.ofName_(p);
+      return '`' + ( of ? name + '<' + of + '>' : name ) + '`';
+    },
+
+    function ofName_(p) {
+      /**
+       * Short name of a property's `of:` target, or '' when there is nothing
+       * worth printing.
+       *
+       * `of` arrives either as a resolved class (an object with an id) or as
+       * the raw string from the model. The raw strings are of two kinds: a
+       * class id, and a primitive — `StringArray` carries `of: 'String'` and
+       * `IntegerArray` carries `of: 'Int'`, which say nothing the type name
+       * has not already said. A dot is what separates the two (185 of the
+       * repo's `of:` strings are the primitive kind, and all of them are
+       * undotted).
+       */
+      var of = p.of;
+      if ( ! of ) return '';
+      if ( typeof of !== 'string' ) return of.id ? of.id.split('.').pop() : '';
+      if ( of.indexOf('.') === -1 ) return '';
+      return of.split('.').pop();
     },
 
     function briefDoc_(doc) {

--- a/tools/tests/lsp/hover.js
+++ b/tools/tests/lsp/hover.js
@@ -125,6 +125,47 @@ foam.CLASS({
 var singleImplHover = hoverHandler.buildClassHover('foam.parse.lsp.test.SingleImplTest');
 test(singleImplHover && singleImplHover.contents.value.indexOf('implements foam.parse.lsp.test.IFoo') !== -1, 'Sig format: single implement inline');
 
+// ========== Property types carry their of: target ==========
+section('Hover Property Of');
+
+foam.ENUM({
+  package: 'foam.parse.lsp.test',
+  name: 'OfEnum',
+  values: [ { name: 'ONE' }, { name: 'TWO' } ]
+});
+foam.CLASS({ package: 'foam.parse.lsp.test', name: 'OfTarget' });
+foam.CLASS({
+  package: 'foam.parse.lsp.test',
+  name: 'OfCarrier',
+  properties: [
+    { class: 'Enum', of: 'foam.parse.lsp.test.OfEnum', name: 'mood' },
+    { class: 'FObjectProperty', of: 'foam.parse.lsp.test.OfTarget', name: 'target' },
+    { class: 'StringArray', name: 'tags' },
+    { class: 'String', name: 'label' }
+  ]
+});
+
+var ofHover = hoverHandler.buildClassHover('foam.parse.lsp.test.OfCarrier');
+var ofMd = ofHover ? ofHover.contents.value : '';
+
+test(ofMd.indexOf('Enum<OfEnum>') !== -1,
+  'Hover: an Enum property names the enum it is of, not just "Enum"');
+test(ofMd.indexOf('FObjectProperty<OfTarget>') !== -1,
+  'Hover: an FObjectProperty names the class it holds');
+test(ofMd.indexOf('StringArray<String>') === -1 && ofMd.indexOf('`StringArray`') !== -1,
+  'Hover: StringArray drops its redundant of: String');
+test(ofMd.indexOf('`String`') !== -1,
+  'Hover: a property with no of: still prints its bare type');
+
+// The case the bench asks about: buttonStyle is declared in a refinement in
+// ActionView.js as `class: 'Enum', of: 'foam.u2.ButtonStyle'`.
+if ( index.classExists('foam.lang.Action') ) {
+  var actionHover = hoverHandler.buildClassHover('foam.lang.Action');
+  var actionMd = actionHover ? actionHover.contents.value : '';
+  test(actionMd.indexOf('Enum<ButtonStyle>') !== -1,
+    'Hover: Action.buttonStyle reads Enum<ButtonStyle>, the refinement\'s of:');
+}
+
 // === JRL LOADER ===
 
 


### PR DESCRIPTION
Hovering a class shows a property table. Every enum property in it read `Enum`, and every FObject property read `FObjectProperty` — the property class, with the `of:` target dropped.

That's the half nobody needs. Hover `foam.lang.Action` and `buttonStyle` says `Enum`, when `ActionView.js:25-27` declares it `class: 'Enum', of: 'foam.u2.ButtonStyle'`. Which enum it is was the question.

Now the cell reads `Enum<ButtonStyle>`. It's inside a code span because `<ButtonStyle>` in a plain table cell gets read as an HTML tag and dropped.

One exception, and it's the reason for the extra helper. `of:` arrives either as a resolved class or as the raw model string, and the raw strings come in two kinds: a class id, and a primitive. `StringArray` carries `of: 'String'` and `IntegerArray` carries `of: 'Int'`. `StringArray<String>` says nothing `StringArray` didn't. A dot separates the two kinds — I tallied every `of:` in the index and all 185 primitive ones are undotted, all the class ones aren't.

Five tests, all five red against the old `propTypeName_`. One of them is the bench's `hover-refined` question pinned directly: `foam.lang.Action` must read `Enum<ButtonStyle>`.

Suite 1713/0.

Merge order: independent. Only file touched is `HoverHandler.js`, so it doesn't collide with #5405 or with the FoamIndex work behind it.