### PR TITLE
PT-FIXES:DOS-4887 Include precision in aggregation sink toString

### DIFF
--- a/src/foam/mlang/sink/AbstractUnarySink.js
+++ b/src/foam/mlang/sink/AbstractUnarySink.js
@@ -31,14 +31,7 @@ foam.CLASS({
 
   methods: [
     function toString() {
-      return foam.String.constantize(this.cls_.name) + '(' + this.arg1.toString() + this.precisionSuffix() + ')';
-    },
-
-    function precisionSuffix() {
-      /* Part of toString() because TTLSelectCachingDAO keys its select cache on
-         the sink's toString(); without it a precision change reuses the cached
-         result computed at the old precision. */
-      return this.precision < 0 ? '' : ', p' + this.precision;
+      return foam.String.constantize(this.cls_.name) + '(' + this.arg1.toString() + ')';
     },
 
     function applyPrecision(val) {

--- a/src/foam/mlang/sink/AbstractUnarySink.js
+++ b/src/foam/mlang/sink/AbstractUnarySink.js
@@ -31,7 +31,14 @@ foam.CLASS({
 
   methods: [
     function toString() {
-      return foam.String.constantize(this.cls_.name) + '(' + this.arg1.toString() + ')';
+      return foam.String.constantize(this.cls_.name) + '(' + this.arg1.toString() + this.precisionSuffix() + ')';
+    },
+
+    function precisionSuffix() {
+      /* Part of toString() because TTLSelectCachingDAO keys its select cache on
+         the sink's toString(); without it a precision change reuses the cached
+         result computed at the old precision. */
+      return this.precision < 0 ? '' : ', p' + this.precision;
     },
 
     function applyPrecision(val) {

--- a/src/foam/mlang/sink/Average.js
+++ b/src/foam/mlang/sink/Average.js
@@ -70,6 +70,6 @@ if (other instanceof foam.mlang.sink.Average) {
     function toSummary() { return this.applyPrecision(this.value); },
     function valueOf() { return this.applyPrecision(this.value); },
     function addToE(e) { e.add(this.applyPrecision(this.value)); },
-    function toString() { return `AVG(${this.arg1}, ${this.value}${this.precisionSuffix()})`; }
+    function toString() { return `AVG(${this.arg1}, ${this.value}, ${this.precision})`; }
   ]
 });

--- a/src/foam/mlang/sink/Average.js
+++ b/src/foam/mlang/sink/Average.js
@@ -70,6 +70,6 @@ if (other instanceof foam.mlang.sink.Average) {
     function toSummary() { return this.applyPrecision(this.value); },
     function valueOf() { return this.applyPrecision(this.value); },
     function addToE(e) { e.add(this.applyPrecision(this.value)); },
-    function toString() { return `AVG(${this.arg1}, ${this.value})`; }
+    function toString() { return `AVG(${this.arg1}, ${this.value}${this.precisionSuffix()})`; }
   ]
 });

--- a/src/foam/mlang/sink/Max.js
+++ b/src/foam/mlang/sink/Max.js
@@ -98,6 +98,6 @@ if (other instanceof foam.mlang.sink.Max) {
     function setPropertyValues(o, sink, ps) {
       ps[0].set(o, sink.applyPrecision(sink.value));
     },
-    function toString() { return `MAX(${this.arg1}, ${this.value}${this.precisionSuffix()})`; }
+    function toString() { return `MAX(${this.arg1}, ${this.value}, ${this.precision})`; }
   ]
 });

--- a/src/foam/mlang/sink/Max.js
+++ b/src/foam/mlang/sink/Max.js
@@ -98,6 +98,6 @@ if (other instanceof foam.mlang.sink.Max) {
     function setPropertyValues(o, sink, ps) {
       ps[0].set(o, sink.applyPrecision(sink.value));
     },
-    function toString() { return `MAX(${this.arg1}, ${this.value})`; }
+    function toString() { return `MAX(${this.arg1}, ${this.value}${this.precisionSuffix()})`; }
   ]
 });

--- a/src/foam/mlang/sink/Min.js
+++ b/src/foam/mlang/sink/Min.js
@@ -92,6 +92,6 @@ if (other instanceof foam.mlang.sink.Min) {
     function setPropertyValues(o, sink, ps) {
       ps[0].set(o, sink.applyPrecision(sink.value));
     },
-    function toString() { return `MIN(${this.arg1}, ${this.value})`; }
+    function toString() { return `MIN(${this.arg1}, ${this.value}${this.precisionSuffix()})`; }
   ]
 });

--- a/src/foam/mlang/sink/Min.js
+++ b/src/foam/mlang/sink/Min.js
@@ -92,6 +92,6 @@ if (other instanceof foam.mlang.sink.Min) {
     function setPropertyValues(o, sink, ps) {
       ps[0].set(o, sink.applyPrecision(sink.value));
     },
-    function toString() { return `MIN(${this.arg1}, ${this.value}${this.precisionSuffix()})`; }
+    function toString() { return `MIN(${this.arg1}, ${this.value}, ${this.precision})`; }
   ]
 });

--- a/src/foam/mlang/sink/Sum.js
+++ b/src/foam/mlang/sink/Sum.js
@@ -65,7 +65,7 @@ if (other instanceof foam.mlang.sink.Sum) {
     },
 
     function toString() {
-      return `SUM(${this.arg1}, ${this.value})`;
+      return `SUM(${this.arg1}, ${this.value}${this.precisionSuffix()})`;
     }
   ]
 });

--- a/src/foam/mlang/sink/Sum.js
+++ b/src/foam/mlang/sink/Sum.js
@@ -65,7 +65,7 @@ if (other instanceof foam.mlang.sink.Sum) {
     },
 
     function toString() {
-      return `SUM(${this.arg1}, ${this.value}${this.precisionSuffix()})`;
+      return `SUM(${this.arg1}, ${this.value}, ${this.precision})`;
     }
   ]
 });


### PR DESCRIPTION
A sum sink whose precision goes from 2 to 1 returns the previous result, still rounded to two decimals. Changing skip or limit on the same query returns the new result.

Cause: `TTLSelectCachingDAO` keys its select cache on `[sink, skip, limit, order, predicate].toString()`, and the sum, min, max and average toStrings carry arg1 and value but not precision, so both precisions land on one key.

```js
var s = SUM(amount);
s.precision = 2; dao.select(s);  // caches under "SUM(amount, 0)"
s.precision = 1; dao.select(s);  // same key, so the precision-2 result comes back
```

The cached entry lives for the DAO's ttlSelectPurgeTime, five minutes on a client DAO, so the value corrects itself once the entry ages out.

Fix: the four toStrings print precision alongside arg1 and value.
