### PR TITLE
fix(security): prevent path traversal and XSS in FileWebAgent

### DIFF
--- a/src/foam/core/http/FileWebAgent.java
+++ b/src/foam/core/http/FileWebAgent.java
@@ -61,11 +61,11 @@ public class FileWebAgent
 
     try {
       path = req.getRequestURI().replaceFirst("/?service/" + nspec_.getName() + "/?", "") + path_;
-      File src = new File(SafetyUtil.isEmpty(path) ? "./" : path);
+      File cwdFile = new File(SafetyUtil.isEmpty(cwd_) ? System.getProperty("user.dir") : cwd_).getCanonicalFile();
+      File src = new File(cwdFile, SafetyUtil.isEmpty(path) ? "./" : path).getCanonicalFile();
 
-      // Checking that it starts with the CanonicalPath prevents path escaping
-      boolean pathStartsWithCwd = src.getAbsolutePath().startsWith(cwd_);
-      if ( ! pathStartsWithCwd ) {
+      // Ensure that the canonical path stays within cwd to prevent path escaping
+      if ( ! src.toPath().startsWith(cwdFile.toPath()) ) {
         throw new FileNotFoundException("File not found: " + path);
       }
 
@@ -80,10 +80,13 @@ public class FileWebAgent
                 "<ul style=\"list-style-type:disc\">");
 
         File[] files = src.listFiles();
-        for ( File file : files ) {
-          pw.write("<li>" + "<a href=\"/service/" + StringEscapeUtils.escapeHtml4(nspec_.getName()) + "/" + path
-              + ( ! path.isEmpty() && ! path.endsWith("/") ? "/" : "" )
-              + file.getName() + "\"?>" + file.getName() + "</a></li>");
+        if ( files != null ) {
+          for ( File file : files ) {
+            String escapedName = StringEscapeUtils.escapeHtml4(file.getName());
+            pw.write("<li>" + "<a href=\"/service/" + StringEscapeUtils.escapeHtml4(nspec_.getName()) + "/" + StringEscapeUtils.escapeHtml4(path)
+                + ( ! path.isEmpty() && ! path.endsWith("/") ? "/" : "" )
+                + escapedName + "\">" + escapedName + "</a></li>");
+          }
         }
 
         pw.write("</ul></body></html>");


### PR DESCRIPTION
### Summary
This PR addresses path traversal and HTML injection/XSS issues in `FileWebAgent`:

1. **Path Traversal Protection**:
   - Previously, path containment was checked via `src.getAbsolutePath().startsWith(cwd_)` against a raw `new File(...)` path, which did not resolve `..` segments or symbolic links before validation.
   - Now canonicalizes both the base working directory (`cwdFile`) and the target file (`src`), verifying that `src.toPath().startsWith(cwdFile.toPath())`.
2. **Directory Listing Hardening**:
   - Added HTML entity escaping (`StringEscapeUtils.escapeHtml4`) to `file.getName()` and `path` in generated directory listing anchors.
   - Added null-safety check on `src.listFiles()` to guard against unreadable or restricted directories.
   - Fixed HTML syntax typo (`\"?>` -> `\">`).

Co-authored-by: Privateer <291203302+privateer-first-mate@users.noreply.github.com>