### PR TITLE
PT-FIXES:DOS-4815 Lowercase the property name in column permission checks

### DIFF
--- a/src/foam/u2/filter/FilterConfigView.js
+++ b/src/foam/u2/filter/FilterConfigView.js
@@ -70,7 +70,7 @@ foam.CLASS({
         if ( ! this.auth || ! p.columnPermissionRequired )
           availableProps.push(p);
         else
-          this.auth.check(null, `${of.name.toLowerCase()}.column.${p.name}`).then(v => v && availableProps.push(p))
+          this.auth.check(null, `${of.name.toLowerCase()}.column.${p.name.toLowerCase()}`).then(v => v && availableProps.push(p))
       }));
       props = availableProps;
       this.overlay_.start()

--- a/src/foam/u2/filter/FilterView.js
+++ b/src/foam/u2/filter/FilterView.js
@@ -430,7 +430,7 @@ foam.CLASS({
         if ( ! this.auth || ! p.columnPermissionRequired )
           availableProps.push(p);
         else
-          this.auth.check(null, `${of.name.toLowerCase()}.column.${p.name}`).then(v => v && availableProps.push(p))
+          this.auth.check(null, `${of.name.toLowerCase()}.column.${p.name.toLowerCase()}`).then(v => v && availableProps.push(p))
       }));
       return availableProps.length > 0;
     }

--- a/src/foam/u2/table/TableComponentView.js
+++ b/src/foam/u2/table/TableComponentView.js
@@ -67,7 +67,7 @@ foam.CLASS({
       const results = await Promise.all(arr.map( async p =>
         p.hidden ? false :
         (! this.auth) ? true : ! p.columnPermissionRequired ||
-        await this.auth.check(ctrl.__subContext__, `${this.of.name.toLowerCase()}.column.${p.name}`)));
+        await this.auth.check(ctrl.__subContext__, `${this.of.name.toLowerCase()}.column.${p.name.toLowerCase()}`)));
       return arr.filter((_v, index) => results[index]);
     },
 


### PR DESCRIPTION
A column permission on a multi-word property never matches its grant. The check lowercases the model but not the property, so `lifecycleState` asks for `user.column.lifecycleState` while the grant is written `user.column.lifecyclestate`. Single-word properties match either way, which is why this stayed hidden.

Every other property permission family lowercases both halves — `Element2.js` for `ro`/`rw`, `PermissionedPropertyDAO` for the server-side `rw` check — and `foam/core/auth/permissions.jrl` already declares `user.column.lifecyclestate` in the lowercase form.

Fix: lowercase the property segment in the three places that build the string.

Worth knowing before merging: a grant written in camelCase to work around this stops matching. Apps carrying one need it lowercased in the same release.

DOS-4815