### PR TITLE
DOS-3019 Keep the QA wizard's Back/Next buttons on screen

### DIFF
--- a/src/foam/u2/qa/QAWizardView.js
+++ b/src/foam/u2/qa/QAWizardView.js
@@ -40,6 +40,11 @@ foam.CLASS({
       display: flex;
       flex-direction: column;
       height: 100%;
+      /* A flex item will not shrink below its content by default, so when this
+         view is itself a flex item sharing a container with anything else — a
+         dialog title, say — a question with many choices makes it taller than
+         its share and the footer lands past the container's bottom edge. */
+      min-height: 0;
       background: $backgroundDefault;
     }
     ^header {
@@ -54,6 +59,9 @@ foam.CLASS({
     }
     ^content {
       flex: 1;
+      /* Same rule, one level in: without this the question area grows to fit its
+         choices instead of scrolling, pushing the footer out of the view. */
+      min-height: 0;
       padding: 24px;
       overflow-y: auto;
       display: flex;

--- a/src/foam/u2/qa/QAWizardView.js
+++ b/src/foam/u2/qa/QAWizardView.js
@@ -59,9 +59,6 @@ foam.CLASS({
     }
     ^content {
       flex: 1;
-      /* Same rule, one level in: without this the question area grows to fit its
-         choices instead of scrolling, pushing the footer out of the view. */
-      min-height: 0;
       padding: 24px;
       overflow-y: auto;
       display: flex;


### PR DESCRIPTION
The questionnaire wizard puts its Back and Next buttons in a footer below the question area. Mounted in a dialog under a title, a question with a long list of choices pushes those buttons off the bottom edge and there is no way to go back.

A flex item is not allowed to become shorter than the things inside it unless you say so explicitly. The wizard shares the dialog with the title, so it needs to shrink to fit — and it could not, so it overflowed and took its footer with it.

Saying min-height: 0 on the wizard's root rule lifts that restriction.

The question area below it does not need the same treatment, and an earlier revision of this PR wrongly gave it some: overflow-y: auto already makes that a scroll container, which has an automatic minimum size of zero on its own. That no-op and the comment beside it are removed in the second commit — thanks @abdelaziz-mahdy for measuring it.

CSS only, no behaviour or markup changes. Wizards with short questions look and behave exactly as before.
