### PR TITLE
Render Glyph properties as the glyph instead of its SVG source

### DIFF
--- a/src/foam/u2/Element2.js
+++ b/src/foam/u2/Element2.js
@@ -2146,6 +2146,30 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'foam.u2',
+  name: 'GlyphViewRefinement',
+  refines: 'foam.lang.GlyphProperty',
+
+  requires: [
+    'foam.u2.view.FObjectView',
+    'foam.u2.view.GlyphView',
+    'foam.u2.view.ModeAltView'
+  ],
+
+  properties: [
+    {
+      name: 'view',
+      value: {
+        class: 'foam.u2.view.ModeAltView',
+        readView: { class: 'foam.u2.view.GlyphView' },
+        writeView: { class: 'foam.u2.view.FObjectView', of: 'foam.lang.Glyph' }
+      }
+    }
+  ]
+});
+
+
+foam.CLASS({
+  package: 'foam.u2',
   name: 'FObjectArrayViewRefinement',
   refines: 'foam.lang.FObjectArray',
 

--- a/src/foam/u2/view/GlyphView.js
+++ b/src/foam/u2/view/GlyphView.js
@@ -15,8 +15,8 @@ foam.CLASS({
 
   css: `
     ^ svg {
-      fill: currentColor;
-      height: 2.4rem;
+      fill: var(--glyph-fill, currentColor);
+      height: var(--glyph-size, 2.4rem);
       width: auto;
     }
   `,

--- a/src/foam/u2/view/GlyphView.js
+++ b/src/foam/u2/view/GlyphView.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.u2.view',
+  name: 'GlyphView',
+  extends: 'foam.u2.View',
+
+  documentation: 'Read-only view of a Glyph which shows the glyph itself rather than its SVG source.',
+
+  requires: [ 'foam.u2.tag.Image' ],
+
+  css: `
+    ^ svg {
+      fill: currentColor;
+      height: 2.4rem;
+      width: auto;
+    }
+  `,
+
+  methods: [
+    function render() {
+      this
+        .addClass()
+        .tag(this.Image, { glyph$: this.data$, role: 'presentation' });
+    }
+  ]
+});

--- a/src/pom.js
+++ b/src/pom.js
@@ -711,6 +711,7 @@ foam.POM({
     { name: "foam/u2/view/CurrencyView",                              flags: "web" },
     { name: "foam/u2/view/CurrencyInputView",                         flags: "web" },
     { name: "foam/u2/view/FObjectPropertyView",                       flags: "web" },
+    { name: "foam/u2/view/GlyphView",                                 flags: "web" },
     { name: "foam/u2/view/CodeView",                                  flags: "web" },
     { name: "foam/u2/view/ReferencePropertyView",                     flags: "web" },
     { name: "foam/u2/view/EnumView",                                  flags: "web" },


### PR DESCRIPTION
A Glyph property renders as its template text, so a theme's glyph list reads as a wall of markup:

```
Checkmark    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="/*%FILL%*/ #ffffff"><path d="M0 0h24v24H0V0z" fill="none"/>...
Speed        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="/*%FILL%*/ #ffffff"><path d="M0 0h24v24H0V0z" fill="none"/>...
Exclamation  <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="/*%FILL%*/ #ffffff" viewBox="0 0 24 24"><path fill-rule="nonzero" d="M 12 0 z m 0 13.2 ...
```

`GlyphProperty` now picks its view by mode. Read mode draws the glyph through `foam.u2.tag.Image`; write mode keeps the `FObjectView` editor, so templates stay editable.

`GlyphView` draws the svg with `fill: var(--glyph-fill, currentColor)`, so the default follows the theme's text colour and a host can retarget it from any ancestor. Size works the same way through `--glyph-size`, defaulting to 2.4rem; auto width keeps the non-square viewBoxes in proportion.

<img width="410" height="588" alt="image" src="https://github.com/user-attachments/assets/ae008305-ad34-46ea-91e2-c9fd5276d5c3" />

