### PR TITLE
Lowercase the section permission string

### DIFF
--- a/doc/guides/Permissions.md
+++ b/doc/guides/Permissions.md
@@ -176,9 +176,9 @@ boolean foam.core.auth.AuthService.check(X x, String permission)
 - **Note:** Defined within individual action models
 
 ### 6. UI Section Visibility
-- **Pattern:** `<modelname.toLowerCase()>.section.<sectionName>`
-- **Example:** `foam.core.cron.schedulable.section.history`
-- **Implementer:** Unknown/undocumented
+- **Pattern:** `<model>.section.<section>`, both lowercased like the `ro`/`rw`/`column` families
+- **Examples:** `schedulable.section.history`, `flow.section.scriptsection`
+- **Implementer:** SectionAxiom.js
 - **Note:** Sections are not permissioned by default. To enable permission include: `permissionRequired: true` in the section.
 
 ### 7. Table Column Visibility

--- a/src/foam/core/cron/permissions.jrl
+++ b/src/foam/core/cron/permissions.jrl
@@ -10,6 +10,6 @@ p({
 })
 p({
   "class":"foam.core.auth.Permission",
-  "id":"foam.core.cron.schedulable.section.history",
+  "id":"schedulable.section.history",
   "description":"permission to see schedulable history section"
 })

--- a/src/foam/core/reflow/Flow.js
+++ b/src/foam/core/reflow/Flow.js
@@ -60,7 +60,7 @@ foam.CLASS({
       name: 'scriptSection',
       title: 'Script',
       collapsable: true,
-      permissionRequired: true, // requires foam.core.reflow.flow.section.scriptSection to access
+      permissionRequired: true, // requires flow.section.scriptsection to access
       properties: [ 'preLoadScript', 'script' ]
     }
   ],

--- a/src/foam/layout/SectionAxiom.js
+++ b/src/foam/layout/SectionAxiom.js
@@ -89,7 +89,7 @@ foam.CLASS({
           var data = data$.get();
           if ( data && data.__subContext__.auth ) {
             data.__subContext__.auth.check(null,
-              `${data.cls_.id.toLowerCase()}.section.${self.name}`).then((hasAuth) => {
+              `${data.cls_.name.toLowerCase()}.section.${self.name.toLowerCase()}`).then((hasAuth) => {
                 permSlot.set(hasAuth);
               });
           }


### PR DESCRIPTION
A section permission used to be built from the full class id, lowercased, with the section name kept as written: `foam.core.reflow.flow.section.scriptSection`. The `ro`, `rw`, and `column` families use the simple model name and lowercase both halves, so a section grant had to be written in its own shape to match.

The check now builds `flow.section.scriptsection`, the same shape as the other families. The Permissions guide and the cron `schedulable.section.history` permission row follow.

A grant written in the old shape stops matching. Apps carrying one need it re-keyed in the same release.