### PR TITLE
Fix inverted assert on updatePermissionRequired

### DIFF
--- a/src/foam/lang/Property.js
+++ b/src/foam/lang/Property.js
@@ -209,7 +209,7 @@ foam.CLASS({
       name: 'updatePermissionRequired',
       value: false,
       preSet: function(_, n) {
-        foam.assert(this.writePermissionRequired && n, 'Redundant updatePermissionRequired on prop', this.toString());
+        foam.assert(! ( this.writePermissionRequired && n ), 'Redundant updatePermissionRequired on prop', this.toString());
         return n;
       }
     },


### PR DESCRIPTION
Turning on `updatePermissionRequired` logs `Redundant updatePermissionRequired on prop`, even though nothing is redundant. Adding `writePermissionRequired` alongside it — the combination that does make it redundant — logs nothing.

The assert's condition is the reverse of the case its message names, so the warning reads as advice to add the setting that gates creates as well.

Fix: negate the condition. The assert only logs, so nothing else changes.