### PR TITLE
lsp: journals load at all, and registered services become symbols

### DIFF
--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -18,7 +18,7 @@ The LSP boots the FOAM runtime via `pmake` (same as `build.sh`), loading all mod
 | `FoamClassGrammar.js` | Grammar parser for completion `sug()` only | Skip-and-match pattern, dynamic `sug()` from registry |
 | `CursorAnalyzer.js` | Shared text/position utilities + regex fallback | `offsetToPosition()`, `resolveClassId()`, `parseRequires()`, `findCreateContext()` |
 | `TypeTracker.js` | Variable type resolution from `.create()` assignments | `getVariableTypes()` |
-| `JrlLoader.js` | Load and parse .jrl (journal) files containing FOAM FObject records | `loadString()`, `filterByClass()` |
+| `JrlLoader.js` | Load and parse .jrl (journal) files containing FOAM FObject records | `loadString()`, `loadStringWithLines()`, `sliceEntries()`, `filterByClass()`. **A journal is not valid JavaScript** — FOAM's triple-quoted values are a syntax error, so the content is cut into entries on the grammar's entry starts and each is evaluated alone with its triple-quoted spans blanked. Evaluating the whole file as one body threw at construction and returned nothing: 68 of 78 `services.jrl` and 119 of 365 journals were silently empty |
 | `JrlGrammar.js` | Position-harvesting grammar for .jrl files (entry heads, embedded class refs, triple-string spans) | `collectJrlPositions()` |
 | `JournalEntryIndex.js` | Query-driven journal lookup: service name / model-entry id → journal file + line. Service lookups touch only services.jrl; journals over maxFileSize skipped; raw-text pre-gate skips parsing non-matching files; per-entry eval isolates malformed entries; per-file parses cached by mtime+size; invalidated on .jrl save | `getServiceLocations()`, `getEntryLocations()`, `invalidate()` |
 | `FileClassifier.js` | The ONE answer to "what kind of file is this", and the ONE scan for where a file's `foam.<X>(` calls are | `classify(uri, text)`. `.jrl` and `pom.js` are decided by FILENAME; everything else by PARSE — the first significant `foam.UPPERCASE(` call, where significant means outside comments and string literals. Both the server dispatch and `DiagnosticsHandler` route through one shared instance, which is also what makes its per-URI memo effective. `significantCalls(text)` returns every such call as `{ name, offset, line }` — see "Model positions" below |
@@ -169,6 +169,33 @@ Known residue (not this machinery): members whose refining file never reaches
 the grammar's whole-file parse. Concentrated in `Element2.js`,
 `java/refinements.js`, `u2/view/TableCellFormatter.js` and
 `swift/refines/Method.js`.
+
+### Services are symbols too
+
+A registered service (`services.jrl` CSpec row) is not an axiom of any class, so
+the class walk that builds `symbolIndex_` cannot see one. `localUserDAO` returned
+no symbol at all while `src/foam/core/auth/services.jrl:409` registered it.
+`pushServiceSymbols_` appends them as kind 13 (Variable — a name in the context,
+not a type), each carrying its own file and line because there is no class to
+resolve a position from. `searchSymbols` passes that `line` through and
+`WorkspaceSymbolHandler` prefers it when present.
+
+Two things had to be true first:
+
+- `JrlLoader` had to return anything at all (see its row above).
+- A CSpec's identity is its `name`, not its `id`. The index required `id` and
+  skipped every row in the repo. `cspecRecords` went 0 → 272, and 190 of those
+  names had no other record anywhere in the string-usage index.
+
+Cost: `buildStringUsageIndex_` 294ms → 370ms, one-time and lazy.
+
+`DefinitionHandler` gained the mirror of `JrlHandler`'s service rule: a string
+literal whose whole content names a registered service jumps to the row
+registering it. Schema-blind on purpose — nothing in a model declares that
+`daoKey` points at a journal — and safe because only `services.jrl` is read and
+only a registered name returns anything. It runs after every schema-driven
+branch has declined. `SERVICE_KEY_NAMES` lives on `JournalEntryIndex` so the two
+handlers share one copy of the convention.
 
 ### Interfaces
 - FOAM interfaces (`foam.INTERFACE`) define properties/methods

--- a/tools/lsp/CLAUDE.md
+++ b/tools/lsp/CLAUDE.md
@@ -20,7 +20,7 @@ The LSP boots the FOAM runtime via `pmake` (same as `build.sh`), loading all mod
 | `TypeTracker.js` | Variable type resolution from `.create()` assignments | `getVariableTypes()` |
 | `JrlLoader.js` | Load and parse .jrl (journal) files containing FOAM FObject records | `loadString()`, `loadStringWithLines()`, `sliceEntries()`, `filterByClass()`. **A journal is not valid JavaScript** — FOAM's triple-quoted values are a syntax error, so the content is cut into entries on the grammar's entry starts and each is evaluated alone with its triple-quoted spans blanked. Evaluating the whole file as one body threw at construction and returned nothing: 68 of 78 `services.jrl` and 119 of 365 journals were silently empty |
 | `JrlGrammar.js` | Position-harvesting grammar for .jrl files (entry heads, embedded class refs, triple-string spans) | `collectJrlPositions()` |
-| `JournalEntryIndex.js` | Query-driven journal lookup: service name / model-entry id → journal file + line. Service lookups touch only services.jrl; journals over maxFileSize skipped; raw-text pre-gate skips parsing non-matching files; per-entry eval isolates malformed entries; per-file parses cached by mtime+size; invalidated on .jrl save | `getServiceLocations()`, `getEntryLocations()`, `invalidate()` |
+| `JournalEntryIndex.js` | Query-driven journal lookup: service name / model-entry id → journal file + line. Entry slicing is `JrlLoader.sliceEntries()`; this class only adds ordered ops + a per-entry key. Service lookups touch only services.jrl; journals over maxFileSize skipped; raw-text pre-gate skips parsing non-matching files; per-entry eval isolates malformed entries; per-file parses cached by mtime+size; invalidated on .jrl save | `getServiceLocations()`, `getEntryLocations()`, `invalidate()` |
 | `FileClassifier.js` | The ONE answer to "what kind of file is this", and the ONE scan for where a file's `foam.<X>(` calls are | `classify(uri, text)`. `.jrl` and `pom.js` are decided by FILENAME; everything else by PARSE — the first significant `foam.UPPERCASE(` call, where significant means outside comments and string literals. Both the server dispatch and `DiagnosticsHandler` route through one shared instance, which is also what makes its per-URI memo effective. `significantCalls(text)` returns every such call as `{ name, offset, line }` — see "Model positions" below |
 | `server.js` | JSON-RPC main loop | Message dispatch, handler creation, helper functions |
 | `lsp-start.js` | Entry point | Console redirect, buildlib globals, pmake invocation |
@@ -62,7 +62,7 @@ The LSP boots the FOAM runtime via `pmake` (same as `build.sh`), loading all mod
 |---|---|---|
 | `getJsUsages(classId)` | classes whose JS code references the class: `this.<Short>` via requires, `.create()` receivers, `.tag(X, {})` args, `{ class: 'dotted.Id' }` spec strings | Grammar `collectAxiomPositions` per source file (memberRef / instCreateReceiver / instTagClass / instClassRef); registry `fn.toString()` scan only for file-less (runtime-registered) classes |
 | `getJavaUsages(classId)` | classes whose javaCode / javaPostSet / etc. reference the type | Same axiom walk, `javaImports` resolves short→full |
-| `getStringUsages(name)` | classes importing the name + Producer classes exporting it + services.jrl CSpec entries | `cls.getOwnAxiomsByClass(foam.lang.Import/Export)` + `JrlLoader.loadFile(...services.jrl)` |
+| `getStringUsages(name)` | classes importing the name + Producer classes exporting it + services.jrl CSpec entries | `cls.getOwnAxiomsByClass(foam.lang.Import/Export)` + `loadStringWithLines()` over the `services.jrl` in every `getJournalDirs()` directory |
 | `getMemberUsages(classId, memberName)` | per-class `this.X` usages of an own / inherited property or method | Reuses `scanFunctions_` axiom walk |
 
 All four indexes share the same invalidation hook (`invalidateSymbolIndex_`)
@@ -189,13 +189,22 @@ Two things had to be true first:
 
 Cost: `buildStringUsageIndex_` 294ms → 370ms, one-time and lazy.
 
-`DefinitionHandler` gained the mirror of `JrlHandler`'s service rule: a string
-literal whose whole content names a registered service jumps to the row
-registering it. Schema-blind on purpose — nothing in a model declares that
-`daoKey` points at a journal — and safe because only `services.jrl` is read and
-only a registered name returns anything. It runs after every schema-driven
+`DefinitionHandler` gained the mirror of `JrlHandler`'s service rule: the value
+of a **service key** — `CursorAnalyzer.getEnclosingKey()` must name one of
+`SERVICE_KEY_NAMES` — whose whole content is a registered service jumps to the
+row registering it. Schema-blind on purpose (nothing in a model declares that
+`daoKey` points at a journal), and the key is what bounds it: the lookup alone
+does not, since `file` and `blobStore` are registered services that also occur
+as ordinary string values across the tree. It runs after every schema-driven
 branch has declined. `SERVICE_KEY_NAMES` lives on `JournalEntryIndex` so the two
 handlers share one copy of the convention.
+
+The `services.jrl` walk asks `FoamIndex.getJournalDirs()` — pom locations ∪
+indexed-source directories — the same set `JournalEntryIndex.findJournalFiles_`
+reads. A walk of indexed sources alone misses `src/services.jrl`, whose
+directory holds no class file. A `.jrl` save invalidates both indexes:
+`journalEntryIndex.invalidate()` and `index.invalidateSymbolIndex_()`, since
+`reindexFile` only reaches the latter for a file that classifies as a class.
 
 ### Interfaces
 - FOAM interfaces (`foam.INTERFACE`) define properties/methods

--- a/tools/lsp/CursorAnalyzer.js
+++ b/tools/lsp/CursorAnalyzer.js
@@ -101,6 +101,48 @@ foam.CLASS({
       return null;
     },
 
+    function getEnclosingKey(text, position) {
+      /**
+       * The object key whose VALUE is the string literal under the cursor —
+       * `daoKey` for `daoKey: 'localUserDAO'` — or null when the cursor is
+       * not in a string, or the string is not a key's value (an argument, an
+       * array element, a nested call). Line-local, like
+       * getEnclosingStringContent, whose scan this repeats to find the same
+       * string's opening quote.
+       *
+       * Callers navigate on a CONVENTION about the key (see
+       * JournalEntryIndex.SERVICE_KEY_NAMES); without the key there is
+       * nothing holding the convention, and every quoted word that happens
+       * to spell a registered name would qualify.
+       */
+      var lines = text.split('\n');
+      var line = lines[position.line] || '';
+      var ch = position.character;
+      var quotes = "'\"`";
+      var i = 0;
+      while ( i < line.length ) {
+        if ( quotes.indexOf(line[i]) !== -1 ) {
+          var q = line[i];
+          var open = i;
+          var start = i + 1;
+          var j = start;
+          while ( j < line.length && line[j] !== q ) {
+            if ( line[j] === '\\' ) j++;
+            j++;
+          }
+          if ( ch > start - 1 && ch <= j ) {
+            var before = line.substring(0, open);
+            var m = /(?:^|[\s{,([])['"`]?([A-Za-z_$][A-Za-z0-9_$]*)['"`]?\s*:\s*$/.exec(before);
+            return m ? m[1] : null;
+          }
+          i = j + 1;
+        } else {
+          i++;
+        }
+      }
+      return null;
+    },
+
     function getSegmentAtPosition(text, position) {
       /**
        * Get just the single identifier segment under the cursor (stops at dots).

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -2091,17 +2091,14 @@ foam.CLASS({
         var jrlLoader = foam.parse.lsp.JrlLoader.create();
         var fs_       = require('fs');
         var path_     = require('path');
-        var fileIndex = this.fileIndex_ || {};
-        var seenDirs  = {};
-        var services  = [];
-        for ( var id in fileIndex ) {
-          var entry = fileIndex[id];
-          var p     = typeof entry === 'string' ? entry : entry.path;
-          if ( ! p ) continue;
-          var dir = path_.dirname(p);
-          if ( seenDirs[dir] ) continue;
-          seenDirs[dir] = true;
-          var svc = path_.join(dir, 'services.jrl');
+        // getJournalDirs, not getIndexedDirs: src/services.jrl — 38 rows,
+        // `file`, `blobStore`, `httpServer` among them — sits in a directory
+        // holding no class file at all, so a walk of indexed sources never
+        // reaches it. The pom locations do.
+        var services = [];
+        var svcDirs  = this.getJournalDirs();
+        for ( var d = 0 ; d < svcDirs.length ; d++ ) {
+          var svc = path_.join(svcDirs[d], 'services.jrl');
           if ( fs_.existsSync(svc) ) services.push(svc);
         }
         for ( var s = 0 ; s < services.length ; s++ ) {
@@ -2132,6 +2129,35 @@ foam.CLASS({
       } catch (e) {}
 
       this.stringUsageIndex_ = { byName: byName };
+    },
+
+    function getJournalDirs() {
+      /**
+       * Every directory a .jrl may live in: the pom locations plus the
+       * directories of indexed sources. THE one answer to that question —
+       * JournalEntryIndex asks it for journal discovery and
+       * buildStringUsageIndex_ asks it for services.jrl, and when those two
+       * were separate walks they disagreed: the index missed the 38
+       * registrations in src/services.jrl that the journal lookup found.
+       *
+       * Not cached: foam.poms is mutable at runtime.
+       */
+      var seen = {};
+      var dirs = [];
+      var poms = ( typeof foam !== 'undefined' && foam.poms ) || [];
+      for ( var p = 0 ; p < poms.length ; p++ ) {
+        var loc = poms[p] && poms[p].location;
+        if ( ! loc || seen[loc] ) continue;
+        seen[loc] = true;
+        dirs.push(loc);
+      }
+      var indexed = this.getIndexedDirs();
+      for ( var i = 0 ; i < indexed.length ; i++ ) {
+        if ( seen[indexed[i]] ) continue;
+        seen[indexed[i]] = true;
+        dirs.push(indexed[i]);
+      }
+      return dirs;
     },
 
     function getIndexedDirs() {

--- a/tools/lsp/FoamIndex.js
+++ b/tools/lsp/FoamIndex.js
@@ -1557,8 +1557,48 @@ foam.CLASS({
         }
       }
 
+      this.pushServiceSymbols_(out);
+
       this.symbolIndex_ = out;
       return out;
+    },
+
+    function pushServiceSymbols_(out) {
+      /**
+       * Registered services (`services.jrl` CSpec rows) as workspace symbols.
+       *
+       * A service name is not an axiom of any class, so nothing above finds
+       * it: searching `localUserDAO` returned no symbol at all while
+       * `services.jrl` registered it on line 409. They are the names an
+       * `imports:` entry is written against, which makes them exactly the
+       * kind of thing a symbol search is for.
+       *
+       * Kind 13 (Variable) — a service is a name in the context, not a type.
+       * The entry carries its own file and line because there is no class to
+       * resolve a position from.
+       */
+      var byName;
+      try {
+        if ( ! this.stringUsageIndex_ ) this.buildStringUsageIndex_();
+        byName = this.stringUsageIndex_ && this.stringUsageIndex_.byName;
+      } catch ( e ) { return; }
+      if ( ! byName ) return;
+
+      for ( var name in byName ) {
+        var recs = byName[name];
+        for ( var i = 0 ; i < recs.length ; i++ ) {
+          var r = recs[i];
+          if ( r.kind !== 'cspec' || ! r.file ) continue;
+          out.push({
+            name:          name,
+            kind:          13,
+            classId:       '',
+            containerName: 'services.jrl',
+            filePath:      r.file,
+            line:          r.line || 0
+          });
+        }
+      }
     },
 
     function searchSymbols(query, opts) {
@@ -1587,7 +1627,9 @@ foam.CLASS({
         var s = symbols[i];
         if ( ! s.filePath )                                      continue;
         if ( kindFilter    && s.kind !== kindFilter )            continue;
-        if ( packagePrefix && s.classId.indexOf(packagePrefix) !== 0 ) continue;
+        // A service symbol has no class id, so a package filter cannot match
+        // it — it is filtered out rather than crashing on an empty string.
+        if ( packagePrefix && ( ! s.classId || s.classId.indexOf(packagePrefix) !== 0 ) ) continue;
 
         if ( ! q ) {
           scored.push({ s: s, score: 1 });
@@ -1617,6 +1659,9 @@ foam.CLASS({
           classId:       e.s.classId,
           containerName: e.s.containerName,
           filePath:      e.s.filePath,
+          // Carried through only when the entry brought one — a services.jrl
+          // row has no class to resolve a position from later.
+          line:          e.s.line,
           score:         e.score
         };
       });
@@ -2061,15 +2106,25 @@ foam.CLASS({
         }
         for ( var s = 0 ; s < services.length ; s++ ) {
           try {
-            var entries = jrlLoader.loadFile(services[s]);
+            // With lines, because a CSpec row is worth pointing AT: it is the
+            // one place the service is registered.
+            var entries = jrlLoader.loadStringWithLines(
+              fs_.readFileSync(services[s], 'utf8'));
             for ( var e = 0 ; e < entries.length ; e++ ) {
-              var ent = entries[e];
-              if ( ! ent || typeof ent.id !== 'string' ) continue;
-              record(ent.id, {
+              var ent = entries[e].obj;
+              if ( ! ent ) continue;
+              // A CSpec's identity is its `name`, not `id` — that is what an
+              // import key is matched against. Requiring `id` skipped every
+              // row in every services.jrl in the repo.
+              var entId = typeof ent.id === 'string' ? ent.id
+                        : ( typeof ent.name === 'string' ? ent.name : null );
+              if ( ! entId ) continue;
+              record(entId, {
                 sourceClassId: null,
                 axiomName:     'services.jrl',
                 kind:          'cspec',
-                file:          services[s]
+                file:          services[s],
+                line:          entries[e].line
               });
             }
           } catch (e) {}

--- a/tools/lsp/JournalEntryIndex.js
+++ b/tools/lsp/JournalEntryIndex.js
@@ -30,6 +30,15 @@ foam.CLASS({
 
   requires: [ 'foam.parse.lsp.JrlGrammar' ],
 
+  constants: {
+    // Keys whose VALUE names a registered service rather than describing one.
+    // Schema-blind by nature: nothing in the model says `daoKey` points at a
+    // services.jrl row, it is a convention. Lives here because both the
+    // journal handler and the JS definition handler navigate on it, and two
+    // copies of a convention list drift.
+    SERVICE_KEY_NAMES: [ 'daoKey' ]
+  },
+
   properties: [
     {
       name: 'index',

--- a/tools/lsp/JournalEntryIndex.js
+++ b/tools/lsp/JournalEntryIndex.js
@@ -13,7 +13,7 @@ foam.CLASS({
     per-model entry id. Backs JrlHandler's cross-reference
     go-to-definition (daoKey -> services.jrl, parent -> menu entry).
 
-    Positions come from JrlGrammar (parser combinators); entry
+    Positions come from JrlGrammar via JrlLoader.sliceEntries(); entry
     SEMANTICS come from evaluating each entry with p/c/r interceptors
     (JrlLoader's pattern). Each entry is evaluated ALONE, sliced on
     the grammar's entry starts, so a malformed entry costs only
@@ -28,7 +28,7 @@ foam.CLASS({
     invalidate() (wired to .jrl saves in server.js) drops the caches
     so the next query re-reads from disk.`,
 
-  requires: [ 'foam.parse.lsp.JrlGrammar' ],
+  requires: [ 'foam.parse.lsp.JrlLoader' ],
 
   constants: {
     // Keys whose VALUE names a registered service rather than describing one.
@@ -42,7 +42,7 @@ foam.CLASS({
   properties: [
     {
       name: 'index',
-      documentation: 'FoamIndex; supplies getIndexedDirs() for journal discovery.'
+      documentation: 'FoamIndex; supplies getJournalDirs() for journal discovery.'
     },
     {
       class: 'StringArray',
@@ -50,8 +50,13 @@ foam.CLASS({
       documentation: 'Explicit journal list (tests). Empty -> discover via index.'
     },
     {
-      name: 'grammar',
-      factory: function() { return this.JrlGrammar.create(); }
+      name: 'loader',
+      documentation: `Supplies sliceEntries() — the cut-on-entry-starts,
+        blank-the-triple-quotes step. Shared rather than repeated: the two
+        copies computed the same spans from the same grammar output, so a
+        change to one silently made the journal lookup and the journal
+        loader read the same file differently.`,
+      factory: function() { return this.JrlLoader.create(); }
     },
     {
       class: 'Int',
@@ -107,27 +112,9 @@ foam.CLASS({
       var fs_ = require('fs');
       var path_ = require('path');
       var files = [];
-      var seen = {};
-      var dirs = [];
-
-      // Collect directories from foam.poms locations
-      var poms = ( typeof foam !== 'undefined' && foam.poms ) || [];
-      for ( var p = 0 ; p < poms.length ; p++ ) {
-        var pomDir = poms[p] && poms[p].location;
-        if ( pomDir && ! seen[pomDir] ) {
-          seen[pomDir] = true;
-          dirs.push(pomDir);
-        }
-      }
-
-      // Collect directories from indexed source files
-      var indexDirs = ( this.index && this.index.getIndexedDirs() ) || [];
-      for ( var d = 0 ; d < indexDirs.length ; d++ ) {
-        if ( ! seen[indexDirs[d]] ) {
-          seen[indexDirs[d]] = true;
-          dirs.push(indexDirs[d]);
-        }
-      }
+      // The pom locations + indexed source dirs union lives on FoamIndex, so
+      // this and buildStringUsageIndex_'s services.jrl walk cannot drift.
+      var dirs = ( this.index && this.index.getJournalDirs() ) || [];
 
       // Read .jrl files from each directory
       for ( var i = 0 ; i < dirs.length ; i++ ) {
@@ -199,28 +186,20 @@ foam.CLASS({
 
     function parseFile_(content) {
       /**
-       * Grammar positions -> per-entry eval. Slicing each entry on the
+       * JrlLoader.sliceEntries -> per-entry eval. Slicing each entry on the
        * grammar's own entry starts isolates syntax errors: ops[0] of a
        * slice IS that slice's entry, and a slice that fails to compile
        * drops only its own entry.
+       *
+       * The slicing itself is the loader's — this class only differs in what
+       * it does with a slice (ordered ops and a per-entry key, rather than a
+       * deduped object list), so it keeps parseEntriesOrdered_ and nothing
+       * else.
        */
       var recs = [];
-      var pos = this.grammar.collectJrlPositions(content);
-      for ( var i = 0 ; i < pos.entries.length ; i++ ) {
-        var start = pos.entries[i].startPos;
-        var end   = i + 1 < pos.entries.length ?
-          pos.entries[i + 1].startPos : content.length;
-
-        var spans = [];
-        for ( var t = 0 ; t < pos.tripleStrings.length ; t++ ) {
-          var s = pos.tripleStrings[t];
-          if ( s.startPos >= start && s.endPos <= end ) {
-            spans.push({ startPos: s.startPos - start, endPos: s.endPos - start });
-          }
-        }
-
-        var ops = this.parseEntriesOrdered_(
-          this.sanitizeContent_(content.substring(start, end), spans));
+      var slices = this.loader.sliceEntries(content);
+      for ( var i = 0 ; i < slices.length ; i++ ) {
+        var ops = this.parseEntriesOrdered_(slices[i].text);
         if ( ! ops.length || ops[0].op === 'r' ) continue;
         var obj = ops[0].obj;
         if ( ! obj || typeof obj !== 'object' ) continue;
@@ -229,26 +208,9 @@ foam.CLASS({
         var key = this.entryKey_(clsId, obj);
         if ( key === null ) continue;
 
-        recs.push({ clsId: clsId, key: key, line: pos.entries[i].line });
+        recs.push({ clsId: clsId, key: key, line: slices[i].line });
       }
       return recs;
-    },
-
-    function sanitizeContent_(content, tripleSpans) {
-      /**
-       * Replace """...""" spans (positions from JrlGrammar) with an
-       * empty JS string so the content becomes evaluable. Pure
-       * position-based string surgery — no pattern matching.
-       */
-      var out = '';
-      var last = 0;
-      for ( var i = 0 ; i < tripleSpans.length ; i++ ) {
-        var s = tripleSpans[i];
-        if ( s.startPos < last ) continue;
-        out += content.substring(last, s.startPos) + '""';
-        last = s.endPos;
-      }
-      return out + content.substring(last);
     },
 
     function parseEntriesOrdered_(content) {

--- a/tools/lsp/JrlLoader.js
+++ b/tools/lsp/JrlLoader.js
@@ -11,7 +11,30 @@ foam.CLASS({
   documentation: `Generic JRL file loader using eval-intercept pattern.
     Defines p (put), c (create), r (remove) as interceptor functions,
     evals the JRL content, and returns collected objects.
-    Reusable by any part of the system that needs to load JRL files.`,
+    Reusable by any part of the system that needs to load JRL files.
+
+    A journal is NOT valid JavaScript. FOAM writes long values as
+    triple-quoted strings, which no JS engine accepts, so evaluating a
+    whole journal as one function body throws a SyntaxError at
+    CONSTRUCTION — the body never runs and nothing at all is collected.
+    68 of this repo's 78 services.jrl files are in that state, and 119
+    of 365 journals overall.
+
+    So the content is cut into entries on the grammar's own entry starts
+    and each is evaluated alone, with its triple-quoted spans replaced by
+    empty strings first. A malformed entry then costs only itself.
+    sliceEntries() is that step on its own, because JournalEntryIndex
+    needs the same slices with their line numbers.`,
+
+  requires: [ 'foam.parse.lsp.JrlGrammar' ],
+
+  properties: [
+    {
+      name: 'grammar_',
+      documentation: 'Shared JrlGrammar — supplies entry starts and triple-quoted spans.',
+      factory: function() { return this.JrlGrammar.create(); }
+    }
+  ],
 
   methods: [
     function loadFile(filePath) {
@@ -40,15 +63,31 @@ foam.CLASS({
     },
 
     function loadString(content) {
+      /** Surviving entry objects, in document order. */
+      var entries = this.loadStringWithLines(content);
+      var out = [];
+      for ( var i = 0 ; i < entries.length ; i++ ) out.push(entries[i].obj);
+      return out;
+    },
+
+    function loadStringWithLines(content) {
+      /**
+       * Surviving entries as [ { obj, line } ], line being the 0-based line
+       * the entry starts on. Callers that want to point a user AT an entry —
+       * a services.jrl row shown as a reference — need the line, and the
+       * slices already carry it.
+       */
       var objects = {};
       var ordered = [];
       var nextId = 0;
+
+      var curLine = 0;
 
       function put(obj) {
         if ( ! obj || typeof obj !== 'object' ) return;
         var key = (obj['class'] || '') + ':' + (obj.id != null ? obj.id : '__auto_' + (nextId++));
         if ( ! objects[key] ) ordered.push(key);
-        objects[key] = obj;
+        objects[key] = { obj: obj, line: curLine };
       }
 
       function remove(obj) {
@@ -61,11 +100,18 @@ foam.CLASS({
         }
       }
 
-      try {
-        var fn = new Function('p', 'c', 'r', content);
-        fn(put, put, remove);
-      } catch ( e ) {
-        // Malformed JRL — return whatever was collected before the error
+      // One entry at a time. Evaluating the whole journal as one function
+      // body means one unparseable entry — or one triple-quoted string,
+      // which is every real services.jrl — returns nothing at all.
+      var slices = this.sliceEntries(content);
+      for ( var i = 0 ; i < slices.length ; i++ ) {
+        curLine = slices[i].line;
+        try {
+          var fn = new Function('p', 'c', 'r', slices[i].text);
+          fn(put, put, remove);
+        } catch ( e ) {
+          // Malformed entry — it drops, the rest of the journal does not
+        }
       }
 
       var result = [];
@@ -73,6 +119,68 @@ foam.CLASS({
         if ( objects[ordered[i]] ) result.push(objects[ordered[i]]);
       }
       return result;
+    },
+
+    function sliceEntries(content) {
+      /**
+       * Cut journal text into one evaluable slice per entry:
+       * [ { text, line, startPos } ], in document order.
+       *
+       * Entry starts and triple-quoted spans both come from JrlGrammar, so
+       * this is position surgery, not pattern matching — a `"""` written
+       * inside an ordinary string cannot be mistaken for a real one. Each
+       * slice has its triple-quoted spans replaced by an empty string,
+       * which is what makes it valid JavaScript.
+       *
+       * A journal the grammar cannot read at all yields one slice holding
+       * the whole text, so a caller still gets the old behaviour rather
+       * than silence.
+       */
+      if ( ! content ) return [];
+
+      var pos;
+      try { pos = this.grammar_.collectJrlPositions(content); } catch ( e ) { pos = null; }
+      if ( ! pos || ! pos.entries || ! pos.entries.length ) {
+        return [ { text: content, line: 0, startPos: 0 } ];
+      }
+
+      var out = [];
+      for ( var i = 0 ; i < pos.entries.length ; i++ ) {
+        var start = pos.entries[i].startPos;
+        var end   = i + 1 < pos.entries.length ? pos.entries[i + 1].startPos : content.length;
+
+        var spans = [];
+        var triples = pos.tripleStrings || [];
+        for ( var t = 0 ; t < triples.length ; t++ ) {
+          var sp = triples[t];
+          if ( sp.startPos >= start && sp.endPos <= end ) {
+            spans.push({ startPos: sp.startPos - start, endPos: sp.endPos - start });
+          }
+        }
+
+        out.push({
+          text:     this.spliceTriples_(content.substring(start, end), spans),
+          line:     pos.entries[i].line,
+          startPos: start
+        });
+      }
+      return out;
+    },
+
+    function spliceTriples_(content, tripleSpans) {
+      /**
+       * Replace """...""" spans (positions relative to `content`) with an
+       * empty JS string so the content becomes evaluable.
+       */
+      var out = '';
+      var last = 0;
+      for ( var i = 0 ; i < tripleSpans.length ; i++ ) {
+        var s = tripleSpans[i];
+        if ( s.startPos < last ) continue;
+        out += content.substring(last, s.startPos) + '""';
+        last = s.endPos;
+      }
+      return out + content.substring(last);
     },
 
     function filterByClass(objects, className) {

--- a/tools/lsp/handlers/DefinitionHandler.js
+++ b/tools/lsp/handlers/DefinitionHandler.js
@@ -32,6 +32,14 @@ foam.CLASS({
       of: 'foam.parse.lsp.CursorAnalyzer',
       name: 'analyzer',
       factory: function() { return this.CursorAnalyzer.create(); }
+    },
+    {
+      name: 'journalEntryIndex',
+      documentation: `Optional. Supplies services.jrl lookups so a service
+        name written in a .js model navigates to the row that registers it.
+        Absent (tests constructing this handler bare) simply skips that
+        branch — no service jump, everything else unchanged.`,
+      value: null
     }
   ],
 
@@ -157,7 +165,41 @@ foam.CLASS({
         }
       }
 
+
+      // Last resort: a string literal that names a REGISTERED SERVICE jumps to
+      // the services.jrl row registering it. `daoKey: 'localUserDAO'` in a .js
+      // model resolved to nothing at all — JrlHandler had the rule, but only
+      // fires when the cursor is inside a .jrl file.
+      //
+      // Schema-blind on purpose, the way JrlHandler's own service rule is:
+      // nothing in a model declares that daoKey points at a journal. The
+      // evidence is the lookup itself — only services.jrl is read, and only a
+      // string that IS a registered name returns anything, so this is reached
+      // after every schema-driven branch has declined.
+      var svcJump = this.serviceNameJump_(text, position);
+      if ( svcJump ) return svcJump;
+
       return null;
+    },
+
+    function serviceNameJump_(text, position) {
+      /**
+       * A quoted string whose whole content names a registered service ->
+       * its services.jrl row. Null when there is no journal index wired, the
+       * cursor is not inside a string, or the name is not registered.
+       */
+      if ( ! this.journalEntryIndex ) return null;
+      var value = this.analyzer.getEnclosingStringContent(text, position);
+      if ( ! value ) return null;
+      var locs = this.journalEntryIndex.getServiceLocations(value);
+      if ( ! locs || ! locs.length ) return null;
+      var out = locs.map(function(l) {
+        return {
+          uri: 'file://' + l.file,
+          range: { start: { line: l.line, character: 0 }, end: { line: l.line, character: 0 } }
+        };
+      });
+      return out.length === 1 ? out[0] : out;
     },
 
     function isPomFile_(uri) {

--- a/tools/lsp/handlers/DefinitionHandler.js
+++ b/tools/lsp/handlers/DefinitionHandler.js
@@ -172,10 +172,11 @@ foam.CLASS({
       // fires when the cursor is inside a .jrl file.
       //
       // Schema-blind on purpose, the way JrlHandler's own service rule is:
-      // nothing in a model declares that daoKey points at a journal. The
-      // evidence is the lookup itself — only services.jrl is read, and only a
-      // string that IS a registered name returns anything, so this is reached
-      // after every schema-driven branch has declined.
+      // nothing in a model declares that daoKey points at a journal. What
+      // bounds it is the same thing that bounds JrlHandler's rule — the KEY
+      // must be one of SERVICE_KEY_NAMES. The lookup alone does not bound it:
+      // `file` and `blobStore` are registered service names that also occur
+      // as ordinary string values all over the tree.
       var svcJump = this.serviceNameJump_(text, position);
       if ( svcJump ) return svcJump;
 
@@ -184,11 +185,19 @@ foam.CLASS({
 
     function serviceNameJump_(text, position) {
       /**
-       * A quoted string whose whole content names a registered service ->
-       * its services.jrl row. Null when there is no journal index wired, the
-       * cursor is not inside a string, or the name is not registered.
+       * A SERVICE-KEY value whose whole content names a registered service
+       * -> its services.jrl row. Null when there is no journal index wired,
+       * the cursor is not inside a string, the string is not the value of a
+       * key in SERVICE_KEY_NAMES, or the name is not registered.
        */
       if ( ! this.journalEntryIndex ) return null;
+      // Gated on the key, exactly as JrlHandler's rule is. Without it the
+      // rule is not "a service key's value" but "any quoted word that spells
+      // a service name": `attrs({ type: 'file' })` in BlobView.js jumped to
+      // the `file` CSpec in src/services.jrl, and so did an array element.
+      var key = this.analyzer.getEnclosingKey(text, position);
+      if ( ! key ) return null;
+      if ( this.journalEntryIndex.SERVICE_KEY_NAMES.indexOf(key) === -1 ) return null;
       var value = this.analyzer.getEnclosingStringContent(text, position);
       if ( ! value ) return null;
       var locs = this.journalEntryIndex.getServiceLocations(value);

--- a/tools/lsp/handlers/JrlHandler.js
+++ b/tools/lsp/handlers/JrlHandler.js
@@ -16,7 +16,6 @@ foam.CLASS({
   ],
 
   constants: {
-    SERVICE_KEY_NAMES: [ 'daoKey' ],
     JAVA_EMBED_KEYS_: {
       javaCode: true, javaFactory: true, javaGetter: true, javaSetter: true,
       javaPreSet: true, javaPostSet: true, javaAdapt: true, javaCompare: true,
@@ -1463,7 +1462,7 @@ foam.CLASS({
         }
 
         // (B) Convention rule: schema-blind service keys -> services.jrl.
-        if ( this.SERVICE_KEY_NAMES.indexOf(segment.key) !== -1 ) {
+        if ( this.journalEntryIndex.SERVICE_KEY_NAMES.indexOf(segment.key) !== -1 ) {
           var svcLocs = this.journalEntryIndex.getServiceLocations(segment.rawValue);
           if ( svcLocs ) return this.toLocations_(svcLocs);
         }

--- a/tools/lsp/handlers/WorkspaceSymbolHandler.js
+++ b/tools/lsp/handlers/WorkspaceSymbolHandler.js
@@ -35,7 +35,11 @@ foam.CLASS({
         // side. Keeping h.filePath and taking only the line pairs a number
         // with a file that has no such line.
         var uri = 'file://' + h.filePath, line = 0, character = 0;
-        if ( h.kind === 5 || h.kind === 11 || h.kind === 10 ) {
+        if ( h.line !== undefined ) {
+          // The entry brought its own position — a services.jrl row has no
+          // class to resolve one from.
+          line = h.line;
+        } else if ( h.kind === 5 || h.kind === 11 || h.kind === 10 ) {
           line = this.index.getClassLine(h.classId);
         } else {
           var pos = this.index.getSymbolPosition(h.classId, h.name, h.kind);

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -845,6 +845,12 @@ function start() {
         reindexFile(params.textDocument.uri);
         if ( params.textDocument.uri && params.textDocument.uri.endsWith('.jrl') ) {
           journalEntryIndex.invalidate();
+          // reindexFile only reaches index.invalidate for a file that
+          // classifies as a class, so a journal save left the symbol and
+          // string-usage indexes untouched — and those now carry the
+          // services.jrl rows. A renamed service kept answering workspace
+          // symbol search under its old name until an unrelated .js save.
+          index.invalidateSymbolIndex_();
         }
         break;
 

--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -35,7 +35,10 @@ function start() {
 
   var completionHandler  = foam.parse.lsp.handlers.CompletionHandler.create({ index: index, grammar: grammar, cache: fileModelCache, cssTokenResolver: cssTokenResolver });
   var hoverHandler       = foam.parse.lsp.handlers.HoverHandler.create({ index: index, cache: fileModelCache, typeTracker: typeTracker, cssTokenResolver: cssTokenResolver });
-  var definitionHandler  = foam.parse.lsp.handlers.DefinitionHandler.create({ index: index });
+  // Created before definitionHandler because that handler takes it: a `var`
+  // declared further down is hoisted but still undefined here.
+  var journalEntryIndex  = foam.parse.lsp.JournalEntryIndex.create({ index: index });
+  var definitionHandler  = foam.parse.lsp.handlers.DefinitionHandler.create({ index: index, journalEntryIndex: journalEntryIndex });
   var i18nHandler        = foam.parse.lsp.handlers.I18nHandler.create({ index: index, cache: fileModelCache });
   // Translation provider: created here (server-start scope) so `provider` is
   // reachable from the 'initialize' case below, where config actually
@@ -51,7 +54,6 @@ function start() {
   var referencesHandler = foam.parse.lsp.handlers.ReferencesHandler.create({ index: index });
   var documentHighlightHandler = foam.parse.lsp.handlers.DocumentHighlightHandler.create();
   var renameHandler = foam.parse.lsp.handlers.RenameHandler.create({ index: index });
-  var journalEntryIndex = foam.parse.lsp.JournalEntryIndex.create({ index: index });
   var jrlHandler = foam.parse.lsp.handlers.JrlHandler.create({
     index: index,
     journalEntryIndex: journalEntryIndex

--- a/tools/tests/lsp/foamIndex.js
+++ b/tools/tests/lsp/foamIndex.js
@@ -407,3 +407,30 @@ var ownFile = index.getSymbolPosition('foam.lang.Property', 'name', 7);
 test(ownFile && ownFile.uri.split('/').pop() === 'Property.js',
   'a member in the class\'s own file still resolves there, not to a refinement'
   + ' (got ' + ( ownFile ? ownFile.uri.split('/').pop() : 'null' ) + ')');
+
+// === Registered services are workspace symbols ===
+section('FoamIndex service symbols');
+
+// A service name is not an axiom of any class, so nothing in the class walk
+// finds it. src/foam/core/auth/services.jrl registers localUserDAO.
+var svcHits = (index.searchSymbols('localUserDAO', { limit: 20 }) || [])
+  .filter(function(s) { return s.name === 'localUserDAO'; });
+test(svcHits.length > 0 && svcHits[0].kind === 13 && svcHits[0].filePath.endsWith('services.jrl'),
+  'service symbols: localUserDAO is findable, kind 13, in a services.jrl'
+  + ' (got ' + ( svcHits.length ? svcHits[0].kind + ' ' + svcHits[0].filePath.split('/').pop() : 'no hit' ) + ')');
+test(svcHits.length > 0 && svcHits[0].line > 0,
+  'service symbols: the entry carries its own line, having no class to resolve one from'
+  + ' (got line ' + ( svcHits.length ? svcHits[0].line : '?' ) + ')');
+
+// A package filter cannot match something with no class id, and must not
+// throw on the empty string either.
+var filtered = index.searchSymbols('localUserDAO', { limit: 20, packagePrefix: 'foam.u2.' }) || [];
+test(filtered.every(function(s) { return s.name !== 'localUserDAO'; }),
+  'service symbols: a package filter excludes them rather than crashing');
+
+// The CSpec identity is `name`, not `id` — requiring id skipped every row.
+var cspecUses = (index.getStringUsages('localUserDAO') || [])
+  .filter(function(u) { return u.kind === 'cspec'; });
+test(cspecUses.length > 0 && cspecUses[0].file.endsWith('services.jrl') && cspecUses[0].line > 0,
+  'cspec records: localUserDAO is recorded with its file and line'
+  + ' (got ' + ( cspecUses.length ? cspecUses[0].file.split('/').pop() + ':' + cspecUses[0].line : 'none' ) + ')');

--- a/tools/tests/lsp/foamIndex.js
+++ b/tools/tests/lsp/foamIndex.js
@@ -434,3 +434,30 @@ var cspecUses = (index.getStringUsages('localUserDAO') || [])
 test(cspecUses.length > 0 && cspecUses[0].file.endsWith('services.jrl') && cspecUses[0].line > 0,
   'cspec records: localUserDAO is recorded with its file and line'
   + ' (got ' + ( cspecUses.length ? cspecUses[0].file.split('/').pop() + ':' + cspecUses[0].line : 'none' ) + ')');
+
+// The services.jrl walk must ask getJournalDirs, not getIndexedDirs:
+// src/services.jrl is 38 registrations in a directory holding no class file
+// at all, so a walk of indexed sources alone never opens it.
+var jDirs = index.getJournalDirs();
+var iDirs = index.getIndexedDirs();
+test(jDirs.length > iDirs.length,
+  'getJournalDirs is a superset of getIndexedDirs (pom locations added)'
+  + ' (' + jDirs.length + ' vs ' + iDirs.length + ')');
+
+var srcRoot = path.resolve(__dirname, '../../../src');
+test(iDirs.indexOf(srcRoot) === -1 && jDirs.indexOf(srcRoot) !== -1,
+  'getJournalDirs reaches src/, which holds services.jrl and no class file');
+
+// The registrations themselves, by name, in the string-usage index.
+var fileCspec = (index.getStringUsages('file') || [])
+  .filter(function(u) { return u.kind === 'cspec' && /[\/\\]src[\/\\]services\.jrl$/.test(u.file); });
+test(fileCspec.length > 0 && fileCspec[0].line > 0,
+  'src/services.jrl registrations are recorded (file CSpec at line '
+  + ( fileCspec.length ? fileCspec[0].line : '?' ) + ')');
+
+var srcSvcSymbols = (index.searchSymbols('blobStore', { limit: 20 }) || [])
+  .filter(function(s) { return s.name === 'blobStore' && s.kind === 13 &&
+    /[\/\\]src[\/\\]services\.jrl$/.test(s.filePath); });
+test(srcSvcSymbols.length > 0 && srcSvcSymbols[0].line > 0,
+  'and they are workspace symbols — blobStore is findable in src/services.jrl'
+  + ' (line ' + ( srcSvcSymbols.length ? srcSvcSymbols[0].line : '?' ) + ')');

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -1378,3 +1378,162 @@ if ( fs.existsSync(realServices) ) {
   test(realLoaded.length > 0 && realLoaded.some(function(o) { return o.name === 'cSpecDAO'; }),
     'JrlLoader: src/services.jrl loads (' + realLoaded.length + ' entries) and contains cSpecDAO');
 }
+
+// === One slice-and-blank step, shared ===
+section('JournalEntryIndex / JrlLoader share sliceEntries');
+
+// The two used to compute the same spans from the same grammar output. The
+// invariant that keeps them honest: on a journal whose triple-quoted block
+// CONTAINS a fake entry start, both must cut it in the same places, because
+// both now ask JrlLoader.sliceEntries.
+var sharedJrl = [
+  'p({',
+  '  "class":"foam.core.boot.CSpec",',
+  '  "name":"sharedAlpha",',
+  '  "serviceScript":"""',
+  '    p({ "class":"foam.core.boot.CSpec", "name":"notAnEntry" })',
+  '  """',
+  '})',
+  '',
+  'p({"class":"foam.core.boot.CSpec","name":"sharedBeta"})'
+].join('\n');
+
+var sharedLoader = foam.parse.lsp.JrlLoader.create();
+var sharedSlices = sharedLoader.sliceEntries(sharedJrl);
+test(sharedSlices.length === 2 && sharedSlices[0].line === 0 && sharedSlices[1].line === 8,
+  'sliceEntries: the fake entry head inside """...""" does not start a slice'
+  + ' (got ' + sharedSlices.length + ' slices at lines '
+  + sharedSlices.map(function(s) { return s.line; }).join(',') + ')');
+
+// Named services.jrl in its own dir: getServiceLocations only ever reads a
+// file with that basename.
+var sharedDir  = fs.mkdtempSync(path.join(require('os').tmpdir(), 'lsp-jrl-shared-'));
+var sharedFile = path.join(sharedDir, 'services.jrl');
+fs.writeFileSync(sharedFile, sharedJrl);
+var sharedJei = foam.parse.lsp.JournalEntryIndex.create({
+  index: index, journalFiles: [ sharedFile ] });
+var sharedRecs = sharedJei.parseFile_(sharedJrl);
+test(sharedRecs.length === sharedSlices.length &&
+     sharedRecs.map(function(r) { return r.line; }).join(',') ===
+     sharedSlices.map(function(s) { return s.line; }).join(','),
+  'JournalEntryIndex cuts the same journal in the same places as JrlLoader'
+  + ' (got ' + sharedRecs.map(function(r) { return r.key + '@' + r.line; }).join(',') + ')');
+test(sharedJei.getServiceLocations('sharedAlpha') !== null &&
+     sharedJei.getServiceLocations('notAnEntry') === null,
+  'and the name inside the blanked block registers nothing');
+try { fs.rmSync(sharedDir, { recursive: true, force: true }); } catch ( e ) {}
+
+// === Saving a .jrl refreshes the SYMBOL index too, over the wire ===
+// reindexFile only reaches index.invalidate for a file that classifies as a
+// class, so before this the didSave(.jrl) branch refreshed JournalEntryIndex
+// and left symbolIndex_ (which now carries the services.jrl rows) stale: a
+// renamed service kept answering workspace/symbol under its old name.
+// Driven through the real server because the bug IS the wiring — the handler
+// and the index were both already correct.
+var os = require('os');
+var jrlSaveDone = h.withServerLane(async function() {
+  var origWrite = process.stdout.write;
+  var wsDir = null;
+  var pomPushed = false;
+  try {
+    var frames = [];
+    var inBuf  = Buffer.alloc(0);
+    function drain() {
+      while ( true ) {
+        var headerEnd = inBuf.indexOf('\r\n\r\n');
+        if ( headerEnd === -1 ) return;
+        var m = /Content-Length:\s*(\d+)/i.exec(inBuf.slice(0, headerEnd).toString('utf8'));
+        if ( ! m ) { inBuf = inBuf.slice(headerEnd + 4); continue; }
+        var len = parseInt(m[1], 10), bodyStart = headerEnd + 4;
+        if ( inBuf.length < bodyStart + len ) return;
+        var body = inBuf.slice(bodyStart, bodyStart + len).toString('utf8');
+        inBuf = inBuf.slice(bodyStart + len);
+        try { frames.push(JSON.parse(body)); } catch ( e ) {}
+      }
+    }
+    process.stdout.write = function(chunk) {
+      inBuf = Buffer.concat([ inBuf, Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), 'utf8') ]);
+      drain();
+      return true;
+    };
+
+    var nextId = 1;
+    function send(method, params, wantId) {
+      var msg = { jsonrpc: '2.0', method: method, params: params };
+      if ( wantId ) msg.id = nextId++;
+      var json = JSON.stringify(msg);
+      process.stdin.emit('data', Buffer.from(
+        'Content-Length: ' + Buffer.byteLength(json) + '\r\n\r\n' + json, 'utf8'));
+      return msg.id;
+    }
+    function waitFor(pred, what) {
+      return new Promise(function(resolve, reject) {
+        var deadline = Date.now() + 20000;
+        (function poll() {
+          for ( var i = 0 ; i < frames.length ; i++ ) if ( pred(frames[i]) ) return resolve(frames[i]);
+          if ( Date.now() > deadline ) return reject(new Error('timed out waiting for ' + what));
+          setTimeout(poll, 10);
+        })();
+      });
+    }
+    function request(method, params, what) {
+      var id = send(method, params, true);
+      return waitFor(function(m) { return m.id === id; }, what);
+    }
+
+    // A journal directory the server's index will discover: getJournalDirs
+    // reads foam.poms at call time, so pushing it before the first query is
+    // enough — no class file needs to live there.
+    wsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lsp-jrlsave-'));
+    var svcPath = path.join(wsDir, 'services.jrl');
+    var svcUri  = 'file://' + svcPath;
+    fs.writeFileSync(svcPath,
+      'p({"class":"foam.core.boot.CSpec","name":"lspSaveProbeAlpha","serve":true})\n');
+    foam.poms = foam.poms || [];
+    foam.poms.push({ location: wsDir });
+    pomPushed = true;
+
+    process.stdin.removeAllListeners('data');
+    require('../../lsp/server').start();
+    process.stdin.removeAllListeners('end');
+    frames = [];
+    inBuf  = Buffer.alloc(0);
+
+    await request('initialize', { rootUri: 'file://' + wsDir, capabilities: {} },
+      'the initialize response');
+
+    function names(res) {
+      return ((res && res.result) || []).map(function(s) { return s.name; });
+    }
+
+    var before = await request('workspace/symbol', { query: 'lspSaveProbe' },
+      'the first workspace/symbol answer');
+    test(names(before).indexOf('lspSaveProbeAlpha') !== -1,
+      'jrl save: the registered service answers workspace/symbol before the edit'
+      + ' (got ' + JSON.stringify(names(before)) + ')');
+
+    // Rename on disk, then save. Nothing else changes — no .js is touched,
+    // which is exactly the case that used to leave the old name answering.
+    fs.writeFileSync(svcPath,
+      'p({"class":"foam.core.boot.CSpec","name":"lspSaveProbeBeta","serve":true})\n');
+    send('textDocument/didSave', { textDocument: { uri: svcUri } });
+
+    var after = await request('workspace/symbol', { query: 'lspSaveProbe' },
+      'the workspace/symbol answer after the save');
+    test(names(after).indexOf('lspSaveProbeBeta') !== -1,
+      'jrl save: the renamed service is findable under its new name'
+      + ' (got ' + JSON.stringify(names(after)) + ')');
+    test(names(after).indexOf('lspSaveProbeAlpha') === -1,
+      'jrl save: and no longer under the old one'
+      + ' (got ' + JSON.stringify(names(after)) + ')');
+  } finally {
+    process.stdout.write = origWrite;
+    process.stdin.removeAllListeners('data');
+    if ( pomPushed ) foam.poms.pop();
+    if ( wsDir ) { try { fs.rmSync(wsDir, { recursive: true, force: true }); } catch ( e ) {} }
+  }
+});
+
+module.exports = { done: jrlSaveDone.catch(function(e) {
+  test(false, 'jrl save lane failed — ' + ( e && e.message ? e.message : e ));
+}) };

--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -1321,3 +1321,60 @@ var dId = navHandler.handleDefinition(
   menusText2, valuePos(menusText2, '"id":"cookbook.recipe"'),
   'file://' + path.join(jrlnavDir, 'menus.jrl'));
 test(dId === null, 'nav: dotted menu id is not a class ref -> null');
+
+// === JrlLoader: a journal is not one JavaScript program ===
+section('JrlLoader entry slicing');
+
+var jrlLoader = foam.parse.lsp.JrlLoader.create();
+
+// FOAM writes long values as triple-quoted strings. No JS engine accepts
+// those, so evaluating a whole journal as one function body throws at
+// CONSTRUCTION and collects nothing at all — not "whatever came before".
+var tripleJrl = [
+  'p({',
+  '  "class":"foam.core.boot.CSpec",',
+  '  "name":"probeAlphaDAO",',
+  '  "serviceScript":"""',
+  '    x = 1;',
+  '  """',
+  '})',
+  'p({',
+  '  "class":"foam.core.boot.CSpec",',
+  '  "name":"probeBetaDAO"',
+  '})'
+].join('\n');
+
+var tripleLoaded = jrlLoader.loadString(tripleJrl);
+test(tripleLoaded.length === 2,
+  'JrlLoader: a triple-quoted value no longer costs the whole file'
+  + ' (got ' + tripleLoaded.length + ' entries)');
+test(tripleLoaded.some(function(o) { return o.name === 'probeAlphaDAO'; }) &&
+     tripleLoaded.some(function(o) { return o.name === 'probeBetaDAO'; }),
+  'JrlLoader: both entries survive, the triple-quoted one included');
+
+// One unparseable entry drops itself and nothing else.
+var brokenJrl = [
+  'p({ "class":"foam.core.boot.CSpec", "name":"probeGoodOne" })',
+  'p({ "class":"foam.core.boot.CSpec", "name": })',
+  'p({ "class":"foam.core.boot.CSpec", "name":"probeGoodTwo" })'
+].join('\n');
+var brokenLoaded = jrlLoader.loadString(brokenJrl);
+test(brokenLoaded.length === 2 &&
+     brokenLoaded.map(function(o) { return o.name; }).join(',') === 'probeGoodOne,probeGoodTwo',
+  'JrlLoader: a malformed entry costs only itself'
+  + ' (got ' + brokenLoaded.map(function(o) { return o.name; }).join(',') + ')');
+
+// Lines come back with the entries — a services.jrl row is worth pointing at.
+var withLines = jrlLoader.loadStringWithLines(tripleJrl);
+test(withLines.length === 2 && withLines[0].line === 0 && withLines[1].line === 7,
+  'JrlLoader: loadStringWithLines reports each entry\'s start line'
+  + ' (got ' + withLines.map(function(e) { return e.line; }).join(',') + ')');
+
+// Not a fixture: the repo's own journal, which is the file the old loader
+// silently returned nothing for.
+var realServices = path.resolve(__dirname, '../../../src/services.jrl');
+if ( fs.existsSync(realServices) ) {
+  var realLoaded = jrlLoader.loadFile(realServices);
+  test(realLoaded.length > 0 && realLoaded.some(function(o) { return o.name === 'cSpecDAO'; }),
+    'JrlLoader: src/services.jrl loads (' + realLoaded.length + ' entries) and contains cSpecDAO');
+}

--- a/tools/tests/lsp/navigation.js
+++ b/tools/tests/lsp/navigation.js
@@ -774,3 +774,64 @@ var plainText = daoKeyText.replace('localUserDAO', 'notARegisteredServiceName');
 var plainLoc = svcDefHandler.handle(plainText, { line: 4, character: 48 }, 'file:///probe/DaoKeyProbe.js');
 test(plainLoc === null,
   'service jump: an ordinary string is left alone (got ' + JSON.stringify(plainLoc) + ')');
+
+// The rule is "a SERVICE KEY's value", not "any quoted word". `file` and
+// `blobStore` are registered CSpecs in src/services.jrl and also ordinary
+// string values all over the tree, so the negative case has to be a
+// REGISTERED name in a non-service position — an unregistered name passes
+// with or without the gate and proves nothing.
+var svcNegatives = [
+  { what: 'an attribute value',
+    src: "foam.CLASS({ package: 'p', name: 'N', methods: [ function render() {\n" +
+         "  this.start('input').attrs({ type: 'file' }).end();\n} ] });",
+    line: 1, find: "'file'" },
+  { what: 'an array element',
+    src: "foam.CLASS({ package: 'p', name: 'N',\n" +
+         "  properties: [ { class: 'StringArray', name: 'xs', value: [ 'file' ] } ] });",
+    line: 1, find: "'file'" },
+  { what: 'a non-service key',
+    src: "foam.CLASS({ package: 'p', name: 'N',\n" +
+         "  properties: [ { class: 'String', name: 'x', label: 'blobStore' } ] });",
+    line: 1, find: "'blobStore'" }
+];
+svcNegatives.forEach(function(c) {
+  var col = c.src.split('\n')[c.line].indexOf(c.find) + 2;
+  var got = svcDefHandler.handle(c.src, { line: c.line, character: col }, 'file:///probe/N.js');
+  test(got === null,
+    'service jump: ' + c.what + ' spelling a registered service is left alone'
+    + ' (got ' + JSON.stringify(got && got.uri ? got.uri.split('/').pop() + ':' + got.range.start.line : got) + ')');
+});
+
+// Not a fixture: the file the review named. BlobView really does write
+// attrs({ type: 'file' }), and `file` really is a CSpec in src/services.jrl.
+var blobPath = path.resolve(__dirname, '../../../src/foam/u2/view/BlobView.js');
+if ( fs.existsSync(blobPath) ) {
+  var blobText  = fs.readFileSync(blobPath, 'utf8');
+  var blobLines = blobText.split('\n');
+  var blobLine  = -1;
+  for ( var bi = 0 ; bi < blobLines.length ; bi++ ) {
+    if ( blobLines[bi].indexOf("type: 'file'") !== -1 ) { blobLine = bi; break; }
+  }
+  test(blobLine !== -1, 'service jump: BlobView.js still writes attrs({ type: ' + Q + 'file' + Q + ' })');
+  if ( blobLine !== -1 ) {
+    var blobCol = blobLines[blobLine].indexOf("type: 'file'") + "type: '".length + 1;
+    var blobGot = svcDefHandler.handle(blobText, { line: blobLine, character: blobCol },
+      'file://' + blobPath);
+    test(blobGot === null,
+      'service jump: cmd-click on BlobView.js attrs({ type: ' + Q + 'file' + Q + ' }) does not enter services.jrl'
+      + ' (got ' + JSON.stringify(blobGot && blobGot.uri ? blobGot.uri.split('/').pop() + ':' + blobGot.range.start.line : blobGot) + ')');
+  }
+}
+
+// getEnclosingKey itself, since the gate is only as good as it is.
+// h.analyzer, not `analyzer` — line 703 rebinds that name to a
+// WorkspaceAnalyzer for the rest of the file.
+var cursorAnalyzer = h.analyzer;
+test(cursorAnalyzer.getEnclosingKey("  daoKey: 'localUserDAO'", { line: 0, character: 14 }) === 'daoKey',
+  'getEnclosingKey: reads the key of the string the cursor is in');
+test(cursorAnalyzer.getEnclosingKey('  "daoKey": "localUserDAO"', { line: 0, character: 16 }) === 'daoKey',
+  'getEnclosingKey: a quoted key reads the same');
+test(cursorAnalyzer.getEnclosingKey("  value: [ 'localUserDAO' ]", { line: 0, character: 14 }) === null,
+  'getEnclosingKey: an array element has no key of its own');
+test(cursorAnalyzer.getEnclosingKey("  daoKey: 'localUserDAO'", { line: 0, character: 3 }) === null,
+  'getEnclosingKey: the cursor on the key itself is not inside the value');

--- a/tools/tests/lsp/navigation.js
+++ b/tools/tests/lsp/navigation.js
@@ -744,3 +744,33 @@ var ownLoc = defHandler.resolveMemberOnClass_('foam.lang.Property', 'name');
 test(ownLoc && ownLoc.uri.indexOf('Property.js') !== -1,
   'resolveMemberOnClass_: a property in the class\'s own file still resolves there'
   + ' (got ' + ( ownLoc ? ownLoc.uri.split('/').pop() : 'null' ) + ')');
+
+// === A service name in a .js model navigates to services.jrl ===
+// JrlHandler has had this rule, but it only fires with the cursor inside a
+// .jrl file. In a model, daoKey: 'localUserDAO' resolved to nothing.
+var svcDefHandler = foam.parse.lsp.handlers.DefinitionHandler.create({
+  index: index,
+  journalEntryIndex: foam.parse.lsp.JournalEntryIndex.create({ index: index })
+});
+var daoKeyText = [
+  "foam.CLASS({",
+  "  package: 'probe',",
+  "  name: 'DaoKeyProbe',",
+  "  properties: [",
+  "    { class: 'String', name: 'x', daoKey: 'localUserDAO' }",
+  "  ]",
+  "});"
+].join('\n');
+var daoKeyLoc = svcDefHandler.handle(daoKeyText, { line: 4, character: 48 }, 'file:///probe/DaoKeyProbe.js');
+test(daoKeyLoc && ! Array.isArray(daoKeyLoc) && daoKeyLoc.uri.endsWith('services.jrl'),
+  'service jump: daoKey value in a .js model resolves to a services.jrl'
+  + ' (got ' + ( daoKeyLoc ? ( Array.isArray(daoKeyLoc) ? daoKeyLoc.length + ' locs' : daoKeyLoc.uri.split('/').pop() ) : 'null' ) + ')');
+test(daoKeyLoc && ! Array.isArray(daoKeyLoc) && daoKeyLoc.range.start.line > 0,
+  'service jump: and at the registering row, not the top of the file'
+  + ' (got line ' + ( daoKeyLoc && ! Array.isArray(daoKeyLoc) ? daoKeyLoc.range.start.line : '?' ) + ')');
+
+// A string that is NOT a registered service must not be hijacked.
+var plainText = daoKeyText.replace('localUserDAO', 'notARegisteredServiceName');
+var plainLoc = svcDefHandler.handle(plainText, { line: 4, character: 48 }, 'file:///probe/DaoKeyProbe.js');
+test(plainLoc === null,
+  'service jump: an ordinary string is left alone (got ' + JSON.stringify(plainLoc) + ')');


### PR DESCRIPTION
`JrlLoader` evaluated a whole journal as one `new Function('p','c','r', content)`. FOAM writes long values as triple-quoted strings, which no JS engine accepts, so it threw a SyntaxError **at construction** — the body never ran and nothing was collected. The `catch` comment says it returns whatever came before the error. There was never anything.

```
services.jrl files=78   parseOK=10   SyntaxError=68   containTripleQuote=68
all .jrl sampled=365    parseOK=246  SyntaxError=119
```

Perfect correlation with `"""`. `src/services.jrl` is 16KB of registrations and returned zero entries.

Entries are now cut on the grammar's own entry starts and each is evaluated alone with its triple-quoted spans blanked — position surgery, not pattern matching, so a `"""` written inside an ordinary string can't be mistaken for a real one. A malformed entry costs only itself. `src/services.jrl`: **0 → 38 entries**.

`JournalEntryIndex` already did this correctly for its own lookups; the shared step now lives in `JrlLoader.sliceEntries()` so there's one copy.

Two more layers were stacked behind that, each invisible while the loader returned nothing:

- The cspec branch required `ent.id`. A CSpec's identity is its **`name`** — that's what an `imports:` key is matched against — so every row in every `services.jrl` was skipped. `cspecRecords 0 → 310`, index names `377 → 590`, and **213 of those names have no other record anywhere in the string-usage index**.
- The walk that finds those files took one directory per indexed class file. No class file sits directly in `src/`, so `src/services.jrl` — 38 registrations including `file`, `blobStore` and `httpServer` — was never opened. `FoamIndex.getJournalDirs()` (pom locations plus indexed dirs) is now the one answer to "where can a `.jrl` live", shared with `JournalEntryIndex.findJournalFiles_` so the two can't drift.
- `symbolIndex_` is built from class axioms, and a service is not an axiom of any class. `searchSymbols('localUserDAO')` found nothing while `src/foam/core/auth/services.jrl:409` registered it. Services are now kind 13 (Variable — a name in the context, not a type), carrying their own file and line since there's no class to resolve a position from. A `.jrl` save drops that index too: `reindexFile` reaches `index.invalidate` only for a file that classifies as a class, so `didSave` now calls `index.invalidateSymbolIndex_()` alongside the journal one, and a renamed service stops answering under its old name.

`DefinitionHandler` gained the mirror of `JrlHandler`'s service rule. `daoKey: 'localUserDAO'` in a `.js` model resolved to nothing, because that rule only fires with the cursor inside a `.jrl` file. It's schema-blind on purpose — nothing in a model declares that `daoKey` points at a journal — and bounded the same way `JrlHandler`'s rule is, on the key: `CursorAnalyzer.getEnclosingKey()` has to name one of `SERVICE_KEY_NAMES` before the lookup runs. The lookup on its own is no bound, since `file`, `blobStore`, `export` and `static` are registered service names as well as ordinary string values. It runs last, after every schema-driven branch has declined. `SERVICE_KEY_NAMES` moved to `JournalEntryIndex` so both handlers read one copy.

**Cost:** `buildStringUsageIndex_` is one-time and lazy — 298ms cold, 115ms warm, and widening the directory walk from 299 to 302 costs nothing measurable (302ms/107ms on the narrow walk, inside the noise). `loadString` is 1.3ms per `services.jrl`, where it previously failed instantly.

**Not in here.** Surfacing `services.jrl` rows as references for a class would need a CSpec id to match its result type's class id, and the overlap between service names and known class ids in this repo is **0**. The class references that do live in journals sit mostly inside `serviceScript`, the triple-quoted blocks this has to blank to make an entry evaluable. That's the blind spot in #5264/#5265 and it needs its own design.

Thirty-one tests, and each behavioural part goes red on its own when reverted: reverting `JrlLoader` reds the loader tests, `getJournalDirs` reds the `src/services.jrl` tests, `DefinitionHandler`'s key gate reds the jump tests (`got "services.jrl:218"` on `attrs({ type: 'file' })` in `BlobView.js`), and the `didSave` line reds the save lane (`got ["lspSaveProbeAlpha"]`). The negative cases use *registered* names in non-service positions, since an unregistered one passes either way. The one test that can't go red is the slicing agreement between `JournalEntryIndex` and `JrlLoader` — the two copies did agree, so it guards divergence from here on rather than proving this change.

Suite 1772/0.

Merge order: independent. Nothing else is in flight.
