### PR TITLE
Reflow markdown: wrapped paragraphs, and markdown inside an HTML block

### DIFF
--- a/src/foam/u2/view/MarkdownView.js
+++ b/src/foam/u2/view/MarkdownView.js
@@ -190,7 +190,16 @@ foam.CLASS({
             '\n'
           ),
 
-          paragraph: sym('inlineContent'),
+          // A wrapped paragraph is one paragraph: a newline continues it unless
+          // the next line opens a different block.
+          paragraph: repeat(sym('inlineContent'), sym('softBreak'), 1),
+
+          softBreak: seq0('\n', not(sym('blockLineStart'))),
+
+          blockLineStart: alt(
+            '\n', '#', '```', '> ', '- ', '* ', '+ ', '|', '---', '***', '___',
+            seq(repeat(range('0', '9'), null, 1), '. ')
+          ),
 
           blankLine: peek('\n'),
 
@@ -427,7 +436,12 @@ foam.CLASS({
         },
 
         function paragraph(v) {
-          return function() { this.start().addClass('p','mdParagraph').call(v); };
+          return function() {
+            this.start().addClass('p','mdParagraph').call(function() {
+              // Wrapped lines rejoin with a space, not a line break.
+              v.forEach((line, i) => { if ( i ) this.add(' '); line.call(this); });
+            });
+          };
         },
 
         function blankLine(v) {
@@ -467,7 +481,15 @@ foam.CLASS({
         },
 
         function htmlText(v) {
-          return function() { this.add(v); };
+          // Multi-line content inside a tag is block markdown -- the <details>
+          // case -- so parse it. A single line stays plain text, or <b>x</b>
+          // would render its text as a paragraph.
+          if ( v.indexOf('\n') == -1 ) return function() { this.add(v); };
+
+          let fs = this.markdownGrammar.parseString(v);
+          if ( ! fs ) return function() { this.add(v); };
+
+          return function() { fs.forEach(f => this.call(f)); };
         },
 
         function text(v) {


### PR DESCRIPTION
I was writing setup docs in a markdown block and kept getting something other than what I typed.

## Wrapped paragraphs

I wrote one paragraph over two lines:

```markdown
This Console offers reflow_run and reflow_state to AI
tools while the tab is open.
```

I got two, a full `1rem` apart:

> This Console offers reflow_run and reflow_state to AI
>
> tools while the tab is open.

A single newline is a soft break inside a paragraph, so one was what I expected. `paragraph` matched a single line and `START` splits elements on `\n`, so every wrapped line became its own `div.p`.

**Fix.** `paragraph` now repeats `inlineContent` across a `softBreak`: a newline not followed by a heading, list, quote, fence, table or rule. The lines rejoin with a space:

> This Console offers reflow_run and reflow_state to AI tools while the tab is open.

## Markdown inside `<details>`

Then I wrote a collapsible with a list in it:

```markdown
<details>
<summary><b>Claude Code</b></summary>

1. Install the [bridge extension](https://github.com/MCPCat/webmcp-react)
2. Run `npx webmcp-server`

</details>
```

I got my characters back, brackets and backticks and all, on one line:

> 1. Install the [bridge extension](https://github.com/MCPCat/webmcp-react) 2. Run \`npx webmcp-server\`

I expected the numbered list with a working link, since the blank line after `<summary>` puts the content in markdown again. `htmlContent` takes nested HTML or raw text, so nothing inside the tag reached the grammar.

**Fix.** `htmlText` now re-parses its content when it spans several lines:

> 1. Install the [bridge extension](https://github.com/MCPCat/webmcp-react)
> 2. Run `npx webmcp-server`

Single-line text is still added as-is, so `<b>x</b>` does not turn into a paragraph.
