### PR TITLE
Load non-lazy DAOs at boot again, and start framework services first

### DIFF
--- a/src/foam/box/services.jrl
+++ b/src/foam/box/services.jrl
@@ -2,6 +2,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "boxThreadPool",
   "lazy": false,
+  "lazyOrder": -1,
   "serve": false,
   "serviceScript": `
     return new foam.core.pool.ThreadPoolAgency.Builder(x)

--- a/src/foam/box/socket/services.jrl
+++ b/src/foam/box/socket/services.jrl
@@ -2,6 +2,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "socketConnectionBoxManager",
   "lazy": false,
+  "lazyOrder": -1,
   "service": {
     "class": "foam.box.socket.SocketConnectionBoxManager"
   }
@@ -11,6 +12,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "socketServer",
   "lazy": false,
+  "lazyOrder": -1,
   "service": {
     "class": "foam.box.socket.SocketServer"
   }
@@ -21,6 +23,7 @@ p({
   "name": "sslContextFactory",
   "description": "ssl context factory for creating ssl socket",
   "lazy":false,
+  "lazyOrder":-1,
   "service": {
     "class": "foam.box.socket.SslContextFactory"
   }
@@ -31,6 +34,7 @@ p({
   "name": "unsafeSslContextFactory",
   "description": "ssl context factory for creating ssl socket, without certificate verification",
   "lazy":false,
+  "lazyOrder":-1,
   "service": {
     "class": "foam.box.socket.UnsafeSslContextFactory"
   }

--- a/src/foam/core/app/services.jrl
+++ b/src/foam/core/app/services.jrl
@@ -2,6 +2,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "version",
   "lazy": false,
+  "lazyOrder": -1,
   "authenticate": false,
   "serviceClass": "foam.core.app.VersionWebAgent"
 })
@@ -31,6 +32,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "health",
   "lazy": false,
+  "lazyOrder": -1,
   "authenticate": false,
   "parameters": true,
   "serviceClass": "foam.core.app.HealthWebAgent"
@@ -51,6 +53,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"healthSupport",
   "lazy":false,
+  "lazyOrder":-1,
   "service": {
     "class": "foam.core.app.HealthSupport"
   }
@@ -60,6 +63,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "healthHeartbeatService",
   "lazy": false,
+  "lazyOrder": -1,
   "enabled": false,
   "service": {
     class: "foam.core.app.HealthHeartbeatService",
@@ -72,6 +76,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "healthHeartbeatMonitor",
   "lazy": false,
+  "lazyOrder": -1,
   "enabled": false,
   "service": {
     class: "foam.core.app.HealthHeartbeatMonitor",

--- a/src/foam/core/auth/services.jrl
+++ b/src/foam/core/auth/services.jrl
@@ -59,12 +59,13 @@ p({
   """
 })
 
-p({"class":"foam.core.boot.CSpec", "name":"agentAuth",                        "lazy":false, "serve":true, "authenticate": false, "description":"Permits users to act as others if permitted. Places user as an agent of the system.", "boxClass":"foam.core.auth.AgentAuthServiceSkeleton", "serviceScript":"return new foam.core.auth.AgentUserAuthService(x);", "client": "{\"class\":\"foam.core.auth.AgentAuthClient\",\"delegate\":{\"class\":\"foam.core.auth.ClientAgentAuthService\"}}"})
+p({"class":"foam.core.boot.CSpec", "name":"agentAuth",                        "lazy":false, "lazyOrder":-1, "serve":true, "authenticate": false, "description":"Permits users to act as others if permitted. Places user as an agent of the system.", "boxClass":"foam.core.auth.AgentAuthServiceSkeleton", "serviceScript":"return new foam.core.auth.AgentUserAuthService(x);", "client": "{\"class\":\"foam.core.auth.AgentAuthClient\",\"delegate\":{\"class\":\"foam.core.auth.ClientAgentAuthService\"}}"})
 
 p({
   "class": "foam.core.boot.CSpec",
   "name": "agentJunctionDAO",
   "lazy": false,
+  "lazyOrder": -1,
   "serve": true,
   "description": "DAO responsible for storing agent authentication permission information.",
   "serviceScript": """
@@ -237,6 +238,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"languageDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":true,
   "authenticate": false,
   "serviceScript":`
@@ -257,6 +259,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"commonPasswordDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":true,
   "authenticate":false,
   "serviceScript":`
@@ -512,6 +515,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "userRegistrationDAO",
   "lazy": false,
+  "lazyOrder": -1,
   "serve": true,
   "authenticate": false,
   "authNotes": "UserRegistrationDAO disables find, select and remove operations.",

--- a/src/foam/core/boot/CSpec.js
+++ b/src/foam/core/boot/CSpec.js
@@ -149,7 +149,7 @@ foam.CLASS({
       class: 'Int',
       name: 'lazyOrder',
       tableWidth: 65,
-      documentation: 'Order non-lazy DAO invocation from low (0) to high.  Essential DAOs such as users, grants, ... should be low order, 0, with larger DAOs which take minutes to load should be a higher order value'
+      documentation: 'Order non-lazy service invocation from low to high. Boot submits non-lazy services to the threadPool in this order, so a service submitted after the pool is full waits for a running one to finish. Framework services (http, logger, threadPools, ...) use -1 so they always start ahead of application data; application services default to 0; anything that must load after other data uses a higher value.'
     },
     {
       class: 'Boolean',

--- a/src/foam/core/boot/CSpec.js
+++ b/src/foam/core/boot/CSpec.js
@@ -149,7 +149,7 @@ foam.CLASS({
       class: 'Int',
       name: 'lazyOrder',
       tableWidth: 65,
-      documentation: 'Order non-lazy service invocation from low to high. Boot submits non-lazy services to the threadPool in this order, so a service submitted after the pool is full waits for a running one to finish. Framework services (http, logger, threadPools, ...) use -1 so they always start ahead of application data; application services default to 0; anything that must load after other data uses a higher value.'
+      documentation: 'Order non-lazy service invocation from low to high. Boot submits non-lazy services to the threadPool in this order; once every pool thread is busy, the remaining services wait for a running one to finish. Framework services (http, logger, threadPools, ...) use -1 so they always start ahead of application data; application services default to 0; anything that must load after other data uses a higher value.'
     },
     {
       class: 'Boolean',

--- a/src/foam/core/boot/services.jrl
+++ b/src/foam/core/boot/services.jrl
@@ -2,6 +2,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"bootScriptDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":false,
   "serviceScript":"""
     return new foam.dao.EasyDAO.Builder(x)

--- a/src/foam/core/cron/services.jrl
+++ b/src/foam/core/cron/services.jrl
@@ -77,6 +77,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"cronScheduler",
   "lazy":false,
+  "lazyOrder":-1,
   "serviceScript":"""
     return new foam.core.cron.CronScheduler();
   """

--- a/src/foam/core/crunch/services.jrl
+++ b/src/foam/core/crunch/services.jrl
@@ -146,6 +146,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"bareUserCapabilityJunctionDAO",
   "lazy": false,
+  "lazyOrder": -1,
   "serviceScript":"""
     dao = new foam.dao.EasyDAO.Builder(x)
       .setPm(true)
@@ -253,6 +254,7 @@ p({
   "description": "DAO containing any modifications made to userCapabilityJunctions",
   "serve": true,
   "lazy": false,
+  "lazyOrder": -1,
   "enabled":true,
   "authNotes": "Protected by service-level access control. This service requires the 'service.userCapabilityJunctionHistoryDAO' permission to access.",
   "serviceScript":

--- a/src/foam/core/http/services.jrl
+++ b/src/foam/core/http/services.jrl
@@ -2,6 +2,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "ping",
   "lazy": false,
+  "lazyOrder": -1,
   "authenticate": false,
   "serviceClass": "foam.core.http.PingService"
 })
@@ -10,6 +11,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "uptime",
   "lazy": false,
+  "lazyOrder": -1,
   "authenticate": false,
   "serviceClass": "foam.core.http.UptimeWebAgent"
 })

--- a/src/foam/core/jetty/services.jrl
+++ b/src/foam/core/jetty/services.jrl
@@ -2,6 +2,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"jettyThreadPoolConfig",
   "lazy": false,
+  "lazyOrder": -1,
   "service":{"class":"foam.core.jetty.JettyThreadPoolConfig"}
 })
 p({
@@ -9,6 +10,7 @@ p({
   "name": "jettyIPAccessDAO",
   "serve": true,
   "lazy": false,
+  "lazyOrder": -1,
   "serviceScript": """
     return new foam.dao.EasyDAO.Builder(x)
       .setOf(foam.core.jetty.IPAccess.getOwnClassInfo())

--- a/src/foam/core/logger/services.jrl
+++ b/src/foam/core/logger/services.jrl
@@ -2,6 +2,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"localLogMessageDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serviceScript":"""
     mdao = new foam.dao.MDAO(foam.core.logger.LogMessage.getOwnClassInfo());
     return new foam.dao.EasyDAO.Builder(x)
@@ -53,6 +54,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"logLevelFilterLogger",
   "lazy":false,
+  "lazyOrder":-1,
   "service":{"class":"foam.core.logger.LogLevelFilterLogger"}
 })
 
@@ -60,6 +62,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"logger",
   "lazy":false,
+  "lazyOrder":-1,
   "serviceScript":"""
     import foam.core.app.AppConfig;
     import foam.core.app.Mode;

--- a/src/foam/core/ndiff/services.jrl
+++ b/src/foam/core/ndiff/services.jrl
@@ -3,6 +3,7 @@ p({
   "name":"ndiffDAO",
   "serve":true,
   "lazy":false,
+  "lazyOrder":-1,
   "serviceScript": """
     dao  = new foam.dao.EasyDAO.Builder(x)
       .setOf(foam.core.ndiff.NDiff.getOwnClassInfo())

--- a/src/foam/core/notification/email/ms/services.jrl
+++ b/src/foam/core/notification/email/ms/services.jrl
@@ -2,6 +2,7 @@ p({
   class:"foam.core.boot.CSpec",
   name:"microsoftGraphEmailAgent",
   lazy: false,
+  lazyOrder: -1,
   service:{
     class:"foam.core.notification.email.ms.MicrosoftGraphEmailAgent",
     id: 'msGraph'

--- a/src/foam/core/notification/email/services.jrl
+++ b/src/foam/core/notification/email/services.jrl
@@ -40,6 +40,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"localEmailMessageDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serviceScript":"""
     return new foam.dao.EasyDAO.Builder(x)
       .setPm(false)
@@ -214,6 +215,7 @@ p({
   class:"foam.core.boot.CSpec",
   name:"smtpAgent",
   lazy: false,
+  lazyOrder: -1,
   service:{
     class:"foam.core.notification.email.SMTPAgent",
     id: 'smtp'
@@ -224,6 +226,7 @@ p({
   class:"foam.core.boot.CSpec",
   name:"emailFolderAgent",
   lazy: false,
+  lazyOrder: -1,
   service:{
     class:"foam.core.notification.email.EmailFolderAgent",
     id: 'imap'

--- a/src/foam/core/notification/push/services.jrl
+++ b/src/foam/core/notification/push/services.jrl
@@ -67,6 +67,7 @@ p({
   class: "foam.core.boot.CSpec",
   name: "pushNotificationThreadPool",
   lazy: false,
+  lazyOrder: -1,
   serve: false,
   serviceScript: """
     return new foam.lang.TimeoutAgency(

--- a/src/foam/core/notification/services.jrl
+++ b/src/foam/core/notification/services.jrl
@@ -3,6 +3,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "localNotificationDAO",
   "lazy": false,
+  "lazyOrder": -1,
   "serviceScript": """
     mdao = new foam.dao.MDAO(foam.core.notification.Notification.getOwnClassInfo());
     mdao.addIndex(new foam.lang.PropertyInfo[] { foam.core.notification.Notification.GROUP_ID,foam.core.notification.Notification.READ });
@@ -36,6 +37,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "notificationDAO",
   "lazy": false,
+  "lazyOrder": -1,
   "serve": true,
   "serviceScript": """
     return new foam.dao.EasyDAO.Builder(x)
@@ -77,6 +79,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "myNotificationDAO",
   "lazy": false,
+  "lazyOrder": -1,
   "serve": true,
   "serviceScript": """
     import foam.core.auth.User;
@@ -118,6 +121,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"notificationTemplateDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":true,
   "serviceScript":"""
     return new foam.dao.EasyDAO.Builder(x)

--- a/src/foam/core/notification/sms/services.jrl
+++ b/src/foam/core/notification/sms/services.jrl
@@ -3,6 +3,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"localSmsMessageDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serviceScript":"""
     return new foam.dao.EasyDAO.Builder(x)
       .setOf(foam.core.notification.sms.SMSMessage.getOwnClassInfo())
@@ -54,5 +55,6 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"twilioConfig",
   "lazy":false,
+  "lazyOrder":-1,
   "service":{"class":"foam.core.notification.sms.TwilioConfig"}
 })

--- a/src/foam/core/referral/services.jrl
+++ b/src/foam/core/referral/services.jrl
@@ -25,6 +25,7 @@ p({
   name:"referralCodeGenerationService",
   serve:false,
   lazy:false,
+  lazyOrder:-1,
   authenticate:false,
   service:{
     class:"foam.core.referral.IdReferralCodeGenerationService"

--- a/src/foam/core/referral/services.jrl
+++ b/src/foam/core/referral/services.jrl
@@ -25,7 +25,6 @@ p({
   name:"referralCodeGenerationService",
   serve:false,
   lazy:false,
-  lazyOrder:-1,
   authenticate:false,
   service:{
     class:"foam.core.referral.IdReferralCodeGenerationService"

--- a/src/foam/core/ruler/services.jrl
+++ b/src/foam/core/ruler/services.jrl
@@ -2,6 +2,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "ruleThreadPool",
   "lazy": false,
+  "lazyOrder": -1,
   "serve": false,
   "serviceScript": `
     return new foam.core.pool.ThreadPoolAgency.Builder(x)

--- a/src/foam/core/services.jrl
+++ b/src/foam/core/services.jrl
@@ -2,6 +2,7 @@ p({
   class: "foam.core.boot.CSpec",
   name: "serviceReloaderAgency",
   lazy: false,
+  lazyOrder: -1,
   serve: false,
   serviceScript: """
     new foam.core.pool.ThreadPoolAgency.Builder(x)

--- a/src/foam/core/session/services.jrl
+++ b/src/foam/core/session/services.jrl
@@ -58,6 +58,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"localSettingDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":true,
   "authenticate": true,
   "serviceScript":"""

--- a/src/foam/core/theme/services.jrl
+++ b/src/foam/core/theme/services.jrl
@@ -80,6 +80,7 @@ p({
   "serve": true,
   "authenticate":false,
   "lazy": false,
+  "lazyOrder": -1,
   "lazyClient": false,
   "boxClass":"foam.core.theme.ThemeServiceSkeleton",
   "serviceClass": "foam.core.theme.Themes",

--- a/src/foam/dao/EasyDAO.js
+++ b/src/foam/dao/EasyDAO.js
@@ -1049,6 +1049,9 @@ dao loading, which improves overall startup time.`,
             foam.core.partition.NotPartitionedDAO pdao = new foam.core.partition.NotPartitionedDAO(x, getOf(), getJournalName());
             pdao.setServiceName(getCSpec() != null && ! foam.util.SafetyUtil.isEmpty(getCSpec().getName()) ? getCSpec().getName() : getName());
             pdao.setEasyDAO(this);
+            // lazy:false promises the data is loaded at boot; NotPartitionedDAO
+            // defers replay to the first access, so load it now, on the boot thread.
+            if ( getCSpec() != null && ! getCSpec().getLazy() ) pdao.getDelegate();
             delegate = pdao;
           } else if ( getFixedSize() != null ) {
             // FixedSizeDAO already wraps the mdao/dedup chain above (see the

--- a/src/foam/dao/jdbc/test/services.jrl
+++ b/src/foam/dao/jdbc/test/services.jrl
@@ -2,6 +2,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"JDBCConnectionSpec",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":false,
   "class":"foam.core.boot.CSpec",
   "service":{

--- a/src/foam/net/services.jrl
+++ b/src/foam/net/services.jrl
@@ -18,6 +18,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"portDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":true,
   "serviceScript":"""
     return new foam.dao.EasyDAO.Builder(x)

--- a/src/foam/util/uid/services.jrl
+++ b/src/foam/util/uid/services.jrl
@@ -17,6 +17,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"fuidKeyDAO",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":true,
   "authenticate":true,
   "serviceScript": """

--- a/src/services.jrl
+++ b/src/services.jrl
@@ -283,7 +283,6 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"addressParser",
   "lazy":false,
-  "lazyOrder":-1,
   "serve":false,
   "serviceScript": """
     return new foam.core.geocode.GoogleMapsAddressParser.Builder(x).build();
@@ -293,7 +292,6 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"googleMapsCredentials",
   "lazy":false,
-  "lazyOrder":-1,
   "serve":false,
   "service":{
     "class": "foam.core.geocode.GoogleMapsCredentials"

--- a/src/services.jrl
+++ b/src/services.jrl
@@ -42,6 +42,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "http",
   "lazy": false,
+  "lazyOrder": -1,
   "service": {
     "class": "foam.core.jetty.HttpServer",
     "welcomeFiles": ["welcome"],
@@ -104,6 +105,7 @@ p({
   "name":"columnConfigToPropertyConverter",
   "serve": true,
   "lazy":false,
+  "lazyOrder":-1,
   "serviceClass": "foam.core.column.ColumnConfigToPropertyConverter",
   "client": "{\"class\":\"foam.core.column.ColumnConfigToPropertyConverter\"}"
 })
@@ -118,6 +120,7 @@ p({
   "class": "foam.core.boot.CSpec",
   "name": "threadPool",
   "lazy": false,
+  "lazyOrder": -1,
   "serve": false,
   "serviceScript": `
     return new foam.core.pool.ThreadPoolAgency.Builder(x)
@@ -262,12 +265,13 @@ p({
     }
   """
 })
-p({"class":"foam.core.boot.CSpec", "name":"emailDocService",                  "lazy":false, "serve":true,  "boxClass":"foam.core.auth.email.EmailDocInterfaceSkeleton", "serviceClass":"foam.core.auth.email.EmailDocService","client":"{\"class\":\"foam.core.auth.email.ClientEmailDocService\", \"delegate\": { \"class\":\"foam.box.HTTPBox\", \"url\":\"service/emailDocService\" } }"})
+p({"class":"foam.core.boot.CSpec", "name":"emailDocService",                  "lazy":false, "lazyOrder":-1, "serve":true,  "boxClass":"foam.core.auth.email.EmailDocInterfaceSkeleton", "serviceClass":"foam.core.auth.email.EmailDocService","client":"{\"class\":\"foam.core.auth.email.ClientEmailDocService\", \"delegate\": { \"class\":\"foam.box.HTTPBox\", \"url\":\"service/emailDocService\" } }"})
 
 p({
   "class":"foam.core.boot.CSpec",
   "name":"appConfig",
   "lazy":false,
+  "lazyOrder":-1,
   "service": {
     "class":"foam.core.app.AppConfig"
   }
@@ -279,6 +283,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"addressParser",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":false,
   "serviceScript": """
     return new foam.core.geocode.GoogleMapsAddressParser.Builder(x).build();
@@ -288,6 +293,7 @@ p({
   "class":"foam.core.boot.CSpec",
   "name":"googleMapsCredentials",
   "lazy":false,
+  "lazyOrder":-1,
   "serve":false,
   "service":{
     "class": "foam.core.geocode.GoogleMapsCredentials"


### PR DESCRIPTION
Since 318d037f82 every SINGLE_JOURNAL EasyDAO is wrapped in NotPartitionedDAO (unloadable defaults to true), which replays the journal on the first access. A lazy:false spec now builds only the wrapper at boot, so the first request that touches a big DAO runs the whole replay on the request thread, and every other request to that DAO waits on the same lock. On a big journal that is a browser timeout.

Two changes:

- EasyDAO: when the spec is lazy:false, load the NotPartitionedDAO right away, inside the same boot threadPool agent that created the service. lazy:false means loaded at boot again, and the soft reference still lets the DAO unload later. Boot heap holds every lazy:false DAO again, as it did before 318d037f82.

- lazyOrder -1 on the critical framework CSpecs (http, logger, thread pools, auth, ...). Once replays run at boot again, http at lazyOrder 0 sorts among the data DAOs by name and waits in the FIFO pool queue behind them. The lazyOrder doc on CSpec now states the convention: framework -1, application 0, higher for anything that must load after other data.

Measured on a 4-thread pool with 262 non-lazy specs plus 8 extra DAOs of 600K rows each (4 named before "http", 4 after). The select is sent the moment http answers:

| | development | eager load only | both |
|---|---|---|---|
| http ready | 1.4s | 8.6s | 0.2s |
| select on a big DAO right after http is up | 3.3s, replay ran on the request thread | 0.3s | 4.6s, waits for that DAO's boot replay |
| select once boot loads are done | | 0.1s | 0.1s |

Deployment overrides that omit lazyOrder inherit -1 through the journal merge, so apps need no change.