### PR TITLE
lsp: a name-addressed property hover answers about the property

### DIFF
--- a/tools/lsp/server.js
+++ b/tools/lsp/server.js
@@ -246,7 +246,19 @@ function start() {
         // buildMethodHover_ returns a raw markdown string (wrap it);
         // buildClassHover already returns a { contents: {...} } hover (pass
         // it through). Don't double-wrap.
-        if ( info.memberName && info.kind === 6 ) {
+        //
+        // Any member name is tried here, not only kind 6. Gated on methods,
+        // a property fell past every branch to buildClassHover, so asking
+        // about one property answered with the whole class — 34 properties
+        // for User, with the asked-for one somewhere inside. The cursor path
+        // has always answered from getPropertyDoc; this is the same call.
+        // Each lookup below identifies its own axiom kind and returns null
+        // otherwise, so the order is a preference, not a gate: an action or
+        // an enum member still reaches buildClassHover as before.
+        if ( info.memberName ) {
+          var propMd = index.getPropertyDoc(classId, info.memberName);
+          if ( propMd ) return { contents: { kind: 'markdown', value: propMd } };
+
           var cls = index.getClass(classId);
           var methodAxiom = null;
           if ( cls ) {

--- a/tools/tests/lsp/hover.js
+++ b/tools/tests/lsp/hover.js
@@ -394,3 +394,99 @@ if ( index.classExists('foam.core.auth.Group') ) {
   test(grpText.indexOf('*:*') !== -1 || grpText.indexOf('1:*') !== -1,
     'cardinality (*:* or 1:*) appears verbatim in relationship hover');
 }
+
+
+// === byName hover answers about the member, not the whole class ===
+//
+// Tested through the wire rather than through HoverHandler: getPropertyDoc was
+// always right and buildClassHover was always right — the gate in server.js's
+// byNameResult decided which one a property reached, so the handler cannot
+// show the bug. A lane boots server.js in-process and asks foam/byName.
+
+var byNameHoverDone = h.withServerLane(async function() {
+  var origWrite = process.stdout.write;
+  try {
+    var frames = [];
+    var inBuf  = Buffer.alloc(0);
+    function drain() {
+      while ( true ) {
+        var headerEnd = inBuf.indexOf('\r\n\r\n');
+        if ( headerEnd === -1 ) return;
+        var m = /Content-Length:\s*(\d+)/i.exec(inBuf.slice(0, headerEnd).toString('utf8'));
+        if ( ! m ) { inBuf = inBuf.slice(headerEnd + 4); continue; }
+        var len = parseInt(m[1], 10), bodyStart = headerEnd + 4;
+        if ( inBuf.length < bodyStart + len ) return;
+        var body = inBuf.slice(bodyStart, bodyStart + len).toString('utf8');
+        inBuf = inBuf.slice(bodyStart + len);
+        try { frames.push(JSON.parse(body)); } catch ( e ) {}
+      }
+    }
+    process.stdout.write = function(chunk) {
+      inBuf = Buffer.concat([ inBuf, Buffer.isBuffer(chunk) ? chunk : Buffer.from(String(chunk), 'utf8') ]);
+      drain();
+      return true;
+    };
+
+    var nextId = 1;
+    function request(method, params, what) {
+      var msg = { jsonrpc: '2.0', method: method, params: params, id: nextId++ };
+      var json = JSON.stringify(msg);
+      process.stdin.emit('data', Buffer.from(
+        'Content-Length: ' + Buffer.byteLength(json) + '\r\n\r\n' + json, 'utf8'));
+      return new Promise(function(resolve, reject) {
+        var deadline = Date.now() + 20000;
+        (function poll() {
+          for ( var i = 0 ; i < frames.length ; i++ ) {
+            if ( frames[i].id === msg.id ) return resolve(frames[i]);
+          }
+          if ( Date.now() > deadline ) return reject(new Error('timed out waiting for ' + what));
+          setTimeout(poll, 10);
+        })();
+      });
+    }
+
+    process.stdin.removeAllListeners('data');
+    require('../../lsp/server').start();
+    process.stdin.removeAllListeners('end');
+    frames = [];
+    inBuf  = Buffer.alloc(0);
+
+    section('byName hover — a property answers about itself');
+
+    // foam.core.auth.User.email resolves as kind 7 with getPropertyDoc
+    // '**email** (EMail)'; the class hover for User is ~5.3k characters.
+    var propRes = await request('foam/byName',
+      { name: 'foam.core.auth.User.email', op: 'hover' }, 'byName property hover');
+    var propVal = ( propRes && propRes.result && propRes.result.contents &&
+                    propRes.result.contents.value ) || '';
+
+    test(propVal.indexOf('**email**') === 0,
+      'byName hover on User.email opens with the property, got: ' +
+      JSON.stringify(propVal.slice(0, 40)));
+    test(propVal.indexOf('(EMail)') !== -1,
+      'byName hover on User.email names its property type');
+    // The bug was a whole-class dump. Assert the shape it must NOT have:
+    // the class hover carries other properties' names and runs into the
+    // thousands of characters.
+    test(propVal.length < 1000,
+      'byName hover on User.email is the property, not the class dump (' +
+      propVal.length + ' chars)');
+
+    // Non-regression: a class with no member still gets the class hover.
+    var clsRes = await request('foam/byName',
+      { name: 'foam.core.auth.User', op: 'hover' }, 'byName class hover');
+    var clsVal = ( clsRes && clsRes.result && clsRes.result.contents &&
+                   clsRes.result.contents.value ) || '';
+    test(clsVal.indexOf('foam.core.auth.User') !== -1 && clsVal.length > 1000,
+      'byName hover on the bare class still returns the class hover (' +
+      clsVal.length + ' chars)');
+  } finally {
+    process.stdout.write = origWrite;
+    process.stdin.removeAllListeners('data');
+    process.stdin.removeAllListeners('end');
+  }
+});
+
+module.exports = { done: byNameHoverDone.catch(function(e) {
+  test(false, 'byName hover lane failed — ' + ( e && e.message ? e.message : e ));
+}) };


### PR DESCRIPTION
Asking about one property answers with the whole class. `foam.core.auth.User.email` returns 5357 characters of class hover with the answer somewhere inside it.

Cause: `byNameResult`'s member branch is gated on `info.kind === 6`, methods. A property carries kind 7, so it falls past every branch to `buildClassHover`.

```
foam/byName { name: "foam.core.auth.User.email", op: "hover" }

before:  ```foam\nfoam.core.auth.User\n```*implements…     <- 5357 chars, the whole class
after:   **email** (EMail)\n\nThe email address of…        <- 51 chars
```

The cursor path has always answered this from `getPropertyDoc`; the name-addressed path now makes the same call.

Each lookup identifies its own axiom kind and returns null otherwise, so the order is a preference rather than a gate — an action or an enum member still reaches the class hover, as before.

Tested through the wire, not the handler: `getPropertyDoc` and `buildClassHover` were both always correct, and the gate that chose between them lives in `server.js`, so a handler-level test cannot see the bug. A lane boots `server.js` in-process and asks `foam/byName`. Restoring the `kind === 6` gate reds it with the 5357-character value quoted.

Suite 1773/0.

Merge order: independent.