### PR TITLE
Switch EasyDAO.unloadable back to true by default

### DIFF
--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -545,7 +545,7 @@ foam.CLASS({
       // Unloadable-by-default is intended: SINGLE_JOURNAL EasyDAOs get memory
       // management via lazy journal reload (NotPartitionedDAO) unless explicitly
       // opted out; wrappers that can't safely rebuild (e.g. fixedSize) exclude themselves.
-      value: false
+      value: true
     },
     {
       documentation: 'Sets the inner dao to a nullDAO',


### PR DESCRIPTION
SINGLE_JOURNAL EasyDAOs currently default to `unloadable: false`, so each one keeps its whole journal in memory for the life of the process instead of unloading and reloading it lazily through NotPartitionedDAO.