### PR TITLE
lsp: a reused variable name reds the whole jrl test category

### DIFF
--- a/tools/tests/lsp/jrl.js
+++ b/tools/tests/lsp/jrl.js
@@ -1213,8 +1213,12 @@ if ( require('fs').existsSync(realJrlPath) ) {
   for ( var rl = 0 ; rl < realLines.length ; rl++ ) {
     var m = realLines[rl].indexOf('.setPm(');
     if ( m === -1 ) continue;
-    var h = jrlH3.handleHover(realText, { line: rl, character: m + 3 });
-    test(h && h.contents && h.contents.value && /setPm|pm/i.test(h.contents.value),
+    // Not `h`: that is the harness at the top of this file, and the lane test
+    // near the end of the file still needs it. This block only runs when a host
+    // app's journals/ sits four levels up, so reusing the name went unnoticed
+    // until then — where it left `h.withServerLane` reading off a hover result.
+    var hovPm = jrlH3.handleHover(realText, { line: rl, character: m + 3 });
+    test(hovPm && hovPm.contents && hovPm.contents.value && /setPm|pm/i.test(hovPm.contents.value),
       'Real services.jrl: hover on .setPm at line ' + rl + ' resolves (setPm or pm in output)');
     break;
   }


### PR DESCRIPTION
The `jrl` test category throws while loading on any checkout where foam3 sits inside a host app, taking all 200-odd of its tests with it: `TypeError: h.withServerLane is not a function`.

Cause: `jrl.js` binds the harness as `h` at the top of the file, and the real-journal block further down reuses `h` for a hover result. `var` is function-scoped, so those are one binding, not two.

Reproduce — the block is guarded on a path four levels up, so it runs only when that file is there:

```js
var h = require('./_harness');                    // the harness

var realJrlPath = require('path').resolve(__dirname, '../../../../journals/services.jrl');
if ( require('fs').existsSync(realJrlPath) ) {
  var h = jrlH3.handleHover(realText, ...);       // same binding — h is now a hover result
}

var jrlSaveDone = h.withServerLane(async function() { ... });   // throws
```

```
foam3 inside a host app   199 passed, 1 failed   <- journals/ resolves, the block runs
standalone foam3 / CI     202 passed, 0 failed   <- path is absent, block skipped
```

That is why it stayed quiet: the name is only reused on checkouts that have a sibling `journals/services.jrl`, and CI has none.

Fix: the hover result gets its own name.

The category goes 199/1 to 202/0. The three that come back are the save-lane tests at the end of the file — `jrl save: the registered service answers workspace/symbol before the edit`, `…findable under its new name`, `…no longer under the old one` — which sit after the throw. The hover block above it ran on development all along. Suite 1829/0.

Sweeping the file for the same shape: eight other names are declared twice, and every one of them is read only on the line right after its second assignment. `h` was the one read from another block.

Merge order: independent.
