### PR TITLE
Reflow over WebMCP: drive the Console from an external AI tool

### DIFF
--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -833,6 +833,7 @@ foam.CLASS({
     'foam.core.reflow.ReflowHeader',
     'foam.core.reflow.ReflowToolBar',
     'foam.core.reflow.ToolbarControl',
+    'foam.core.reflow.ai.mcp.ReflowWebMCP',
     'foam.dao.ArrayDAO',
     'foam.flow.Document',
     'foam.u2.Link',
@@ -1387,6 +1388,10 @@ foam.CLASS({
           return await cmd.execute.apply(cmd, args);
         }
       });
+
+      // Offer the same command line to an external agent. Registers only for a
+      // user whose commands include 'mcp', and no-ops without WebMCP.
+      this.onDetach(this.ReflowWebMCP.create({}, this)).install();
 
       // If this.value.script changes
       //   update this.flowChildren

--- a/src/foam/core/reflow/Console.js
+++ b/src/foam/core/reflow/Console.js
@@ -1628,7 +1628,17 @@ foam.CLASS({
             r = arg ? r(arg) : r();
           }
           if ( r instanceof Promise ) {
-            r = await r;
+            try {
+              r = await r;
+            } catch (x) {
+              // An async command that rejects gets the error block a synchronous
+              // one gets. Without this the rejection leaves eval_ before the
+              // block joins the flow, so the failure has nowhere to show.
+              var msg = x?.message || String(x);
+              block.value = this.BadBlock.create({block: block, error: msg});
+              block.error = msg;
+              r = undefined;
+            }
           }
         }}}
       } finally {

--- a/src/foam/core/reflow/Flow.js
+++ b/src/foam/core/reflow/Flow.js
@@ -230,7 +230,44 @@ foam.CLASS({
     }
   ],
 
+  static: [
+    {
+      name: 'systemPrompt',
+      documentation: `Every flow named systemPrompt* concatenated, in name order: the
+        agent's knowledge base, layered global / institution / role / personal by
+        name. The naming convention belongs to Flow, so every reader of it -- the
+        agent command, the WebMCP tool descriptions -- asks here.`,
+      code: async function(x) {
+        var self  = foam.core.reflow.Flow;
+        var E     = foam.mlang.ExpressionsSingleton.create();
+        var flows = (await x.flowDAO.
+          orderBy(self.NAME).
+          where(E.STARTS_WITH(self.NAME, 'systemPrompt')).
+          select()).array;
+
+        return flows.map(f => f.markdown()).join('\n');
+      }
+    }
+  ],
+
   methods: [
+    function markdown() {
+      /** The flow's markdown blocks, concatenated. Flows carry documentation --
+        manual pages, system prompts, MCP tool descriptions -- and every reader of
+        that text used to walk the script itself. */
+      var parts = [];
+      try {
+        JSON.parse(this.script).forEach(b => {
+          var md = b?.value?.markdown;
+          if ( md ) parts.push(md);
+        });
+      } catch (e) {
+        // A hand-edited script may not parse. Documentation lookup is best
+        // effort: return what we have rather than failing the caller.
+      }
+      return parts.join('\n\n');
+    },
+
     {
       name: 'authorizeOnCreate',
       javaCode: `

--- a/src/foam/core/reflow/LayoutBlock.js
+++ b/src/foam/core/reflow/LayoutBlock.js
@@ -123,7 +123,14 @@ foam.CLASS({
     },
     function addFlowChild_(c) {
       this.addToScope(c);
-      this.cmdHolder.add(c);
+      // cmdHolder is the container render() builds, so a child added before the
+      // layout has rendered -- a script or an agent writing the flow, rather
+      // than someone typing into the layout's own toolbar -- arrives first.
+      if ( this.cmdHolder ) {
+        this.cmdHolder.add(c);
+        return;
+      }
+      this.cmdHolder$.sub(foam.events.oneTime(() => this.cmdHolder.add(c)));
     },
     function eval_(...args){
       if ( ! args[3] || args[3] == this.flowParent )

--- a/src/foam/core/reflow/ai/AgentCommand.js
+++ b/src/foam/core/reflow/ai/AgentCommand.js
@@ -41,13 +41,8 @@ foam.CLASS({
   imports: [
     'block',
     'commandDAO',
-    'flowDAO',
     'llmService',
     'subject'
-  ],
-
-  implements: [
-    'foam.mlang.Expressions'
   ],
 
   requires: [
@@ -124,24 +119,8 @@ foam.CLASS({
     },
 
     async function buildSystemPrompt_() {
-      if ( ! this.systemPrompt ) {
-        const prompts = (await this.flowDAO.orderBy(this.Flow.NAME).where(this.STARTS_WITH(this.Flow.NAME, 'systemPrompt')).select()).array;
-        const parts   = [];
-
-        prompts.forEach(p => {
-          const script = JSON.parse(p.script);
-          script.forEach(block => {
-            if ( block?.value?.class == 'foam.core.reflow.Markdown' ) {
-              parts.push(block.value.markdown);
-            } else {
-            }
-          });
-        });
-
-        console.log('sysPrompt: ', parts.join('\n'));
-
-        this.systemPrompt = parts.join('\n');
-      }
+      if ( ! this.systemPrompt )
+        this.systemPrompt = await this.Flow.systemPrompt(this.__context__);
 
       return this.systemPrompt;
     },

--- a/src/foam/core/reflow/ai/cmds.jrl
+++ b/src/foam/core/reflow/ai/cmds.jrl
@@ -46,3 +46,8 @@ p({
   "description": "Propose a command for execution",
   "script": "addValue(foam.core.reflow.ai.Propose.create({command: args.join(' ')}, this));"
 })
+p({
+  "class":"foam.core.reflow.ai.mcp.MCPCommand",
+  "id": "mcp",
+  "permissionRequired": true
+})

--- a/src/foam/core/reflow/ai/mcp/MCPCommand.js
+++ b/src/foam/core/reflow/ai/mcp/MCPCommand.js
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.reflow.ai.mcp',
+  name: 'MCPCommand',
+  extends: 'foam.core.reflow.cmd.Command',
+
+  documentation: `
+    REFLOW command that prints how to connect an external AI tool to this
+    Console, with this session's own values filled in.
+
+    Output goes to 'out', never through addValue: a Block serializes its value
+    into the saved flow (Block.js:205-209), and this output is a live report of
+    what the browser exposes right now. Saving the flow keeps the command, which
+    reprints when it next runs.
+
+    Registration itself happens when the Console loads, for any user whose
+    commands include this one -- see ReflowWebMCP.
+  `,
+
+  requires: [
+    'foam.core.reflow.Markdown',
+    'foam.core.reflow.ai.mcp.ReflowWebMCP'
+  ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'description',
+      value: 'Show how to connect an external AI tool to this Console'
+    }
+  ],
+
+  methods: [
+    async function execute() {
+      this.out.tag(this.Markdown, {
+        markdown: await this.ReflowWebMCP.help(this.__context__)
+      });
+    }
+  ]
+});

--- a/src/foam/core/reflow/ai/mcp/ReflowWebMCP.js
+++ b/src/foam/core/reflow/ai/mcp/ReflowWebMCP.js
@@ -271,12 +271,10 @@ foam.CLASS({
 
       if ( args.config && block.value ) {
         try {
-          Object.keys(args.config).forEach(k => {
-            var v = args.config[k];
-            // FOAM JSON: anything carrying a class -- an agent, a sink, a
-            // __Property__ -- is hydrated; everything else is set as given.
-            block.value[k] = ( v && v.class ) ? foam.json.parse(v, null, block) : v;
-          });
+          // parse hydrates every nested value carrying a class -- an agent, a
+          // sink, a __Property__ -- and builds each in the block's context,
+          // which is what a chart agent expects as its parent.
+          block.value.copyFrom(foam.json.parse(args.config, null, block.__subContext__));
           if ( block.value.run ) block.value.run();
         } catch (e) {
           return this.result_({ error: String(e && e.message || e) });

--- a/src/foam/core/reflow/ai/mcp/ReflowWebMCP.js
+++ b/src/foam/core/reflow/ai/mcp/ReflowWebMCP.js
@@ -142,29 +142,41 @@ foam.CLASS({
     async function install() {
       /** Register the tools, if this browser has WebMCP. Returns whether they
         registered, so the command can say so. */
-      if ( ! this.modelContext )        return false;
+      if ( ! this.modelContext )      return false;
       if ( ! this.localScope['mcp'] ) return false;
 
       this.onDetach(() => this.controller_.abort());
 
       var opts = { signal: this.controller_.signal };
 
-      try {
-        await this.register_(opts);
-      } catch (e) {
-        // registerTool rejects with NotAllowedError where the tools permission
-        // is disabled for this origin. The Console carries on without an agent
-        // surface; the 'mcp' command reports what a browser actually exposes.
-        return false;
+      var tools = this.tools_();
+      var registered = 0;
+
+      for ( var i = 0 ; i < tools.length ; i++ ) {
+        try {
+          await this.modelContext.registerTool({
+            name:        tools[i].name,
+            description: await this.description_(tools[i]),
+            inputSchema: tools[i].inputSchema,
+            execute:     tools[i].execute
+          }, opts);
+          registered++;
+        } catch (e) {
+          // One tool the browser will not take must not cost the others, and
+          // must not fail silently: registerTool rejects with NotAllowedError
+          // where the origin disables tools, and on a schema it rejects.
+          console.error('ReflowWebMCP: ' + tools[i].name + ' not registered', e);
+        }
       }
 
-      return true;
+      return registered > 0;
     },
 
-    async function register_(opts) {
-      await this.modelContext.registerTool({
-        name:        'reflow_run',
-        description: await this.description_('reflow_run'),
+    function tools_() {
+      return [ {
+        name: 'reflow_run',
+        description: `Run one REFLOW command line against the open Console.
+          Proposes it for the user to accept unless execute is set.`,
         inputSchema: {
           type: 'object',
           properties: {
@@ -181,11 +193,10 @@ foam.CLASS({
           required: [ 'cmd' ]
         },
         execute: args => this.run_(args)
-      }, opts);
-
-      await this.modelContext.registerTool({
-        name:        'reflow_block',
-        description: await this.description_('reflow_block'),
+      }, {
+        name: 'reflow_block',
+        description: `Read a block's configuration, or change it. Charts are
+          blocks whose select agent groups rows, so they are built here.`,
         inputSchema: {
           type: 'object',
           properties: {
@@ -202,29 +213,31 @@ foam.CLASS({
           required: [ 'name' ]
         },
         execute: args => this.block_(args)
-      }, opts);
-
-      await this.modelContext.registerTool({
-        name:        'reflow_state',
-        description: await this.description_('reflow_state'),
+      }, {
+        name: 'reflow_state',
+        description: 'The flow open in the Console, and the blocks in it.',
         inputSchema: { type: 'object', properties: {} },
         execute: () => this.state_()
-      }, opts);
+      } ];
     },
 
-    async function description_(name) {
-      /** The tool's own doc flow, and for reflow_run the agent's system prompt
-        as well: an external agent should know the command language as well as
-        the one inside the Console does. */
+    async function description_(tool) {
+      /** The tool's doc flow, and for reflow_run the agent's system prompt as
+        well: an external agent should know the command language as well as the
+        one inside the Console does. The flow is documentation, not the
+        contract -- a browser rejects a tool with no description, so the
+        descriptor's own line stands when no flow is loaded. */
       var parts = [];
-      var doc   = await this.flowDAO.find(this.TOOL_DOC_FLOWS[name]);
+      var doc   = await this.flowDAO.find(this.TOOL_DOC_FLOWS[tool.name]);
 
       if ( doc ) parts.push(doc.markdown());
 
-      if ( name === 'reflow_run' )
+      if ( tool.name === 'reflow_run' )
         parts.push(await this.Flow.systemPrompt(this.__context__));
 
-      return parts.filter(p => p).join('\n\n');
+      parts = parts.filter(p => p);
+
+      return parts.length ? parts.join('\n\n') : tool.description;
     },
 
     async function run_(args) {

--- a/src/foam/core/reflow/ai/mcp/ReflowWebMCP.js
+++ b/src/foam/core/reflow/ai/mcp/ReflowWebMCP.js
@@ -1,0 +1,331 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.reflow.ai.mcp',
+  name: 'ReflowWebMCP',
+
+  documentation: `
+    Registers the Console as an in-page MCP server, so an external coding agent
+    drives the same command line a person does.
+
+    foam.core.ai.mcp.MCPWebAgent is the server half. It already serves flowDAO
+    and commandDAO to an external client through the DAO tools, so reading and
+    writing flows needs nothing new here. What a server cannot serve is
+    execution: a command runs through the Console's eval_ and renders into a
+    Block's DOM, and neither exists outside the page. Those are the two things
+    this registers.
+
+    Two tools, because the command line is itself the uniform interface:
+    'flows', 'daos', 'describe X', 'help' and 'FROM ... TO JSON' are commands,
+    not extra tools. reflow_state exists only because an agent cannot see the
+    page.
+
+    Registered when a Console loads, but only for a user who has the 'mcp'
+    command in scope: page tools live and die with the tab, so requiring a
+    command in every new tab is a ritual, while the permission on that command
+    is the real gate. commandDAO's authorized select decides both.
+
+    Executing without proposing additionally needs the '!' agent command.
+
+    https://github.com/webmachinelearning/webmcp
+  `,
+
+  requires: [ 'foam.core.reflow.Flow' ],
+
+  imports: [
+    'eval_',
+    'findFlowChildByName',
+    'flow',
+    'flowChildren',
+    'flowDAO',
+    'localScope'
+  ],
+
+  constants: {
+    // Tool name -> Flow whose markdown is the tool description, the convention
+    // MCPWebAgent.TOOL_DOC_FLOWS uses, so the docs stay editable in the app.
+    TOOL_DOC_FLOWS: {
+      reflow_run:   'MCP:reflow_run',
+      reflow_state: 'MCP:reflow_state',
+      reflow_block: 'MCP:reflow_block'
+    },
+    // Rendered output is for an agent to read, not to page through.
+    MAX_TEXT: 8192
+  },
+
+  properties: [
+    {
+      name: 'modelContext',
+      hidden: true,
+      transient: true,
+      documentation: `The WebMCP entry point, or null where the browser has no
+        such API. Injectable so the tools can be tested without an origin trial.`,
+      factory: function() {
+        return globalThis.document?.modelContext ||
+               globalThis.navigator?.modelContext ||
+               null;
+      }
+    },
+    {
+      name: 'controller_',
+      hidden: true,
+      transient: true,
+      factory: function() { return new AbortController(); }
+    }
+  ],
+
+  static: [
+    {
+      name: 'help',
+      documentation: `What the 'mcp' command prints: the intro flow, the setup
+        flow this browser needs, and one line of live status. All the wording
+        lives in flows, so it stays editable in the app.`,
+      code: async function(x) {
+        var self  = foam.core.reflow.ai.mcp.ReflowWebMCP;
+        var doc   = await x.flowDAO.find('MCP:howto');
+        // Only the steps this browser actually needs. Each is its own flow, so
+        // the wording stays editable in the app and the code only chooses.
+        var setup = await x.flowDAO.find('MCP:setup-' + self.setupKind());
+
+        return [
+          doc && doc.markdown(),
+          setup && setup.markdown(),
+          await self.status()
+        ].filter(p => p).join('\n\n');
+      }
+    },
+    {
+      name: 'setupKind',
+      documentation: `Which setup flow this browser needs: none once the API is
+        present, otherwise the flag for a browser that has one.`,
+      code: function() {
+        if ( globalThis.document?.modelContext ||
+             globalThis.navigator?.modelContext ) return 'ready';
+
+        var ua = globalThis.navigator?.userAgent || '';
+
+        if ( ua.includes('Edg/') )                       return 'edge';
+        if ( ua.includes('Chrome/') && ! ua.includes('OPR/') ) return 'chrome';
+
+        return 'unsupported';
+      }
+    },
+    {
+      name: 'status',
+      documentation: `One line on what this page exposes right now. A doc flow
+        can describe the steps; only the live page knows whether they worked.`,
+      code: async function() {
+        var mc = globalThis.document?.modelContext || globalThis.navigator?.modelContext;
+
+        if ( ! mc ) return '> Page tools: not registered.';
+
+        var names = [];
+        try {
+          names = (await mc.getTools()).map(t => t.name);
+        } catch (e) {
+          // getTools is newer than registerTool; absence is not an error.
+        }
+
+        return names.length ?
+          '> Page tools registered: `' + names.join('`, `') + '`' :
+          '> Page tools: registration refused. Check the origin trial token and ' +
+            'any `Permissions-Policy: tools=()` header.';
+      }
+    }
+  ],
+
+  methods: [
+    async function install() {
+      /** Register the tools, if this browser has WebMCP. Returns whether they
+        registered, so the command can say so. */
+      if ( ! this.modelContext )        return false;
+      if ( ! this.localScope['mcp'] ) return false;
+
+      this.onDetach(() => this.controller_.abort());
+
+      var opts = { signal: this.controller_.signal };
+
+      try {
+        await this.register_(opts);
+      } catch (e) {
+        // registerTool rejects with NotAllowedError where the tools permission
+        // is disabled for this origin. The Console carries on without an agent
+        // surface; the 'mcp' command reports what a browser actually exposes.
+        return false;
+      }
+
+      return true;
+    },
+
+    async function register_(opts) {
+      await this.modelContext.registerTool({
+        name:        'reflow_run',
+        description: await this.description_('reflow_run'),
+        inputSchema: {
+          type: 'object',
+          properties: {
+            cmd: {
+              type: 'string',
+              description: 'One REFLOW command line, e.g. FROM userDAO TO JSON'
+            },
+            execute: {
+              type: 'boolean',
+              description: `Run the command now instead of proposing it for the
+                user to accept. Requires the '!' agent command.`
+            }
+          },
+          required: [ 'cmd' ]
+        },
+        execute: args => this.run_(args)
+      }, opts);
+
+      await this.modelContext.registerTool({
+        name:        'reflow_block',
+        description: await this.description_('reflow_block'),
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              description: "A block's flowName, as reflow_state lists them"
+            },
+            config: {
+              type: 'object',
+              description: `Properties to set on the block's value, as FOAM JSON.
+                Omit to read the block without changing it.`
+            }
+          },
+          required: [ 'name' ]
+        },
+        execute: args => this.block_(args)
+      }, opts);
+
+      await this.modelContext.registerTool({
+        name:        'reflow_state',
+        description: await this.description_('reflow_state'),
+        inputSchema: { type: 'object', properties: {} },
+        execute: () => this.state_()
+      }, opts);
+    },
+
+    async function description_(name) {
+      /** The tool's own doc flow, and for reflow_run the agent's system prompt
+        as well: an external agent should know the command language as well as
+        the one inside the Console does. */
+      var parts = [];
+      var doc   = await this.flowDAO.find(this.TOOL_DOC_FLOWS[name]);
+
+      if ( doc ) parts.push(doc.markdown());
+
+      if ( name === 'reflow_run' )
+        parts.push(await this.Flow.systemPrompt(this.__context__));
+
+      return parts.filter(p => p).join('\n\n');
+    },
+
+    async function run_(args) {
+      var cmd     = args?.cmd;
+      var execute = !! args?.execute;
+      var denied  = execute && ! this.localScope['!'];
+
+      if ( ! cmd ) return this.result_({ error: 'cmd is required' });
+
+      // Proposing is the default, and the fallback: an agent that asks to
+      // execute without the '!' command still gets its line in front of the
+      // user rather than an error it cannot act on.
+      var block = await this.eval_(( execute && ! denied ) ? cmd : 'propose ' + cmd);
+      var out   = this.summary_(block);
+
+      if ( denied )
+        out.note = "Proposed rather than executed: the '!' command is not granted to this user.";
+
+      return this.result_(out);
+    },
+
+    function block_(args) {
+      /** Read a block's configuration, or patch it. A chart is a block whose
+        value carries an agent and its grouping; the command line cannot say
+        that, so this is how an agent builds one. */
+      var name  = args?.name;
+      if ( ! name ) return this.result_({ error: 'name is required' });
+
+      var block = this.findFlowChildByName(name);
+      if ( ! block ) return this.result_({ error: 'no block named ' + name });
+
+      if ( args.config && block.value ) {
+        try {
+          Object.keys(args.config).forEach(k => {
+            var v = args.config[k];
+            // FOAM JSON: anything carrying a class -- an agent, a sink, a
+            // __Property__ -- is hydrated; everything else is set as given.
+            block.value[k] = ( v && v.class ) ? foam.json.parse(v, null, block) : v;
+          });
+          if ( block.value.run ) block.value.run();
+        } catch (e) {
+          return this.result_({ error: String(e && e.message || e) });
+        }
+      }
+
+      var out = this.summary_(block);
+      if ( block.value ) {
+        try { out.config = foam.json.stringify(block.value); } catch (e) {}
+      }
+      return this.result_(out);
+    },
+
+    function state_() {
+      /** What the agent cannot see: which flow is open and what is in it. */
+      return this.result_({
+        flow:   this.flow?.name,
+        blocks: this.flowChildren.map(b => ({
+          flowName: b.flowName,
+          cmd:      b.cmd,
+          error:    b.error
+        }))
+      });
+    },
+
+    function summary_(block) {
+      var out = { flowName: block.flowName, cmd: block.cmd };
+
+      if ( block.error ) out.error = block.error;
+
+      if ( block.value ) {
+        try {
+          out.value = foam.json.stringify(block.value);
+        } catch (e) {
+          // A block value that will not serialize still has rendered text.
+        }
+      }
+
+      var text = this.text_(block);
+      if ( text ) out.text = text;
+
+      return out;
+    },
+
+    function text_(block) {
+      /** The block's rendered text. A table or a chart has no other textual
+        form, so this is what AskCommand scrapes -- read here from the content
+        element directly, and only once the command has resolved. */
+      try {
+        var text = block.content?.element_?.innerText || '';
+        return text.length > this.MAX_TEXT ?
+          text.substring(0, this.MAX_TEXT) + '\n...[truncated]' :
+          text;
+      } catch (e) {
+        return '';
+      }
+    },
+
+    function result_(o) {
+      // The envelope WebMCP returns and MCPWebAgent.toolResult builds: one text
+      // part carrying JSON.
+      return { content: [ { type: 'text', text: JSON.stringify(o) } ] };
+    }
+  ]
+});

--- a/src/foam/core/reflow/ai/mcp/ReflowWebMCP.js
+++ b/src/foam/core/reflow/ai/mcp/ReflowWebMCP.js
@@ -46,6 +46,10 @@ foam.CLASS({
   ],
 
   constants: {
+    // Console entries kept for reflow_logs. Enough to cover a command and the
+    // rendering it triggers, few enough to hand an agent whole.
+    MAX_LOGS: 200,
+
     // Tool name -> Flow whose markdown is the tool description, the convention
     // MCPWebAgent.TOOL_DOC_FLOWS uses, so the docs stay editable in the app.
     TOOL_DOC_FLOWS: {
@@ -69,6 +73,15 @@ foam.CLASS({
                globalThis.navigator?.modelContext ||
                null;
       }
+    },
+    {
+      name: 'logs_',
+      hidden: true,
+      transient: true,
+      documentation: `Console errors and warnings, captured from the moment the
+        tools register. An external agent cannot open devtools, and a command
+        that fails inside a view reports nothing through eval_.`,
+      factory: function() { return []; }
     },
     {
       name: 'controller_',
@@ -146,6 +159,7 @@ foam.CLASS({
       if ( ! this.localScope['mcp'] ) return false;
 
       this.onDetach(() => this.controller_.abort());
+      this.captureConsole_();
 
       var opts = { signal: this.controller_.signal };
 
@@ -214,11 +228,67 @@ foam.CLASS({
         },
         execute: args => this.block_(args)
       }, {
+        name: 'reflow_logs',
+        description: `Console errors and warnings from this page, newest last.
+          A command that fails inside a view reports nothing through reflow_run,
+          and this is where that failure shows up.`,
+        inputSchema: {
+          type: 'object',
+          properties: {
+            level: {
+              type: 'string',
+              enum: [ 'error', 'warn' ],
+              description: 'Only entries at this level. Omit for both.'
+            },
+            limit: {
+              type: 'integer',
+              description: 'How many of the most recent entries to return. Default 50.'
+            }
+          }
+        },
+        execute: args => this.logs_tool_(args)
+      }, {
         name: 'reflow_state',
         description: 'The flow open in the Console, and the blocks in it.',
         inputSchema: { type: 'object', properties: {} },
         execute: () => this.state_()
       } ];
+    },
+
+    function captureConsole_() {
+      /** Tee console.error and console.warn into logs_, leaving the browser's
+        own output alone. */
+      var console_ = globalThis.console;
+      if ( ! console_ ) return;
+
+      [ 'error', 'warn' ].forEach(level => {
+        var original = console_[level];
+        if ( ! original ) return;
+
+        console_[level] = (...args) => {
+          try {
+            this.logs_.push({
+              level: level,
+              time:  new Date().toISOString(),
+              text:  args.map(a => a instanceof Error ? ( a.stack || a.message ) : String(a)).join(' ')
+            });
+            if ( this.logs_.length > this.MAX_LOGS ) this.logs_.shift();
+          } catch (e) {}
+          original.apply(console_, args);
+        };
+        this.onDetach(() => { console_[level] = original; });
+      });
+    },
+
+    function logs_tool_(args) {
+      var level = args?.level;
+      var limit = args?.limit || 50;
+      var rows  = this.logs_.filter(r => ! level || r.level === level);
+
+      return this.result_({
+        entries: rows.slice(-limit),
+        total:   rows.length
+      });
     },
 
     async function description_(tool) {
@@ -250,8 +320,16 @@ foam.CLASS({
       // Proposing is the default, and the fallback: an agent that asks to
       // execute without the '!' command still gets its line in front of the
       // user rather than an error it cannot act on.
-      var block = await this.eval_(( execute && ! denied ) ? cmd : 'propose ' + cmd);
-      var out   = this.summary_(block);
+      var block;
+      try {
+        block = await this.eval_(( execute && ! denied ) ? cmd : 'propose ' + cmd);
+      } catch (e) {
+        // Whatever escapes eval_ is still the agent's answer; a tool call that
+        // fails outright tells it nothing about what went wrong.
+        return this.result_({ cmd: cmd, error: String(e?.message || e) });
+      }
+
+      var out = this.summary_(block);
 
       if ( denied )
         out.note = "Proposed rather than executed: the '!' command is not granted to this user.";

--- a/src/foam/core/reflow/ai/mcp/flows.jrl
+++ b/src/foam/core/reflow/ai/mcp/flows.jrl
@@ -1,0 +1,172 @@
+p({
+  "class": "foam.core.reflow.Flow",
+  "name": "MCP:reflow_run",
+  "category": "MCP",
+  "keywords": [
+    "mcp",
+    "reflow",
+    "command",
+    "run"
+  ],
+  "accessLevel": 1,
+  "script": [
+    {
+      "flowName": "markdown1",
+      "cmd": "markdown",
+      "value": {
+        "class": "foam.core.reflow.Markdown",
+        "markdown": "# reflow_run\n\nRun one REFLOW command line against the open Console. This is the whole command\nline, so it is also how you list flows, inspect a model, or query a DAO:\n`flows`, `daos`, `describe userDAO`, `help`, `FROM userDAO TO JSON`.\n\n## Parameters\n\n- **cmd** (required): one REFLOW command line. No code fences, no leading `>`.\n- **execute** (optional): run the command now instead of proposing it. Requires\n  the `!` agent command. Without it the line is proposed either way.\n\n## Behaviour\n\nBy default the command is wrapped in `propose`, so it appears in the Console with\naccept and reject controls and does nothing until a person accepts it. This is the\nsame default the in-Console agent uses in `?` mode.\n\n## Response\n\nJSON with the resulting block:\n\n- **flowName**: the block's name, and its variable name in the flow scope\n- **cmd**: the command as it was run\n- **error**: present only when the command failed\n- **value**: the block's value, serialized, when it has one\n- **text**: the block's rendered text, truncated at 8KB. A table or chart has no\n  other textual form.\n\n## Notes\n\n- The command runs as the logged-in user. Permissions, validation and journaling\n  are the Console's, unchanged.\n- A command that renders asynchronously may return before its output is complete;\n  call `reflow_state` or re-read the block if `text` looks short."
+      }
+    }
+  ]
+})
+p({
+  "class": "foam.core.reflow.Flow",
+  "name": "MCP:reflow_state",
+  "category": "MCP",
+  "keywords": [
+    "mcp",
+    "reflow",
+    "state",
+    "blocks"
+  ],
+  "accessLevel": 1,
+  "script": [
+    {
+      "flowName": "markdown1",
+      "cmd": "markdown",
+      "value": {
+        "class": "foam.core.reflow.Markdown",
+        "markdown": "# reflow_state\n\nWhat is open in the Console right now. An external agent cannot see the page, so\ncall this before proposing changes to an existing flow.\n\n## Parameters\n\nNone.\n\n## Response\n\n- **flow**: the name of the loaded flow, if it has been saved\n- **blocks**: each block's `flowName`, `cmd` and `error`\n\nBlock names matter: a name is the variable another block reads, so read them here\nbefore writing a command that references one."
+      }
+    }
+  ]
+})
+p({
+  "class": "foam.core.reflow.Flow",
+  "name": "MCP:reflow_block",
+  "category": "MCP",
+  "keywords": [
+    "mcp",
+    "reflow",
+    "block",
+    "chart",
+    "config"
+  ],
+  "accessLevel": 1,
+  "script": [
+    {
+      "flowName": "markdown1",
+      "cmd": "markdown",
+      "value": {
+        "class": "foam.core.reflow.Markdown",
+        "markdown": "# reflow_block\n\nRead a block's configuration, or change it. `reflow_run` creates blocks; this shapes them.\n\n## Parameters\n\n- **name** (required): a block's `flowName`, as `reflow_state` lists them.\n- **config** (optional): properties to set on the block's value, as FOAM JSON. Omit to read without changing anything.\n\n## Response\n\nThe block's `flowName`, `cmd`, `error`, `value` and `text`, plus **config**: its value serialized, so you can read a block's shape before editing it.\n\n## Building a chart\n\nA chart is a DAO block whose select agent groups rows. The command line cannot express that, so set it here. Any value carrying a `class` is hydrated, including a property reference:\n\n```\n{\"select\": {\"class\": \"foam.core.reflow.dashboard.DashboardPieChartDAOAgent\",\n            \"prop\": {\"class\": \"__Property__\", \"forClass_\": \"foam.core.auth.Region\", \"name\": \"countryId\"},\n            \"sink\": {\"class\": \"foam.core.reflow.CountDAOAgent\"}}}\n```\n\nThe `sink` is a DAO agent, not an mlang sink: `CountDAOAgent`, not `foam.mlang.sink.Count`. Run `FROM agentDAO TO JSON` to list every agent with its label and class \u2014 bar, line, stacked bar, pivot, metric and the rest."
+      }
+    }
+  ]
+})
+p({
+  "class": "foam.core.reflow.Flow",
+  "name": "MCP:howto",
+  "category": "MCP",
+  "keywords": [
+    "mcp",
+    "reflow",
+    "agent",
+    "howto"
+  ],
+  "accessLevel": 1,
+  "script": [
+    {
+      "flowName": "markdown1",
+      "cmd": "markdown",
+      "value": {
+        "class": "foam.core.reflow.Markdown",
+        "markdown": "# Connect an AI tool\n\nThis Console offers `reflow_run`, `reflow_state` and `reflow_block` to AI tools while the tab is open.\n\n## Known limits\n\n- The tools belong to the open Console. Navigating away from the flow page or closing the tab unregisters them; reload to get them back.\n- If the bridge server restarts, it comes back with an empty tool list until the page registers again. Reload the tab.\n- A command that renders from a DAO select returns before its output exists, so `text` comes back empty. Read the block's config with `reflow_block`, or ask for a value instead of a view."
+      }
+    }
+  ]
+})
+p({
+  "class": "foam.core.reflow.Flow",
+  "name": "MCP:setup-ready",
+  "category": "MCP",
+  "keywords": [
+    "mcp",
+    "setup",
+    "client"
+  ],
+  "accessLevel": 1,
+  "script": [
+    {
+      "flowName": "markdown1",
+      "cmd": "markdown",
+      "value": {
+        "class": "foam.core.reflow.Markdown",
+        "markdown": "## Pick your tool\n\n<details>\n<summary><b>Claude Code</b></summary>\n\nThe Chrome Web Store build of WebMCP Bridge is older than Chrome's API and sees no tools, so build the current one:\n\n1. `git clone --depth 1 --branch v1.1.0 https://github.com/MCPCat/webmcp-react.git`\n2. `cd webmcp-react/extension && npm install && npm run build`\n3. `chrome://extensions`, remove any Web Store copy, Developer mode on, Load unpacked, pick `webmcp-react/extension/dist`\n4. Run `claude mcp add --transport stdio webmcp-server -- npx webmcp-server`\n5. Click the extension icon on this tab, choose **Always On**, wait for the green dot\n6. Start a new Claude Code session, ask it to run `flows` in reflow\n\n</details>\n\n<details>\n<summary><b>Cursor</b></summary>\n\n1. Steps 1 to 3 above\n2. Add to `~/.cursor/mcp.json`: `{\"mcpServers\":{\"webmcp-server\":{\"command\":\"npx\",\"args\":[\"webmcp-server\"]}}}`\n3. Click the extension icon on this tab, choose **Always On**, wait for the green dot\n\n</details>\n\n<details>\n<summary><b>ChatGPT Desktop, Brave Leo</b></summary>\n\nNothing to install. Keep this tab open and ask it to run a REFLOW command.\n\n</details>"
+      }
+    }
+  ]
+})
+p({
+  "class": "foam.core.reflow.Flow",
+  "name": "MCP:setup-chrome",
+  "category": "MCP",
+  "keywords": [
+    "mcp",
+    "setup",
+    "chrome"
+  ],
+  "accessLevel": 1,
+  "script": [
+    {
+      "flowName": "markdown1",
+      "cmd": "markdown",
+      "value": {
+        "class": "foam.core.reflow.Markdown",
+        "markdown": "## Turn on WebMCP in Chrome\n\n1. Open `chrome://flags/#enable-webmcp-testing`\n2. Set it to Enabled\n3. Relaunch Chrome, reload this Console, run `mcp` again"
+      }
+    }
+  ]
+})
+p({
+  "class": "foam.core.reflow.Flow",
+  "name": "MCP:setup-edge",
+  "category": "MCP",
+  "keywords": [
+    "mcp",
+    "setup",
+    "edge"
+  ],
+  "accessLevel": 1,
+  "script": [
+    {
+      "flowName": "markdown1",
+      "cmd": "markdown",
+      "value": {
+        "class": "foam.core.reflow.Markdown",
+        "markdown": "## Turn on WebMCP in Edge\n\n1. Open `edge://flags/#enable-webmcp-testing`\n2. Set it to Enabled\n3. Relaunch Edge, reload this Console, run `mcp` again"
+      }
+    }
+  ]
+})
+p({
+  "class": "foam.core.reflow.Flow",
+  "name": "MCP:setup-unsupported",
+  "category": "MCP",
+  "keywords": [
+    "mcp",
+    "setup"
+  ],
+  "accessLevel": 1,
+  "script": [
+    {
+      "flowName": "markdown1",
+      "cmd": "markdown",
+      "value": {
+        "class": "foam.core.reflow.Markdown",
+        "markdown": "## Not available here\n\nPage tools need WebMCP, which ships in Chrome 149 and Edge 150. Open this Console in one of those."
+      }
+    }
+  ]
+})

--- a/src/foam/core/reflow/ai/mcp/pom.js
+++ b/src/foam/core/reflow/ai/mcp/pom.js
@@ -1,0 +1,15 @@
+foam.POM({
+  name: 'reflowwebmcp',
+
+  files: [
+    // Registers the Console as an in-page MCP server. Client-side only: the
+    // tools it exposes are the Console's own eval_ and rendered block output.
+    { name: 'ReflowWebMCP', flags: 'js' },
+
+    // The 'mcp' command: registers the tools and prints the connection steps.
+    // js|java like every other Command with a cmds.jrl row -- commandDAO
+    // replays server-side, so the class has to exist in Java to deserialize.
+    // execute() is JS-only, which generates nothing (java/refinements.js:1021).
+    { name: 'MCPCommand',   flags: 'js|java' }
+  ]
+});

--- a/src/foam/core/reflow/ai/pom.js
+++ b/src/foam/core/reflow/ai/pom.js
@@ -1,6 +1,10 @@
 foam.POM({
   name: 'reflowai',
 
+  projects: [
+    { name: 'mcp/pom' }
+  ],
+
   files: [
     // FLOW/Agent command — registered as both 'agent' and '?'
     { name: 'AgentCommand',   flags: 'js|java' },


### PR DESCRIPTION
Reflow's agent runs inside the Console, so an agent open in your editor cannot touch a flow. The Console now offers its command line as WebMCP tools:

```
reflow_run({cmd: "FROM userDAO TO TABLE"})        // proposed for you to accept
reflow_run({cmd: "save", execute: true})          // runs, with the ! command
reflow_state()                                    // the open flow and its blocks
reflow_block({name: "3", config: {select: {…}}})  // read a block, or shape one
reflow_logs({level: "error"})                     // what the page logged
```

Every command goes through `eval_`, so permissions, validation and journaling are the Console's, unchanged. `execute` needs the `!` command; without it the line is proposed anyway.

`reflow_block` is how a chart gets built: the command line cannot name a select agent and its grouping, so the block's config carries them, and any value with a `class` is hydrated in the block's own context.

`reflow_logs` exists because an external agent cannot open devtools. A command that fails inside a view leaves nothing on the block it created, so its console output is the only account of what happened.

The `mcp` command prints the setup the browser it runs in actually needs, and its own `commandDAO` row is what gates the tools.

Tool text and setup steps live in `MCP:*` flows, the way `MCPWebAgent` already sources its docs; `Flow.markdown()` and `Flow.systemPrompt()` now own the block walk and the naming convention the agent command carried inline.

Two fixes the tools surfaced, both outside the MCP path:

- `eval_` awaited a command's promise outside the try that builds the error block, so a rejected async command left `eval_` before the block joined the flow and the failure had nowhere to render.
- `LayoutBlock.addFlowChild_` threw for a child added before the layout rendered, which is what anything building a flow programmatically does.

Driven end to end from an editor: commands proposed and executed, blocks configured, and a dashboard of metric tiles, a bar chart and a pie chart built through the tools alone.

Stacked on #5413.
