### PR TITLE
PT-FIXES:DOS-4787,DOS-4791 Dig CSV: UTF-8 BOM and ISO 8601 dates

### DIFF
--- a/src/foam/core/dig/drivers/DigCsvDriver.js
+++ b/src/foam/core/dig/drivers/DigCsvDriver.js
@@ -67,7 +67,6 @@ foam.CLASS({
       name: 'outputFObjects',
       javaCode: `
       HttpServletResponse resp   = x.get(HttpServletResponse.class);
-      PrintWriter         out    = x.get(PrintWriter.class);
       ClassInfo           cInfo  = dao.getOf();
       String              output = null;
 
@@ -75,11 +74,15 @@ foam.CLASS({
 
       HttpParameters p = x.get(HttpParameters.class);
       boolean forceDownload = p != null && "true".equalsIgnoreCase(p.getParameter("download"));
-      resp.setContentType("text/csv");
+      // Set before the first PrintWriter lookup: the servlet writer takes its
+      // charset from the content type when it is created and falls back to
+      // ISO-8859-1, which would turn 'É' into '?'.
+      resp.setContentType("text/csv;charset=utf-8");
       if ( forceDownload ) {
         String filename = cInfo != null ? cInfo.getName() : "export";
         resp.setHeader("Content-Disposition", "attachment; filename=\\"" + filename + ".csv\\"");
       }
+      PrintWriter out = x.get(PrintWriter.class);
 
       if ( fobjects == null || fobjects.size() == 0 ) {
         getLogger().info("csv.output.empty");
@@ -90,8 +93,15 @@ foam.CLASS({
       String colsStr = cols == null ? "all" : String.join(",", cols);
       getLogger().info("csv.output.count", "count", fobjects.size(), "columns", colsStr);
 
+      // UTF-8 byte order mark: Excel decodes a CSV as Windows-1252 unless the
+      // file starts with one. ISO 8601 with a 24h time parses as a date in
+      // every Excel locale; Date.toString() and 'MM/dd/yyyy hh:mm:ss aa' stay
+      // text outside the US and sort lexically.
+      out.print("\\uFEFF");
       CSVOutputterImpl csv = new CSVOutputterImpl.Builder(x)
         .setOf(cInfo)
+        .setSheetsCompatible(true)
+        .setDateFormatter(new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss"))
         .build();
 
       if ( cols != null && cols.length > 0 ) csv.setProps(cols);

--- a/src/foam/core/dig/test/DigCsvDriverTest.js
+++ b/src/foam/core/dig/test/DigCsvDriverTest.js
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2026 The FOAM Authors. All Rights Reserved.
+ * http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+foam.CLASS({
+  package: 'foam.core.dig.test',
+  name: 'DigCsvDriverTest',
+  extends: 'foam.core.test.Test',
+
+  documentation: `The dig CSV response must open correctly in Excel: UTF-8
+    bytes behind a charset the servlet writer picks up, a leading byte order
+    mark, and ISO 8601 24h dates. The response stub fixes the writer's charset
+    at creation from the content type set so far, as a servlet container does.`,
+
+  javaImports: [
+    'foam.lang.X',
+    'foam.lang.XFactory',
+    'foam.core.alarming.Alarm',
+    'foam.core.dig.drivers.DigCsvDriver',
+    'foam.dao.MDAO',
+    'jakarta.servlet.http.HttpServletResponse',
+    'java.io.ByteArrayOutputStream',
+    'java.io.OutputStreamWriter',
+    'java.io.PrintWriter',
+    'java.lang.reflect.Proxy',
+    'java.nio.charset.StandardCharsets',
+    'java.text.SimpleDateFormat',
+    'java.util.Date',
+    'java.util.List'
+  ],
+
+  methods: [
+    {
+      name: 'runTest',
+      args: 'X x',
+      javaCode: `
+      final ByteArrayOutputStream bytes       = new ByteArrayOutputStream();
+      final String[]              contentType = new String[1];
+      final PrintWriter[]         writer      = new PrintWriter[1];
+
+      final HttpServletResponse resp = (HttpServletResponse) Proxy.newProxyInstance(
+        HttpServletResponse.class.getClassLoader(),
+        new Class[] { HttpServletResponse.class },
+        (proxy, method, args) -> {
+          switch ( method.getName() ) {
+            case "setContentType": contentType[0] = (String) args[0]; return null;
+            case "getContentType": return contentType[0];
+            case "getWriter":
+              if ( writer[0] == null ) {
+                String cs = contentType[0] != null && contentType[0].toLowerCase().contains("charset=utf-8") ? "UTF-8" : "ISO-8859-1";
+                writer[0] = new PrintWriter(new OutputStreamWriter(bytes, cs), true);
+              }
+              return writer[0];
+          }
+          Class rt = method.getReturnType();
+          if ( rt == boolean.class ) return false;
+          if ( rt.isPrimitive() )    return 0;
+          return null;
+        });
+
+      X y = x
+        .put(HttpServletResponse.class, resp)
+        .putFactory(PrintWriter.class, new XFactory() {
+          public Object create(X ctx) {
+            try { return resp.getWriter(); } catch (java.io.IOException e) { return null; }
+          }
+        });
+
+      Date  created = new Date(1788307145000L); // 2026-09-02T04:59:05Z
+      Alarm alarm   = new Alarm();
+      alarm.setName("CIH Émetteur — «test»");
+      alarm.setCreated(created);
+
+      new DigCsvDriver.Builder(y).build()
+        .outputFObjects(y, new MDAO(Alarm.getOwnClassInfo()), List.of(alarm), new String[] { "name", "created" });
+
+      byte[] out = bytes.toByteArray();
+      test(out.length > 3 && (out[0] & 0xFF) == 0xEF && (out[1] & 0xFF) == 0xBB && (out[2] & 0xFF) == 0xBF,
+        "response starts with the UTF-8 byte order mark");
+      test("text/csv;charset=utf-8".equals(contentType[0]),
+        "content type carries charset=utf-8: " + contentType[0]);
+
+      String csv = new String(out, StandardCharsets.UTF_8);
+      test(csv.contains("CIH Émetteur — «test»"),
+        "non-ASCII text is written as UTF-8 bytes (content type set before the writer was created): " + csv);
+
+      String iso = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(created);
+      test(csv.contains(iso),
+        "DateTime is written as ISO 8601 24h, not Date.toString(): expected " + iso + " in " + csv);
+      test(! csv.contains("EDT 2026") && ! csv.contains("UTC 2026") && ! csv.contains(" AM") && ! csv.contains(" PM"),
+        "no Date.toString() or 12h output: " + csv);
+      `
+    }
+  ]
+});

--- a/src/foam/core/dig/test/tests.jrl
+++ b/src/foam/core/dig/test/tests.jrl
@@ -6,3 +6,7 @@ p({
   class: "foam.core.dig.test.DUGLoopbackTest",
   id:"DUGLoopbackTest"
 })
+p({
+  class: "foam.core.dig.test.DigCsvDriverTest",
+  id:"DigCsvDriverTest"
+})

--- a/src/foam/core/pom.js
+++ b/src/foam/core/pom.js
@@ -439,6 +439,7 @@ foam.POM({
     { name: "dig/LinkView",                                                               flags: "js" },
     { name: "dig/ResultView",                                                             flags: "js" },
     { name: "dig/SUGAR",                                                                  flags: "js|java" },
+    { name: "dig/test/DigCsvDriverTest",                                                  flags: "js&test|java&test" },
     { name: "dig/test/DigJsonDriverTest",                                                 flags: "js&test|java&test" },
     { name: "dig/test/DUGLoopbackTest",                                                   flags: "js&test|java&test" },
     { name: "notification/email/ClientPOP3EmailService",                                  flags: "js|java" },


### PR DESCRIPTION
Follow-up to #5437, which fixed the browser-side CSV export. A Reflow download of a service DAO goes through `/service/dig?format=csv` instead, and that path had the same two Excel problems plus a third:

- `DigCsvDriver` fetched the `PrintWriter` before setting the content type. The servlet writer fixes its charset at creation and falls back to ISO-8859-1, so `É` went out as `?`.

- No byte order mark, so Excel read the bytes as Windows-1252.

- Dates went out as `Date.toString()`, `Wed Aug 27 22:04:42 EDT 2026`, which Excel keeps as text.

Fix, all in `DigCsvDriver.outputFObjects`:

- `text/csv;charset=utf-8` is set before the first `PrintWriter` lookup.

- The response starts with `\uFEFF`.

- The `CSVOutputterImpl` runs with `sheetsCompatible` and a `yyyy-MM-dd HH:mm:ss` formatter, so dates match the browser export. Times are in the JVM's timezone here, the browser's in #5437.

`DigCsvSheetsDriver` (`format=csvsheets`) is unchanged.

`DigCsvDriverTest` covers all three: it stubs `HttpServletResponse` so the writer's charset is fixed from the content type at creation, the way the servlet container does it.

DOS-4787, DOS-4791
