### PR TITLE
lsp: a test category that throws is reported, not silently skipped

### DIFF
--- a/tools/tests/lsp/_harness.js
+++ b/tools/tests/lsp/_harness.js
@@ -17,24 +17,15 @@ console.warn = function() { console.error.apply(console, arguments); };
 globalThis.SILENT = false; globalThis.VERBOSE = false;
 globalThis.DRY_RUN = false; globalThis.HELP = false; globalThis.NOP = '';
 
-// Test counters. Declared above the uncaughtException handler because that
-// handler records into them.
-var counters = { passes: 0, failures: 0 };
-
 process.on('unhandledRejection', function(e) {});
 process.on('uncaughtException', function(e) {
-  // FileModelCache evaluates arbitrary workspace .js files to capture their
-  // foam.CLASS calls, so browser-global and syntax errors from that eval are
-  // expected noise and stay swallowed.
-  if ( e.message && ( e.message.includes('document') || e.message.includes('window') ) ) return;
-  if ( e instanceof SyntaxError ) return;
-  // Anything else is a real defect. Installing a listener at all suppresses
-  // node's default crash, so without this an escaping error left no trace:
-  // the run carried on with whatever work was already scheduled and could
-  // still finish 0.
-  counters.failures++;
-  console.error('  \x1b[31m✘ FAIL:\x1b[0m uncaught exception — ' +
-    ( e && e.stack ? e.stack : e ));
+  // Installing a listener at all suppresses node's default crash, so an error
+  // that escapes to here leaves no trace of its own. Set the exit code before
+  // anything else: a throw out of this module's own load never reaches
+  // testFoamLSP.js's summary, so the FAIL line below would otherwise be
+  // printed by a process that still exits 0.
+  process.exitCode = 1;
+  test(false, 'uncaught exception — ' + ( e && e.stack ? e.stack : e ));
 });
 
 var path = require('path');
@@ -62,8 +53,9 @@ process.stdin.removeAllListeners('data');
 process.stdin.removeAllListeners('end');
 process.stdin.pause();
 
-// Test helpers. `counters` is declared at the top of the file, above the
-// uncaughtException handler that writes to it.
+// Test counters + helpers
+var counters = { passes: 0, failures: 0 };
+
 function test(condition, message) {
   if ( condition ) {
     counters.passes++;

--- a/tools/tests/lsp/_harness.js
+++ b/tools/tests/lsp/_harness.js
@@ -17,10 +17,24 @@ console.warn = function() { console.error.apply(console, arguments); };
 globalThis.SILENT = false; globalThis.VERBOSE = false;
 globalThis.DRY_RUN = false; globalThis.HELP = false; globalThis.NOP = '';
 
+// Test counters. Declared above the uncaughtException handler because that
+// handler records into them.
+var counters = { passes: 0, failures: 0 };
+
 process.on('unhandledRejection', function(e) {});
 process.on('uncaughtException', function(e) {
+  // FileModelCache evaluates arbitrary workspace .js files to capture their
+  // foam.CLASS calls, so browser-global and syntax errors from that eval are
+  // expected noise and stay swallowed.
   if ( e.message && ( e.message.includes('document') || e.message.includes('window') ) ) return;
   if ( e instanceof SyntaxError ) return;
+  // Anything else is a real defect. Installing a listener at all suppresses
+  // node's default crash, so without this an escaping error left no trace:
+  // the run carried on with whatever work was already scheduled and could
+  // still finish 0.
+  counters.failures++;
+  console.error('  \x1b[31m✘ FAIL:\x1b[0m uncaught exception — ' +
+    ( e && e.stack ? e.stack : e ));
 });
 
 var path = require('path');
@@ -48,9 +62,8 @@ process.stdin.removeAllListeners('data');
 process.stdin.removeAllListeners('end');
 process.stdin.pause();
 
-// Test counters + helpers
-var counters = { passes: 0, failures: 0 };
-
+// Test helpers. `counters` is declared at the top of the file, above the
+// uncaughtException handler that writes to it.
 function test(condition, message) {
   if ( condition ) {
     counters.passes++;

--- a/tools/tests/lsp/_harness.js
+++ b/tools/tests/lsp/_harness.js
@@ -17,6 +17,15 @@ console.warn = function() { console.error.apply(console, arguments); };
 globalThis.SILENT = false; globalThis.VERBOSE = false;
 globalThis.DRY_RUN = false; globalThis.HELP = false; globalThis.NOP = '';
 
+// `test` below is a hoisted function declaration, so the handlers can call it
+// from up here. `counters` is not: a `var` holds `undefined` until its
+// assignment RUNS, and an exception during the pmake boot fires the handler
+// long before that. Declared here so `test` has its counter however early the
+// throw lands — read from below the boot, the handler instead throws a
+// TypeError of its own, which node treats as fatal (exit 7) and which replaces
+// the real error in the output.
+var counters = { passes: 0, failures: 0 };
+
 process.on('unhandledRejection', function(e) {});
 process.on('uncaughtException', function(e) {
   // Installing a listener at all suppresses node's default crash, so an error
@@ -25,6 +34,13 @@ process.on('uncaughtException', function(e) {
   // testFoamLSP.js's summary, so the FAIL line below would otherwise be
   // printed by a process that still exits 0.
   process.exitCode = 1;
+  // ...and detach stdin in the same breath. server.js's start() installs an
+  // 'end' listener that calls process.exit(0), and a throw during the boot
+  // below lands BEFORE the detach down there ever runs. That listener then
+  // fires on the first event-loop turn and its exit(0) overrides the code set
+  // one line up, so the run reports green with the FAIL line right there in
+  // the log.
+  detachStdin_();
   test(false, 'uncaught exception — ' + ( e && e.stack ? e.stack : e ));
 });
 
@@ -49,13 +65,14 @@ pmake.bind(buildlib, '-makers=LSP -pom=' + pomPath)();
 // process.exit via testFoamLSP.js) before the loop ever turns, so this
 // went unnoticed until an async category existed. Strip the listeners
 // server.js installed so this process's stdin is inert.
-process.stdin.removeAllListeners('data');
-process.stdin.removeAllListeners('end');
-process.stdin.pause();
+function detachStdin_() {
+  process.stdin.removeAllListeners('data');
+  process.stdin.removeAllListeners('end');
+  process.stdin.pause();
+}
+detachStdin_();
 
-// Test counters + helpers
-var counters = { passes: 0, failures: 0 };
-
+// Test helpers
 function test(condition, message) {
   if ( condition ) {
     counters.passes++;

--- a/tools/tests/lsp/_harness.js
+++ b/tools/tests/lsp/_harness.js
@@ -26,6 +26,12 @@ globalThis.DRY_RUN = false; globalThis.HELP = false; globalThis.NOP = '';
 // the real error in the output.
 var counters = { passes: 0, failures: 0 };
 
+// Flipped once the boot below has been stripped. The detach in the handler is
+// right only during that boot: afterwards withServerLane has its own live
+// server on stdin, and detaching there kills the lane the surviving tests are
+// still talking to.
+var booted_ = false;
+
 process.on('unhandledRejection', function(e) {});
 process.on('uncaughtException', function(e) {
   // Installing a listener at all suppresses node's default crash, so an error
@@ -34,13 +40,13 @@ process.on('uncaughtException', function(e) {
   // testFoamLSP.js's summary, so the FAIL line below would otherwise be
   // printed by a process that still exits 0.
   process.exitCode = 1;
-  // ...and detach stdin in the same breath. server.js's start() installs an
-  // 'end' listener that calls process.exit(0), and a throw during the boot
-  // below lands BEFORE the detach down there ever runs. That listener then
-  // fires on the first event-loop turn and its exit(0) overrides the code set
-  // one line up, so the run reports green with the FAIL line right there in
-  // the log.
-  detachStdin_();
+  // ...and, for a boot-time throw only, detach stdin in the same breath.
+  // server.js's start() installs an 'end' listener that calls process.exit(0),
+  // and a throw during the boot below lands BEFORE the detach down there ever
+  // runs. That listener then fires on the first event-loop turn and its
+  // exit(0) overrides the code set one line up, so the run reports green with
+  // the FAIL line right there in the log.
+  if ( ! booted_ ) detachStdin_();
   test(false, 'uncaught exception — ' + ( e && e.stack ? e.stack : e ));
 });
 
@@ -71,6 +77,7 @@ function detachStdin_() {
   process.stdin.pause();
 }
 detachStdin_();
+booted_ = true;
 
 // Test helpers
 function test(condition, message) {

--- a/tools/tests/testFoamLSP.js
+++ b/tools/tests/testFoamLSP.js
@@ -67,7 +67,20 @@ var h = require('./lsp/_harness');
 // filtered out and change nothing about how they run.
 var pending = [];
 toRun.forEach(function(c){
-  var mod = require('./lsp/' + c);
+  // A category that throws while loading is one failed category, not a failed
+  // run. Without the catch the throw unwinds this forEach, every later
+  // category goes unloaded, the Promise.all below is never reached, and the
+  // process ends on an empty event loop — exit 0, no SUMMARY, and a run that
+  // covered half the suite looks the same as a green one.
+  var mod;
+  try {
+    mod = require('./lsp/' + c);
+  } catch ( e ) {
+    h.counters.failures++;
+    console.error('  \x1b[31m✘ FAIL:\x1b[0m category ' + c +
+      ' threw while loading — ' + ( e && e.stack ? e.stack : e ));
+    return;
+  }
   if ( mod && mod.done && typeof mod.done.then === 'function' ) pending.push(mod.done);
 });
 

--- a/tools/tests/testFoamLSP.js
+++ b/tools/tests/testFoamLSP.js
@@ -94,8 +94,7 @@ function printSummaryAndExit() {
 // the whole run down silently — record it as a failure via the harness
 // counter and still print SUMMARY / exit non-zero, same as any other FAIL.
 Promise.all(pending).then(printSummaryAndExit, function(err) {
-  h.counters.failures++;
-  console.error('  \x1b[31m✘ FAIL:\x1b[0m an async test category rejected — ' +
+  h.test(false, 'an async test category rejected — ' +
     ( err && err.stack ? err.stack : err ));
   printSummaryAndExit();
 });

--- a/tools/tests/testFoamLSP.js
+++ b/tools/tests/testFoamLSP.js
@@ -76,9 +76,8 @@ toRun.forEach(function(c){
   try {
     mod = require('./lsp/' + c);
   } catch ( e ) {
-    h.counters.failures++;
-    console.error('  \x1b[31m✘ FAIL:\x1b[0m category ' + c +
-      ' threw while loading — ' + ( e && e.stack ? e.stack : e ));
+    h.test(false, 'category ' + c + ' threw while loading — ' +
+      ( e && e.stack ? e.stack : e ));
     return;
   }
   if ( mod && mod.done && typeof mod.done.then === 'function' ) pending.push(mod.done);


### PR DESCRIPTION
A category that throws while loading takes every later category with it, and the run still exits 0 with no SUMMARY line — so a run that covered half the suite reads exactly like a green one, locally and in CI.

Cause: `_harness.js` installs a `process.on('uncaughtException')` to swallow the browser-global and syntax errors `FileModelCache` produces while evaluating workspace files. Installing a listener at all suppresses node's default crash, so an error escaping `require('./lsp/<category>')` unwinds `toRun.forEach` in `testFoamLSP.js`, the remaining categories never load, `Promise.all(pending)` is never reached, and the process ends on a drained event loop.

Reproduce — append one bad line to any category:

```js
// tools/tests/lsp/pom.js
noSuchGlobal.boom();
```

```
$ node foam3/tools/tests/testFoamLSP.js pom,pomValidation,classify
exit 0     <- no SUMMARY, no FAIL line; pomValidation and classify never ran
```

Fix:

- `testFoamLSP.js` wraps each category `require` in try/catch: one counted failure naming the category and its stack, then on to the next category.

- `_harness.js` counts anything reaching `uncaughtException` as a failure, sets the exit code, and detaches the stdin listener `server.js` installs so that listener's `exit(0)` can't override the code.

Same injected line after the change:

```
$ node foam3/tools/tests/testFoamLSP.js pom,pomValidation,classify
  ✘ FAIL: category pom threw while loading — ReferenceError: noSuchGlobal is not defined
70 passed, 1 failed
exit 1     <- pomValidation and classify both ran
```

Suite 1772/0 unchanged.

Follow-up from #5409, which is where the exit-0 run turned up.

Merge order: independent.

