### PR TITLE
Reflow: show a running command, and give every failure the same block

### DIFF
--- a/src/foam/core/reflow/Block.js
+++ b/src/foam/core/reflow/Block.js
@@ -101,6 +101,19 @@ foam.CLASS({
     },
     {
       class: 'Boolean',
+      name: 'isLoading_',
+      hidden: true,
+      transient: true,
+      documentation: `True while the block's command is running. Set by
+        Console.eval_, so every command that awaits reports itself without
+        knowing an indicator exists; the toolbar watches it through
+        Console.currentBlock. Not rendered here: a block joins the flow only
+        after its command finishes, so it has no DOM to show a spinner in.
+        Transient -- a block's saved script and undo history describe the
+        document, not what it was doing.`
+    },
+    {
+      class: 'Boolean',
       name: 'allowLimitedEdit',
       documentation: 'When true, Block configuration remains accessible in LIMIT_EDIT_CONSOLE mode.'
     },

--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1576,51 +1576,59 @@ foam.CLASS({
         tag: block.out.tag.bind(block.out)
       };
 
-      // TODO: move into Block
-      with ( this.localScope ) { with ( innerScope ) { with ( this.flowScope ) {
-        let scope = { ...(this.scope || {} ), ...this.localScope };
-        var r, arg;
-        let originalCmd = cmd;
-        try {
-          r = eval(cmd);
-          if ( ! block.flowName ) {
-            // For commands like 'cells(2,3)' pickout 'cells' as the block name
-            var m = cmd.match(/^\s*([a-zA-Z][a-zA-Z0-9_\$]*)\(/);
-            block.flowName = m ? m[1] : 'a';
-            // Make sure we aren't duplicating an existing name;
-            block.flowName = this.createFlowChildName(block.flowName);
-          }
-        } catch (x) {
-          var i = cmd.indexOf(' ');
-          if ( i != -1 ) {
-            arg = cmd.substring(i+1);
-            cmd = cmd.substring(0,i);
-            r = scope[cmd];
-          } else {
-            r = scope[cmd];
-          }
-          if ( r ) {
-            block.flowName = this.createFlowChildName(cmd);
-          } else {
-            console.log(x);
-            block.flowName = this.createFlowChildName('error');
-//            block.value = foam.lang.StringHolder.create({value: x.toString() + ', ' + originalCmd});
-            block.value = this.BadBlock.create({block: block, error: x.message});
-            block.error = x.message;
-          }
-        }
+      // Every command that awaits reports itself busy, without knowing an
+      // indicator exists: the toolbar watches currentBlock.isLoading_.
+      block.isLoading_ = true;
 
-        // Name the block if it hasn't already been named
-        if ( ! block.flowName ) block.flowName = this.createFlowChildName('a');
-        if ( typeof r === 'function' ) {
-          if ( ! block.flowName.startsWith(cmd) )
-            block.flowName = this.createFlowChildName(cmd);
-          r = arg ? r(arg) : r();
-        }
-        if ( r instanceof Promise ) {
-          r = await r;
-        }
-      }}}
+      try {
+        // TODO: move into Block
+        with ( this.localScope ) { with ( innerScope ) { with ( this.flowScope ) {
+          let scope = { ...(this.scope || {} ), ...this.localScope };
+          var r, arg;
+          let originalCmd = cmd;
+          try {
+            r = eval(cmd);
+            if ( ! block.flowName ) {
+              // For commands like 'cells(2,3)' pickout 'cells' as the block name
+              var m = cmd.match(/^\s*([a-zA-Z][a-zA-Z0-9_\$]*)\(/);
+              block.flowName = m ? m[1] : 'a';
+              // Make sure we aren't duplicating an existing name;
+              block.flowName = this.createFlowChildName(block.flowName);
+            }
+          } catch (x) {
+            var i = cmd.indexOf(' ');
+            if ( i != -1 ) {
+              arg = cmd.substring(i+1);
+              cmd = cmd.substring(0,i);
+              r = scope[cmd];
+            } else {
+              r = scope[cmd];
+            }
+            if ( r ) {
+              block.flowName = this.createFlowChildName(cmd);
+            } else {
+              console.log(x);
+              block.flowName = this.createFlowChildName('error');
+  //            block.value = foam.lang.StringHolder.create({value: x.toString() + ', ' + originalCmd});
+              block.value = this.BadBlock.create({block: block, error: x.message});
+              block.error = x.message;
+            }
+          }
+
+          // Name the block if it hasn't already been named
+          if ( ! block.flowName ) block.flowName = this.createFlowChildName('a');
+          if ( typeof r === 'function' ) {
+            if ( ! block.flowName.startsWith(cmd) )
+              block.flowName = this.createFlowChildName(cmd);
+            r = arg ? r(arg) : r();
+          }
+          if ( r instanceof Promise ) {
+            r = await r;
+          }
+        }}}
+      } finally {
+        block.isLoading_ = false;
+      }
 
       flowParent.addFlowChild(block);
 

--- a/src/foam/core/reflow/ReflowToolBar.js
+++ b/src/foam/core/reflow/ReflowToolBar.js
@@ -12,7 +12,8 @@ foam.CLASS({
 
   requires: [
     'foam.core.reflow.ToolbarControl',
-    'foam.mlang.sink.Count'
+    'foam.mlang.sink.Count',
+    'foam.u2.LoadingSpinner'
   ],
 
   imports: [ 'showPrompts','toolbarControlDAO', 'data as importedData' ],
@@ -98,6 +99,13 @@ foam.CLASS({
                   });
               });
           })).
+          // A block is only added to the flow once its command has finished, so
+          // the prompt is where a running command has to report itself.
+          start('span').
+            attrs({ role: 'status', 'aria-live': 'polite' }).
+            show(self.data.currentBlock$.dot('isLoading_')).
+            tag(this.LoadingSpinner, { size: 16 }).
+          end().
         end().
         startContext({ data: this }).
           start().

--- a/src/foam/core/reflow/ai/AgentCommand.js
+++ b/src/foam/core/reflow/ai/AgentCommand.js
@@ -99,9 +99,9 @@ foam.CLASS({
         // Use when offline. TODO: make a mock llmService for when offline
         // result = { content: 'h1 done' };
       } catch (e) {
-        throw 'LLM error: ' + e;
-//        flow.insertError('LLM error: ' + e.message);
-        return;
+        // An Error, not a string: eval_ builds the BadBlock from x.message, so a
+        // thrown string renders an error block with nothing in it.
+        throw new Error('LLM error: ' + ( e.message || e ));
       }
 
       // ── 3. Parse response into command lines ──

--- a/src/foam/core/reflow/ai/AskCommand.js
+++ b/src/foam/core/reflow/ai/AskCommand.js
@@ -9,7 +9,7 @@ foam.CLASS({
   name: 'AskCommand',
   extends: 'foam.core.reflow.cmd.Command',
 
-  imports: [ 'eval_', 'currentBlock' ],
+  imports: [ 'eval_' ],
 
   /*
   properties: [
@@ -27,14 +27,15 @@ foam.CLASS({
 
   methods: [
     async function execute(cmd) {
-      await this.eval_(cmd);
-      // Give command time to finish, TODO: make commands return promises
+      const block = await this.eval_(cmd);
+
+      // eval_ awaits the command, but a block that renders from a DAO select
+      // finishes after that: an agent has no signal to wait on, so this waits
+      // out the render. Remove it once agents report when their output settles.
       await foam.async.sleep(1300)();
 
-      const block    = this.currentBlock;
-      const response = block.childNodes[1].element_.innerText; //innerHTML;
+      const response = block.content?.element_?.innerText || '';
 
-      console.log(`ASK: ${cmd} -> ${response}`);
       const reply = JSON.stringify({asked: cmd, response: response});
       await this.eval_(`agent(${reply})`);
 

--- a/src/foam/core/reflow/ai/LLMCommand.js
+++ b/src/foam/core/reflow/ai/LLMCommand.js
@@ -18,8 +18,7 @@ foam.CLASS({
   ],
 
   imports: [
-    'llmService',
-    'notify'
+    'llmService'
   ],
 
   properties: [
@@ -53,25 +52,19 @@ foam.CLASS({
 
   methods: [
     async function execute(q) {
-      try {
-        var options = this.LLMOptions.create({
-          systemPrompt: this.systemPrompt,
-          model:        this.model
-        });
+      var options = this.LLMOptions.create({
+        systemPrompt: this.systemPrompt,
+        model:        this.model
+      });
 
-        var request = this.CompletionRequest.create({
-          prompt:  q,
-          options: options
-        });
+      var request = this.CompletionRequest.create({
+        prompt:  q,
+        options: options
+      });
 
-        var result = await this.llmService.complete(null, request);
+      var result = await this.llmService.complete(null, request);
 
-        this.out.tag(this.Markdown, {markdown: result.content});
-      } catch (e) {
-        this.notify('LLM error: ' + e.message, '', this.LogLevel.ERROR);
-        //        this.response = '**Error:** ' + e.message;
-        this.out.add('**Error:** ' + e.message);
-      }
+      this.out.tag(this.Markdown, {markdown: result.content});
     }
   ]
 });

--- a/src/foam/core/reflow/ai/Propose.js
+++ b/src/foam/core/reflow/ai/Propose.js
@@ -28,12 +28,12 @@ foam.CLASS({
     }
     ^command input {
       width: 100%;
-      border: 1px solid #ddd;
+      border: 1px solid $grey300;
       border-radius: 4px;
       padding: 4px 8px;
       font-family: monospace;
       font-size: 13px;
-      background: #fff;
+      background: $backgroundDefault;
       outline: none;
     }
     ^command input:focus {
@@ -97,6 +97,7 @@ foam.CLASS({
     {
       name: 'accept',
       label: '✓',
+      ariaLabel: 'Accept and run the proposed command',
       code: function() {
         this.eval_(this.command);
         this.block.del();
@@ -105,6 +106,7 @@ foam.CLASS({
     {
       name: 'reject',
       label: '✕',
+      ariaLabel: 'Reject the proposed command',
       code: function() {
         this.block.del();
       }


### PR DESCRIPTION
Noticed three things running the AI commands:

- A command that awaits reported nothing, so `ai` or `agent` left the Console looking idle for the whole round trip.

- `AgentCommand` threw a string, and `eval_` builds the BadBlock from `x.message`, so an agent failure rendered an error box with nothing in it.

- `LLMCommand` wrote its own error line, which showed its `**` literally and skipped the repair action every other command's failure carries.

Fix:

- `eval_` marks the block busy around the await and the prompt watches `currentBlock.isLoading_`, so every command that awaits gets an indicator rather than the AI ones alone. A block joins the flow only after its command finishes, so the spinner lives on the prompt.

- both commands throw now, and the block carries `aria-busy` while it runs.

- `Propose`'s ✓/✕ actions carry `ariaLabel`s, and its two literal colours move to tokens.

Stacked on #5412.
