### PR TITLE
PT-FIXES:DOS-4811 Restore the pluralize expression on Model.plural

### DIFF
--- a/src/foam/lang/types.js
+++ b/src/foam/lang/types.js
@@ -1403,7 +1403,8 @@ foam.CLASS({
     },
     {
       class: 'I18NString',
-      name: 'plural'
+      name: 'plural',
+      expression: function(label) { return foam.String.pluralize(label); }
     },
     { class: 'Boolean', name: 'abstract' }
   ]


### PR DESCRIPTION
Reflow blocks get numbered instead of taking the DAO's name, because every model's `plural` comes back empty — upgrading it to an I18NString replaced the axiom that carried its pluralize expression.

Fix: restate the expression on `plural`.