### PR TITLE
Let the embedder size the QA wizard

### DIFF
--- a/src/foam/u2/qa/QAWizardView.js
+++ b/src/foam/u2/qa/QAWizardView.js
@@ -14,6 +14,15 @@ foam.CLASS({
     Asks questions one at a time in optimal information-gain order, tracks a
     back-navigation stack, narrows the candidate set, and presents the outcome.
     Fully agnostic to the QA class — works with any compiled foam.QA2() model.
+
+    Sizing: the footer holding Back and Next is pinned to the bottom of
+    whatever height this view is given, and the question area scrolls inside
+    what is left. In a flex container it claims the leftover space by default,
+    whether it sits there directly or inside a wrapper. Outside one it is as
+    tall as its content, so an embedder that wants it to fill a fixed-height
+    container has to say so — and has to say it on this element, not on a
+    wrapper around it, or the footer stops at the end of a short question
+    instead of the bottom of the container.
   `,
 
   exports: ['as wizard'],
@@ -39,10 +48,12 @@ foam.CLASS({
     ^ {
       display: flex;
       flex-direction: column;
-      /* No height here: the embedder gives this view its footprint. A flex item
-         will not shrink below its content by default, so min-height: 0 is what
-         lets it accept a height smaller than a long question and scroll it,
-         rather than growing and carrying its footer off the bottom. */
+      /* No height: the embedder owns the footprint. These two say how to behave
+         once given one — take the leftover space of a flex parent, and accept a
+         height smaller than a long question so the question scrolls rather than
+         the footer sliding off the bottom. Both are defaults an embedder can
+         override, and both are inert outside a flex container. */
+      flex: 1;
       min-height: 0;
       background: $backgroundDefault;
     }

--- a/src/foam/u2/qa/QAWizardView.js
+++ b/src/foam/u2/qa/QAWizardView.js
@@ -39,11 +39,10 @@ foam.CLASS({
     ^ {
       display: flex;
       flex-direction: column;
-      height: 100%;
-      /* A flex item will not shrink below its content by default, so when this
-         view is itself a flex item sharing a container with anything else — a
-         dialog title, say — a question with many choices makes it taller than
-         its share and the footer lands past the container's bottom edge. */
+      /* No height here: the embedder gives this view its footprint. A flex item
+         will not shrink below its content by default, so min-height: 0 is what
+         lets it accept a height smaller than a long question and scroll it,
+         rather than growing and carrying its footer off the bottom. */
       min-height: 0;
       background: $backgroundDefault;
     }


### PR DESCRIPTION
Follow-up to #5451, now merged — this removes the cause rather than the symptom.

QAWizardView sets its own height to 100%. That is a claim about its parent which only holds when the view is an only child. Put it in a dialog with a title above it and the two children add up to more than the dialog holds, so the wizard overflows and its Back/Next buttons end up below the bottom edge.

#5451 stopped that from being visible, by allowing the view to shrink. This removes the cause: a shared view should decide how it looks inside and leave its size to whoever places it.

Removing the height on its own would leave embedders a trap, though, which @abdelaziz-mahdy caught: an embedder that puts flex: 1 and min-height: 0 on a wrapper around the wizard rather than on the wizard itself keeps a long question scrolling but unpins the footer on a short one, because the wizard is then sized by its content. A wrapper is the shape embedders tend to write — ours did, first time.

So rather than document that, the last commit defaults it away. flex: 1 makes the wizard claim the leftover space of a flex parent whether it sits there directly or inside a wrapper, and min-height: 0 lets it be shorter than a long question. Both are inert outside a flex container, and an embedder can override either. The class documentation now states the sizing contract instead of leaving it to be rediscovered.

CSS and documentation only.

