### PR TITLE
OverlayDropdown: ignore a detached parentEl when positioning

### DIFF
--- a/src/foam/u2/md/OverlayDropdown.js
+++ b/src/foam/u2/md/OverlayDropdown.js
@@ -145,6 +145,11 @@ foam.CLASS({
     },
 
     function setPosition() {
+      // A DOM parent the page has re-rendered is detached and reports an
+      // all-zero rect, which would move the dropdown to the top-left corner.
+      // Keep the last position until a connected parent is set. A FOAM Element
+      // parent has no isConnected and positions as before.
+      if ( this.parentEl?.isConnected === false ) return;
       var screenWidth  = this.window.innerWidth;
       var domRect      = this.parentEl.getBoundingClientRect();
       var screenHeight = this.window.innerHeight;
@@ -203,6 +208,7 @@ foam.CLASS({
       let fn = () => {
         if ( ! this.parentEl ) return;
         this.ro_ = new ResizeObserver(() => {
+          if ( this.parentEl?.isConnected === false ) return;
           if ( this.lockToParentWidth ) {
             this.dropdownE_.el_().style.width = this.parentEl.getBoundingClientRect().width;
           }


### PR DESCRIPTION
Alternative to #5442, which fixes the same symptom from the `EditColumnsView` side.

Toggling a column while the column popup is open moves the popup to the top-left corner.

Cause: `UnstyledTableView` renders the header row from `slot(columns_)`, so a column toggle replaces the row and detaches the "..." cell that `EditColumnsView` handed to `OverlayDropdown` as `parentEl`. `OverlayDropdown` keeps a `ResizeObserver` on that cell; a detached target reports a 0x0 box, so `setPosition` reads an all-zero rect and writes `top: 8px; left: 0`.

Fix: `setPosition` and the `ResizeObserver` callback return early when `parentEl.isConnected === false`, so the dropdown keeps its last position until a connected parent is set. The check is `=== false` rather than `! isConnected` because `GlobalFuidSearch` passes a FOAM Element as `parentEl`, which has no `isConnected` and should position as before.

#5442 gets the same result by creating a fixed-position `<span>` in `body`, copying the cell's rect onto it, and handing that to the dropdown. That keeps the fix inside one consumer, while the other `OverlayDropdown` users (`RichChoiceView`, `OverlayActionListView`, `SmartView`, `PropertyFilterView`, ...) can hit the same jump whenever their parent re-renders. The span also has no `id`, so `onKeyDown`'s Escape refocus throws, and a window resize repositions from the span's copied rect instead of the live cell. With the guard in place `EditColumnsView` can stay on its current `openDropDown`.

Verified in a browser: open the column popup, toggle a column, the popup stays in place. No test added: the case needs a DOM and a `ResizeObserver`, so a client-side test is a follow-up.
