### PR TITLE
lsp: a member declared in a refinement resolves to the refinement

### DIFF
--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -93,6 +93,39 @@ so the LSP's reindexFile on save keeps them coherent.
 4. SyntaxError fallback: bracket-matching extracts individual blocks, evals each separately
 5. Returns array of raw model objects with all fields: `package`, `name`, `extends`, `requires`, `properties`, `javaImports`, etc.
 
+### Refinements declare members, and they live in another file
+
+A refined class keeps its OWN file as its definition site — `fileIndex_` only
+falls back to a refining file when nothing else claims the id. So a member that
+only a refinement declares has no entry in the class's own position map, and
+`getSymbolPosition` used to fall back to the class's declaration line: every one
+of them landed at the top of the wrong file.
+
+`refinementIndex_` (built next to `fileIndex_`) maps a refined class id to every
+file refining it, each with the refining model's own `[line, endLine)` range.
+`refinementMemberPosition_` walks those files' position maps and accepts a hit
+only inside the range. Two things make the range necessary:
+
+- A refinement usually shares a file with the class that motivated it, and both
+  can declare the same member name.
+- `collectAxiomPositions` keeps ONE record per name per file for
+  single-occurrence kinds. `FromCsvRefines.js` declares `fromCSV` six times, for
+  six classes. The record now carries `also` — the later sightings — so a caller
+  that knows which model it means can pick. Readers wanting just a position see
+  the same first record as before.
+
+A refinement's `name:` is optional; the index's name guard runs AFTER the
+`refines` branch for that reason.
+
+Cost: a lookup that misses parses each refining file once, mtime-cached.
+`foam.lang.Property` is the worst case in this repo at 26 refining files —
+181ms cold, 0ms warm, 0.11ms per warm hit.
+
+Known residue (not this machinery): members whose refining file never reaches
+the grammar's whole-file parse. Concentrated in `Element2.js`,
+`java/refinements.js`, `u2/view/TableCellFormatter.js` and
+`swift/refines/Method.js`.
+
 ### Interfaces
 - FOAM interfaces (`foam.INTERFACE`) define properties/methods
 - Implementing classes get interface properties ONLY if explicitly declared in JS

--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -117,6 +117,16 @@ only inside the range. Two things make the range necessary:
 A refinement's `name:` is optional; the index's name guard runs AFTER the
 `refines` branch for that reason.
 
+`getSymbolPosition` returns a `uri` along with the line, and that uri is
+authoritative — a member's declaration is not always in its class's file. Every
+caller must use it. `WorkspaceSymbolHandler` and `CallHierarchyHandler` used to
+keep the class's own path and take only the line, which put a line number in a
+file that had no such line: 34 workspace symbols pointed past the end of the
+file they named, 21 of them through the Java path long before refinements were
+indexed. `DefinitionHandler.buildLocationAtProperty` takes the class id for the
+same reason — when the class's own file does not declare the property, it asks
+the index instead of landing on line 0.
+
 Cost: a lookup that misses parses each refining file once, mtime-cached.
 `foam.lang.Property` is the worst case in this repo at 26 refining files —
 181ms cold, 0ms warm, 0.11ms per warm hit.

--- a/tools/lsp/FoamClassGrammar.js
+++ b/tools/lsp/FoamClassGrammar.js
@@ -89,9 +89,17 @@ foam.CLASS({
       };
       // Kinds that allow multiple occurrences per name. Single-occurrence
       // kinds (message, value, property, method, pomFileName) keep their
-      // first sighting only — a model defines each name once. Class
+      // first sighting as the record — a model defines each name once. Class
       // references DO repeat (requires + extends + ofs + raw strings + …),
       // so collect every position.
+      //
+      // "Once" is true per MODEL, and this map covers a FILE. A file of
+      // refinements declares the same member once per refinement:
+      // src/foam/core/reflow/FromCsvRefines.js declares `fromCSV` six times,
+      // for six different classes. So a single-occurrence record also carries
+      // `also` — the later sightings — which a caller that knows which model
+      // it is asking about can pick from. Readers that just want a position
+      // see the same first record they always did.
       var MULTI = { classRef: true, comment: true, documentation: true,
         instCall: true, instCreateReceiver: true, instTagClass: true,
         instClassRef: true, instKey: true, instValue: true, memberRef: true,
@@ -133,8 +141,20 @@ foam.CLASS({
               if ( MULTI[m.kind] ) {
                 var arr = map[m.kind][name] || (map[m.kind][name] = []);
                 arr.push(rec);
-              } else if ( ! map[m.kind][name] ) {
-                map[m.kind][name] = rec;
+              } else {
+                var first = map[m.kind][name];
+                if ( ! first ) {
+                  map[m.kind][name] = rec;
+                } else if ( first.startPos !== startPos ) {
+                  // Backtracking re-runs apply at the same offset, so the same
+                  // sighting can arrive more than once — dedupe on startPos.
+                  if ( ! first.also ) first.also = [];
+                  var dup = false;
+                  for ( var a = 0 ; a < first.also.length ; a++ ) {
+                    if ( first.also[a].startPos === startPos ) { dup = true; break; }
+                  }
+                  if ( ! dup ) first.also.push(rec);
+                }
               }
             }
           }

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -35,6 +35,10 @@ foam.CLASS({
     {
       name: 'filePosCache_',
       documentation: 'filePath → grammar.collectAxiomPositions(content) map. Lazy, per-file; lets getSymbolPosition resolve a member line with one parse per file. Dropped on reindex via invalidateSymbolIndex_.'
+    },
+    {
+      name: 'refinementIndex_',
+      documentation: 'Refined class ID → array of { path, line, endLine } — every file that refines that class, with the refining model\'s own line range. Built alongside fileIndex_. A refined class keeps its own file as its definition site, so without this a member DECLARED in a refinement resolves back to the refined class\'s declaration line instead of to the line that declares it.'
     }
   ],
 
@@ -744,6 +748,7 @@ foam.CLASS({
        */
       this.fileIndex_ = {};
       this.libIndex_ = {};
+      this.refinementIndex_ = {};
       var path_ = require('path');
       var fs_ = require('fs');
 
@@ -795,11 +800,12 @@ foam.CLASS({
         var content = fs_.readFileSync(filePath, 'utf8');
         if ( ! this.libIndex_ ) this.libIndex_ = {};
         var models = foam.parse.lsp.FileModelCache.create().parseFileModels(content);
+        if ( ! this.refinementIndex_ ) this.refinementIndex_ = {};
         for ( var i = 0 ; i < models.length ; i++ ) {
           var m = models[i];
-          if ( ! m.name ) continue;
 
           if ( m.type_ === 'LIB' ) {
+            if ( ! m.name ) continue;
             this.libIndex_[m.name] = {
               path:      filePath,
               line:      m.sourceLine_ || 0,
@@ -809,9 +815,35 @@ foam.CLASS({
             continue;
           }
 
-          // Index the model's own identity (package + name). Refinements also
-          // index under their target class so lookups of the refined type find
-          // the refining file.
+          // A refinement's own `name:` is optional — `foam.CLASS({ refines:
+          // 'x.Y', properties: [...] })` is legal, and the name guard used to
+          // run before this, so a nameless one was dropped along with every
+          // member it declares. Rare (two files across foam3 and the app repo)
+          // but the guard was in the wrong place, not doing a job.
+          if ( m.refines ) {
+            var next    = models[i + 1];
+            var endLine = next && typeof next.sourceLine_ === 'number'
+              ? next.sourceLine_ : Infinity;
+            var refs = this.refinementIndex_[m.refines];
+            if ( ! refs ) refs = this.refinementIndex_[m.refines] = [];
+            refs.push({ path: filePath, line: m.sourceLine_ || 0, endLine: endLine });
+
+            // The refined class keeps its own file as its definition site;
+            // this only fills in when nothing else claims the id.
+            if ( ! this.fileIndex_[m.refines] ) {
+              this.fileIndex_[m.refines] = {
+                path:         filePath,
+                line:         m.sourceLine_ || 0,
+                flags:        fileFlags,
+                pomFile:      pomFile,
+                pomEntryName: pomEntryName
+              };
+            }
+          }
+
+          if ( ! m.name ) continue;
+
+          // Index the model's own identity (package + name).
           var ownId = m.package ? m.package + '.' + m.name : m.name;
           if ( ownId ) this.fileIndex_[ownId] = {
             path:         filePath,
@@ -820,15 +852,6 @@ foam.CLASS({
             pomFile:      pomFile,
             pomEntryName: pomEntryName
           };
-          if ( m.refines && ! this.fileIndex_[m.refines] ) {
-            this.fileIndex_[m.refines] = {
-              path:         filePath,
-              line:         m.sourceLine_ || 0,
-              flags:        fileFlags,
-              pomFile:      pomFile,
-              pomEntryName: pomEntryName
-            };
-          }
         }
       } catch ( e ) {}
     },
@@ -1089,27 +1112,77 @@ foam.CLASS({
       var character = 0;
 
       if ( memberName && filePath ) {
-        var posMap = this.getFilePosMap_(filePath);
-        var rec = null;
-        if ( posMap ) {
-          // 7=Property, 6=Method, 22=EnumMember, 24=Action/Listener (method-ish).
-          var bucket =
-            kind === 7  ? posMap.property :
-            kind === 22 ? posMap.value    :
-            posMap.method;
-          rec = bucket && bucket[memberName];
-          // 24 (Action/Listener) is not msg-tagged; fall back to method bucket.
-          if ( ! rec && kind === 24 && posMap.method ) rec = posMap.method[memberName];
-        }
+        var rec = this.memberBucket_(this.getFilePosMap_(filePath), memberName, kind);
         if ( rec ) {
           line = rec.line; character = rec.col || 0;
-        } else if ( kind === 6 ) {
-          // Method absent from the .js model — resolve to its Java impl.
-          var jp = this.getJavaMemberPosition_(classId, memberName);
-          if ( jp ) return jp;
+        } else {
+          // Not in the class's own file. A member is just as often declared in
+          // a refinement of the class, living in another file entirely —
+          // User.twoFactorEnabled is declared in UserRefinements.js, not in
+          // User.js. Falling back to the class line sent every one of those to
+          // the top of the wrong file.
+          var refPos = this.refinementMemberPosition_(classId, memberName, kind);
+          if ( refPos ) return refPos;
+
+          if ( kind === 6 ) {
+            // Method absent from the .js model — resolve to its Java impl.
+            var jp = this.getJavaMemberPosition_(classId, memberName);
+            if ( jp ) return jp;
+          }
         }
       }
       return { uri: uri, line: line, character: character };
+    },
+
+    function memberBucket_(posMap, memberName, kind) {
+      /**
+       * The position-map record for a member, or null. Bucket by LSP symbol
+       * kind: 7=Property, 6=Method, 22=EnumMember, 24=Action/Listener — 24 is
+       * not msg-tagged by the grammar, so it reads the method bucket.
+       */
+      if ( ! posMap ) return null;
+      var bucket =
+        kind === 7  ? posMap.property :
+        kind === 22 ? posMap.value    :
+        posMap.method;
+      var rec = bucket && bucket[memberName];
+      if ( ! rec && kind === 24 && posMap.method ) rec = posMap.method[memberName];
+      return rec || null;
+    },
+
+    function refinementMemberPosition_(classId, memberName, kind) {
+      /**
+       * { uri, line, character } of a member declared in a REFINEMENT of
+       * `classId`, or null. Refinements are indexed by target at file-index
+       * build time; each carries the line range of its own model.
+       *
+       * The range matters. A position map covers a whole file, and a
+       * refinement usually shares its file with the class that motivated it —
+       * ActionView.js holds both `ActionEnumRefinement` (refining
+       * foam.lang.Action) and `ActionView` itself, and both declare
+       * `buttonStyle`. Without the range check the first name-match in the
+       * file wins, which is how you get an answer that is in the right file
+       * and on the wrong line.
+       */
+      if ( ! this.fileIndex_ ) this.buildFileIndex();
+      var refs = this.refinementIndex_ && this.refinementIndex_[classId];
+      if ( ! refs || ! refs.length ) return null;
+
+      for ( var i = 0 ; i < refs.length ; i++ ) {
+        var r   = refs[i];
+        var rec = this.memberBucket_(this.getFilePosMap_(r.path), memberName, kind);
+        if ( ! rec ) continue;
+        // A name declared once per refinement in the same file yields one
+        // record plus its `also` siblings; only one of them is in this
+        // refinement's range.
+        var sightings = rec.also ? [ rec ].concat(rec.also) : [ rec ];
+        for ( var s = 0 ; s < sightings.length ; s++ ) {
+          var sr = sightings[s];
+          if ( sr.line < r.line || sr.line >= r.endLine ) continue;
+          return { uri: 'file://' + r.path, line: sr.line, character: sr.col || 0 };
+        }
+      }
+      return null;
     },
 
     function getJavaMemberPosition_(classId, memberName) {

--- a/tools/lsp/handlers/CallHierarchyHandler.js
+++ b/tools/lsp/handlers/CallHierarchyHandler.js
@@ -146,10 +146,14 @@ foam.CLASS({
     },
 
     function itemFor_(classId, memberName) {
+      // The position carries its own uri, and it is not always the class's
+      // file — a method can live in a refinement or on the Java side. Pair the
+      // line with the file it came from.
       var filePath = this.index.getFilePath(classId);
-      var uri      = filePath ? 'file://' + filePath : 'file:///' + classId.replace(/\./g, '/');
       var pos      = filePath ? this.index.getSymbolPosition(classId, memberName, this.SYMBOL_KIND_METHOD)
                               : { line: 0, character: 0 };
+      var uri      = pos.uri || ( filePath ? 'file://' + filePath
+                                           : 'file:///' + classId.replace(/\./g, '/') );
       var range    = { start: { line: pos.line, character: pos.character }, end: { line: pos.line, character: pos.character } };
       return {
         name:           memberName,

--- a/tools/lsp/handlers/DefinitionHandler.js
+++ b/tools/lsp/handlers/DefinitionHandler.js
@@ -137,7 +137,7 @@ foam.CLASS({
               var defClass = this.findPropertyDefiner_(cls, segment);
               if ( defClass ) {
                 filePath = this.index.getFilePath(defClass);
-                if ( filePath ) return this.buildLocationAtProperty(filePath, segment);
+                if ( filePath ) return this.buildLocationAtProperty(filePath, segment, defClass);
               }
             }
             // Check if it's a message axiom — `this.LABEL_X`
@@ -346,7 +346,7 @@ foam.CLASS({
         var defClass = this.findPropertyDefiner_(cls, name);
         if ( defClass ) {
           var filePath = this.index.getFilePath(defClass);
-          if ( filePath ) return this.buildLocationAtProperty(filePath, name);
+          if ( filePath ) return this.buildLocationAtProperty(filePath, name, defClass);
         }
       }
 
@@ -479,7 +479,7 @@ foam.CLASS({
       return this.grammarInstance_;
     },
 
-    function buildLocationAtProperty(filePath, propName) {
+    function buildLocationAtProperty(filePath, propName, opt_classId) {
       /**
        * Jump to a property definition within a file. Uses the grammar's
        * axiom-position index (`kind: 'property'` emitted by `propertyNameValue`
@@ -505,6 +505,23 @@ foam.CLASS({
           };
         }
       } catch ( e ) {}
+      // The class's own file may not declare the property at all — a
+      // refinement in another file can, and the index knows where those are.
+      // Without this, User.twoFactorEnabled navigated to User.js line 0 while
+      // the same member looked up through the index answered
+      // UserRefinements.js:14.
+      if ( opt_classId ) {
+        var idxPos = this.index.getSymbolPosition(opt_classId, propName, 7);
+        if ( idxPos && idxPos.uri && idxPos.uri !== 'file://' + filePath ) {
+          return {
+            uri: idxPos.uri,
+            range: {
+              start: { line: idxPos.line, character: idxPos.character },
+              end:   { line: idxPos.line, character: idxPos.character + propName.length }
+            }
+          };
+        }
+      }
       return this.buildLocation(filePath);
     },
 
@@ -551,7 +568,7 @@ foam.CLASS({
                 var defClass = this.findPropertyDefiner_(cls, propName);
                 if ( defClass ) {
                   var filePath = this.index.getFilePath(defClass);
-                  if ( filePath ) return this.buildLocationAtProperty(filePath, propName);
+                  if ( filePath ) return this.buildLocationAtProperty(filePath, propName, defClass);
                 }
               }
             }

--- a/tools/lsp/handlers/WorkspaceSymbolHandler.js
+++ b/tools/lsp/handlers/WorkspaceSymbolHandler.js
@@ -30,18 +30,22 @@ foam.CLASS({
         // Class-level hits (Class/Interface/Enum) sit at the foam.CLASS call;
         // member hits resolve to their axiom line via the grammar position map
         // (one parse per file, cached in FoamIndex.getFilePosMap_).
-        var line = 0, character = 0;
+        // The position's own uri is authoritative: a member can be declared
+        // in another file entirely — a refinement of the class, or its Java
+        // side. Keeping h.filePath and taking only the line pairs a number
+        // with a file that has no such line.
+        var uri = 'file://' + h.filePath, line = 0, character = 0;
         if ( h.kind === 5 || h.kind === 11 || h.kind === 10 ) {
           line = this.index.getClassLine(h.classId);
         } else {
           var pos = this.index.getSymbolPosition(h.classId, h.name, h.kind);
-          line = pos.line; character = pos.character;
+          uri = pos.uri || uri; line = pos.line; character = pos.character;
         }
         out.push({
           name:          h.name,
           kind:          h.kind,
           location: {
-            uri:   'file://' + h.filePath,
+            uri:   uri,
             range: { start: { line: line, character: character }, end: { line: line, character: character } }
           },
           containerName: h.containerName

--- a/tools/tests/lsp/callHierarchy.js
+++ b/tools/tests/lsp/callHierarchy.js
@@ -107,3 +107,14 @@ if ( realCls && index.getFilePath('foam.core.controller.ApplicationController') 
 } else {
   test(true, 'method position test skipped (ApplicationController not in file index)');
 }
+
+// === itemFor_ uses the position's own uri ===
+// A method need not live in its class's file. fclone has no JS axiom on
+// foam.core.partition.All and resolves to FObject.java; pairing that line with
+// All.js pointed at line 393 of a 34-line file.
+var javaItem = ch.itemFor_('foam.core.partition.All', 'fclone');
+test(javaItem && javaItem.uri.endsWith('.java'),
+  'itemFor_: a Java-resolved method keeps the .java uri its position came from'
+  + ' (got ' + ( javaItem ? javaItem.uri.split('/').pop() : 'null' ) + ')');
+test(javaItem && javaItem.range.start.line > 0,
+  'itemFor_: and a real line inside it (@' + ( javaItem ? javaItem.range.start.line : '?' ) + ')');

--- a/tools/tests/lsp/editorFeatures.js
+++ b/tools/tests/lsp/editorFeatures.js
@@ -112,6 +112,27 @@ test(propHits.some(function(s) { return s.kind === 7; }) || propHits.length === 
 var methodHits = wsSymbolHandler.handle('toSummary');
 test(Array.isArray(methodHits), 'WorkspaceSymbol: method search returns array');
 
+// A member's location must use the position's OWN uri. Pairing the line with
+// the class's file puts a line number in a file that may not have one — 34
+// workspace symbols pointed past the end of the file they named.
+var twoFactorHits = wsSymbolHandler.handle('twoFactorEnabled').filter(function(sym) {
+  return sym.name === 'twoFactorEnabled' && sym.containerName === 'foam.core.auth.User';
+});
+test(twoFactorHits.length > 0 && twoFactorHits[0].location.uri.indexOf('UserRefinements.js') !== -1
+  && twoFactorHits[0].location.range.start.line === 14,
+  'WorkspaceSymbol: a member declared in a refinement points at the refining file'
+  + ' (got ' + ( twoFactorHits.length ? twoFactorHits[0].location.uri.split('/').pop() + ':'
+    + twoFactorHits[0].location.range.start.line : 'no hit' ) + ')');
+
+// The same discard broke the Java side long before refinements existed:
+// fclone has no JS axiom on foam.core.partition.All and resolves to FObject.java.
+var fcloneHits = wsSymbolHandler.handle('fclone').filter(function(sym) {
+  return sym.name === 'fclone' && sym.containerName === 'foam.core.partition.All';
+});
+test(fcloneHits.length > 0 && fcloneHits[0].location.uri.endsWith('.java'),
+  'WorkspaceSymbol: a Java-resolved member points at the .java file, not the .js'
+  + ' (got ' + ( fcloneHits.length ? fcloneHits[0].location.uri.split('/').pop() : 'no hit' ) + ')');
+
 // Empty index → empty results (no crash).
 var emptyIndex = foam.parse.lsp.FoamIndex.create();
 var emptyHandler = foam.parse.lsp.handlers.WorkspaceSymbolHandler.create({ index: emptyIndex });

--- a/tools/tests/lsp/foamIndex.js
+++ b/tools/tests/lsp/foamIndex.js
@@ -355,3 +355,55 @@ if ( index.classExists(JAVA_CLASS) && index.getFilePath(JAVA_CLASS) ) {
 } else {
   test(true, 'Java-only method tests skipped (FObject not in file index)');
 }
+
+// === Members declared in a refinement ===
+section('FoamIndex refinement members');
+
+// A refined class keeps its own file as its definition site, so a member that
+// only a refinement declares used to resolve to the top of the wrong file.
+// Every assertion below names a real declaration in this repo; lines are
+// 0-based, one less than what an editor shows.
+
+function refPos(classId, member) {
+  var p = index.getSymbolPosition(classId, member, 7);
+  return p ? { file: p.uri.split('/').pop(), line: p.line } : null;
+}
+
+var twoFactor = refPos('foam.core.auth.User', 'twoFactorEnabled');
+test(twoFactor && twoFactor.file === 'UserRefinements.js' && twoFactor.line === 14,
+  'refinement member: User.twoFactorEnabled resolves to UserRefinements.js:14, not User.js'
+  + ' (got ' + ( twoFactor ? twoFactor.file + ':' + twoFactor.line : 'null' ) + ')');
+
+// A refinement must not hijack a member the class declares itself.
+// foam.lang.Action declares buttonStyle at Action.js:46 and ActionView.js
+// refines it to an Enum — the declaration site is still Action.js.
+var buttonStyle = refPos('foam.lang.Action', 'buttonStyle');
+test(buttonStyle && buttonStyle.file === 'Action.js' && buttonStyle.line === 46,
+  'own declaration wins: Action.buttonStyle stays at Action.js:46 though ActionView.js refines it'
+  + ' (got ' + ( buttonStyle ? buttonStyle.file + ':' + buttonStyle.line : 'null' ) + ')');
+
+// FromCsvRefines.js declares `fromCSV` six times, once per refined class, and
+// the file's position map recorded only the first (line 14, the
+// foam.lang.Property refinement). Both assertions below would land on 14
+// without the per-refinement line range.
+var intFromCSV   = refPos('foam.lang.Int', 'fromCSV');
+var floatFromCSV = refPos('foam.lang.Float', 'fromCSV');
+test(intFromCSV && intFromCSV.file === 'FromCsvRefines.js' && intFromCSV.line === 32,
+  'repeated member: Int.fromCSV resolves to FromCsvRefines.js:32'
+  + ' (got ' + ( intFromCSV ? intFromCSV.file + ':' + intFromCSV.line : 'null' ) + ')');
+test(floatFromCSV && floatFromCSV.file === 'FromCsvRefines.js' && floatFromCSV.line === 69,
+  'repeated member: Float.fromCSV resolves to its OWN line 69 in the same file'
+  + ' (got ' + ( floatFromCSV ? floatFromCSV.file + ':' + floatFromCSV.line : 'null' ) + ')');
+
+// A refinement needs no `name:` of its own. EndBoot.js has the repo's only
+// nameless one; the name guard used to drop it before its target was recorded.
+var modelProps = refPos('foam.lang.Model', 'properties');
+test(modelProps && modelProps.file === 'EndBoot.js' && modelProps.line === 42,
+  'nameless refinement: Model.properties resolves to EndBoot.js:42'
+  + ' (got ' + ( modelProps ? modelProps.file + ':' + modelProps.line : 'null' ) + ')');
+
+// Non-regression: a member declared in the class's own file still wins.
+var ownFile = index.getSymbolPosition('foam.lang.Property', 'name', 7);
+test(ownFile && ownFile.uri.split('/').pop() === 'Property.js',
+  'a member in the class\'s own file still resolves there, not to a refinement'
+  + ' (got ' + ( ownFile ? ownFile.uri.split('/').pop() : 'null' ) + ')');

--- a/tools/tests/lsp/navigation.js
+++ b/tools/tests/lsp/navigation.js
@@ -728,3 +728,19 @@ if ( index.classExists('foam.u2.view.ReferenceArrayView') && index.classExists('
   test(vsLocs.some(function(l) { return l.uri.indexOf('Group.js') !== -1; }),
     'references: view-spec-only user (Group.js) included via view-spec index');
 }
+
+// === A property declared in a refinement, from the cursor-driven path ===
+// resolveMemberOnClass_ resolves the definer to User, because the refinement
+// installs the axiom there — but User.js does not declare the property, so the
+// grammar lookup found nothing and it fell to User.js line 0.
+var refMemberLoc = defHandler.resolveMemberOnClass_('foam.core.auth.User', 'twoFactorEnabled');
+test(refMemberLoc && refMemberLoc.uri.indexOf('UserRefinements.js') !== -1
+  && refMemberLoc.range.start.line === 14,
+  'resolveMemberOnClass_: User.twoFactorEnabled lands in UserRefinements.js:14'
+  + ' (got ' + ( refMemberLoc ? refMemberLoc.uri.split('/').pop() + ':' + refMemberLoc.range.start.line : 'null' ) + ')');
+
+// Non-regression: a property the class declares itself is untouched.
+var ownLoc = defHandler.resolveMemberOnClass_('foam.lang.Property', 'name');
+test(ownLoc && ownLoc.uri.indexOf('Property.js') !== -1,
+  'resolveMemberOnClass_: a property in the class\'s own file still resolves there'
+  + ' (got ' + ( ownLoc ? ownLoc.uri.split('/').pop() : 'null' ) + ')');


### PR DESCRIPTION
Go-to-definition on `user.twoFactorEnabled` lands on `User.js` line 7. The property is declared in `UserRefinements.js`.

A refined class keeps its own file as its definition site — `fileIndex_` only falls back to a refining file when nothing else claims the id. So a member that only a refinement declares has no record in the class's own position map, and `getSymbolPosition` fell back to the class's declaration line.

I counted it: **423 properties across `src/` are declared in a refinement of a class that lives in another file. Before this, 0 of them resolved anywhere but the top of the wrong file.** After, 259 do.

`refinementIndex_` is built next to `fileIndex_` and maps a refined class id to every file refining it, each with the refining model's own `[line, endLine)` range. `refinementMemberPosition_` walks those and accepts a hit only inside the range.

That range earns its keep twice:

- A refinement usually shares a file with the class that motivated it, and both can declare the same name.
- `collectAxiomPositions` kept one record per name per file. That's true per model and this map covers a file — `FromCsvRefines.js` declares `fromCSV` six times, for six classes. Records now carry `also`, the later sightings. Readers that just want a position still read the first record and see no change.

A refinement's own `name:` is optional. The name guard used to run before the `refines` branch, so a nameless one was dropped along with everything it declares. It's rare — one file here, one in the app repo — but the guard was in the wrong place.

**What still doesn't resolve, and why.** Of the 164 remaining: 4 are refinement files no active pom registers, and the other 160 sit in files whose whole-file grammar parse stops early, so the later models never get recorded at all. It's concentrated: `Element2.js` 37, `java/refinements.js` 60, `TableCellFormatter.js` 25, `swift/refines/Method.js` 15. Separate defect, separate fix — I didn't touch the grammar's coverage here.

Cost, worst case in the repo: `foam.lang.Property` has 26 refining files. A lookup that misses parses each one, mtime-cached — 181ms cold, 0ms warm, 0.11ms per warm hit.

Six tests, each half proven on its own: reverting `FoamIndex` reds four, reverting only the grammar's `also` reds the two `fromCSV` ones, and re-adding the old name guard reds the nameless case alone. One is a non-regression guard — `Action.buttonStyle` must stay at `Action.js:46`, since Action declares it itself and `ActionView.js` only refines its class.

Suite 1714/0.

Merge order: independent of #5405 and #5406 — different files. C-c (DAO and service symbols) also touches `FoamIndex.js` and should go after this one.