### PR TITLE
PT-FIXES:DOS-4787,DOS-4791 CSV export: ISO 8601 dates and a UTF-8 BOM

### DIFF
--- a/src/foam/core/column/CSVTableOutputter.js
+++ b/src/foam/core/column/CSVTableOutputter.js
@@ -11,6 +11,16 @@ foam.CLASS({
 
   documentation: 'Outputter to output array of values to CSV',
 
+  constants: [
+    {
+      name: 'BOM',
+      // UTF-8 byte order mark. Excel ignores the download's charset and reads
+      // a CSV as Windows-1252 unless the file starts with one, turning 'É'
+      // into 'Ã‰' and '—' into 'â€”'.
+      value: '\uFEFF'
+    }
+  ],
+
   methods: [
     function arrayToCSV(arrayOfValues) {
       var output = [];
@@ -20,7 +30,7 @@ foam.CLASS({
         });
         output.push(row.join(','));
       }
-      return output.join('\n');
+      return this.BOM + output.join('\n');
     }
   ]
 });

--- a/src/foam/core/column/test/CSVTableOutputterJSTest.js
+++ b/src/foam/core/column/test/CSVTableOutputterJSTest.js
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.column.test',
+  name: 'CSVTableOutputterJSTest',
+  extends: 'foam.core.test.JSTest',
+
+  documentation: `CSV export output must open correctly in Excel: the file
+    starts with a UTF-8 BOM so accented and special characters are not read
+    as Windows-1252, and the default date format is ISO 8601 with a 24h time
+    so every Excel locale parses the column as a date and sorts it
+    chronologically.`,
+
+  requires: [
+    'foam.core.export.CSVTableExportDriver'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      code: async function(x) {
+        var driver    = this.CSVTableExportDriver.create({}, x);
+        var outputter = driver.outputter;
+        var csv       = outputter.arrayToCSV([ [ 'Émetteur', 'a — b' ] ]);
+
+        x.test(csv.charCodeAt(0) === 0xFEFF,
+          'CSV output starts with the UTF-8 BOM');
+        x.test(csv.slice(1) === '"Émetteur","a — b"',
+          'BOM is the only prefix; rows are unchanged: ' + JSON.stringify(csv.slice(1)));
+
+        // Local-time date, as the outputter formats in the exporting browser's timezone
+        var d = new Date(2026, 8, 2, 0, 59, 5);
+        x.test(outputter.dateTimeToString(d) === '2026-09-02 00:59:05',
+          'default date format is ISO 8601 date with 24h time: ' + outputter.dateTimeToString(d));
+        x.test(outputter.dateToString(d) === '2026-09-02',
+          'default Date-only format is ISO 8601: ' + outputter.dateToString(d));
+
+        var pm = new Date(2026, 7, 27, 22, 4, 42);
+        x.test(outputter.dateTimeToString(pm) === '2026-08-27 22:04:42',
+          'afternoon times are 24h, not AM/PM: ' + outputter.dateTimeToString(pm));
+
+        var ddmm = driver.choices[1][0];
+        x.test(ddmm[0](d) + ' ' + ddmm[1](d) === '02/09/2026 00:59:05',
+          'DDMMYYYY choice is unchanged: ' + ddmm[0](d) + ' ' + ddmm[1](d));
+      }
+    }
+  ]
+});

--- a/src/foam/core/column/test/tests.jrl
+++ b/src/foam/core/column/test/tests.jrl
@@ -1,1 +1,2 @@
 p({"class":"foam.core.column.test.TableColumnOutputterJSTest","id":"TableColumnOutputterJSTest","description":"DoubleUnitValue table export formatting, incl. RefSummary unit values", language: 0})
+p({"class":"foam.core.column.test.CSVTableOutputterJSTest","id":"CSVTableOutputterJSTest","description":"CSV export starts with a UTF-8 BOM and defaults to ISO 8601 24h dates", language: 0})

--- a/src/foam/core/export/CSVTableExportDriver.js
+++ b/src/foam/core/export/CSVTableExportDriver.js
@@ -30,17 +30,23 @@ foam.CLASS({
       name: 'choices',
       hidden: true,
       factory: function() {
+        var pad  = n => ('0' + n).slice(-2);
+        var time = d => pad(d.getHours()) + ':' + pad(d.getMinutes()) + ':' + pad(d.getSeconds());
         return [
+          // ISO 8601 date, 24h time. Locale-independent: every Excel locale
+          // parses it as a date, so the column sorts chronologically. The
+          // en-US locale strings this replaced ('8/27/2026 10:04:42 PM') stay
+          // text in a UK Excel for days > 12 and then sort lexically.
           [ [
-              d => d.toLocaleDateString('en-us'),
-              d => d.toLocaleTimeString('en-us')
+              d => d.getFullYear() + '-' + pad(d.getMonth() + 1) + '-' + pad(d.getDate()),
+              time
             ],
             this.SPREADSHEET
           ],
           [
             [
-              d => ('0' + d.getDate()).slice(-2) + '/' + ('0' + (d.getMonth() + 1)).slice(-2) + '/' + d.getFullYear(),
-              d => ('0' + d.getHours()).slice(-2) + ':' + ('0' + d.getMinutes()).slice(-2) + ':' + ('0' + d.getSeconds()).slice(-2)
+              d => pad(d.getDate()) + '/' + pad(d.getMonth() + 1) + '/' + d.getFullYear(),
+              time
             ],
             this.DDMMYYYY
           ],

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -49,6 +49,7 @@ foam.POM({
     { name: "column/CSVTableOutputter",                                                   flags: "js" },
     { name: "column/NestedPropertiesExpression",                                          flags: "js|java" },
     { name: "column/TableColumnOutputter",                                                flags: "js|java" },
+    { name: "column/test/CSVTableOutputterJSTest",                                        flags: "js&test|java&test" },
     { name: "column/test/TableColumnOutputterJSTest",                                     flags: "js&test|java&test" },
     { name: "controller/AppStyles",                                                       flags: "web" },
     { name: "controller/Fonts",                                                           flags: "web" },


### PR DESCRIPTION
Two things kept CSV exports from opening cleanly in Excel:

- The default date choice wrote en-US locale strings (`8/27/2026 10:04:42 PM`). An Excel set to a day-first locale reads that as a date only when the day is 12 or less, so one column ends up part dates, part text, and sorts lexically (10 PM, 11 PM, 3 AM, 9 PM).

- The file had no byte order mark. Excel ignores the download's `charset=utf-8` and decodes the bytes as Windows-1252, so `É` shows as `Ã‰` and `—` as `â€”`.

Fix:

- The first (default) choice in `CSVTableExportDriver` is now ISO 8601 with a 24h time, `2026-08-27 22:04:42`. Every Excel locale parses it as a date. The DDMMYYYY, Long and Locale choices are unchanged.

- `CSVTableOutputter.arrayToCSV` prefixes the output with `\uFEFF`, so the export modal and a Reflow download of a local DAO both get it. A Reflow download of a service DAO goes through the dig servlet instead; that path gets the same treatment in #5438.

`CSVTableOutputterJSTest` covers both.

DOS-4787, DOS-4791
