### PR TITLE
Add a design-skill rule for reading a DAO whose of is a base class

### DIFF
--- a/.claude/skills/foam-design-patterns/references/context-and-dao.md
+++ b/.claude/skills/foam-design-patterns/references/context-and-dao.md
@@ -9,6 +9,7 @@ system context; every other rule here is the same instinct at smaller scale.
 | Inside a decorator, call the `_` methods with `x` | any bare `find(`/`put(`/`select(` on `getDelegate()`? |
 | Inside a rule, `x` reads, `ruler.getX()` writes | which context does the `put` use? |
 | Existence is `find`, count is `COUNT()` | any `ArraySink` followed by `isEmpty()` or `size()`? |
+| Filter a shared-base DAO to one class before naming a subclass property | does a predicate name a subclass property on a DAO whose `of` is a base class? |
 | Configure EasyDAO before writing a new layer | is there a `cache`, `decorator`, or `pm` switch for this? |
 
 ### Take `x` from the argument and pass it down
@@ -48,6 +49,11 @@ Review asked: "Can be done with find() or if you don't care about the result the
 A loop that compares rows in Java bypasses indices and the decorators that would have scoped it.
 Don't: `OR(EQ(p, a), EQ(p, b), ...)` built in a loop; string join keys per comparison; `List.remove` inside a merge
 Do:    `IN(p, values)`; `addPropertyIndex` on the columns the query uses; sort once and merge
+
+### Filter a shared-base DAO to one class before naming a subclass property
+A generated `PropertyInfo.get_` casts to the class that declared the property, so naming a subclass property on a sibling row throws. A predicate never shows you: `PredicatedSink.put` catches `ClassCastException` and drops the row, leaving a partial answer. The same cast at a call site does throw, so the two read as unrelated bugs while sharing one cause.
+Don't: `(Sub) dao.find(AND(EQ(Base.KEY, k), EQ(Sub.STATUS, s)))`, where `dao.of` is the base class
+Do:    build the view once, `DAO subRows = dao.where(INSTANCE_OF(Sub.class));`, and read every query through it; `FilteredDAO` composes its own predicate ahead of the caller's, so the type check runs before any subclass property is read
 
 ### Configure EasyDAO before writing a new layer
 EasyDAO already has the cache, the TTL, the decorator slot, and the PM switch.


### PR DESCRIPTION
The context-and-DAO reference had no entry for querying a DAO whose `of` is a base class with several sibling models stored under it.

Naming a subclass property in a predicate there reads a sibling row through a getter that casts to the declaring class. `PredicatedSink.put` catches the `ClassCastException` and drops the row, so the query comes back with a row missing rather than an error, while the same cast written at a call site throws. The two look like unrelated bugs and share one cause, which is what makes the rule worth writing down.

The entry says to build the filtered view once with `INSTANCE_OF` and read every query through it, and notes that `FilteredDAO` composes its own predicate ahead of the caller's so the type check runs first.