### PR TITLE
DOS-4904: Render Markdown in "real" time

### DIFF
--- a/src/foam/u2/view/MarkdownView.js
+++ b/src/foam/u2/view/MarkdownView.js
@@ -513,6 +513,11 @@ foam.CLASS({
     {
       class: 'String',
       name: 'data'
+    },
+    'lastGoodTokens_',
+    {
+      class: 'String',
+      name: 'renderData_'
     }
   ],
 
@@ -521,19 +526,29 @@ foam.CLASS({
       this.SUPER();
       var self = this;
 
+      this.renderData_ = this.data;
+      this.onDetach(this.data$.sub(this.updateRender));
+
       this
         .addClass()
         .add(this.dynamic(function(data) {
           self.markdownContext = undefined;
           var tokens = self.markdownGrammar.parseString(data + '\n');
-          if ( tokens ) {
-            tokens.forEach(t => t.call(this));
-          } else {
-            this.start().add('PARSE ERROR');
-          }
+          if ( tokens ) self.lastGoodTokens_ = tokens;
+          else          tokens = self.lastGoodTokens_;
+          if ( tokens ) tokens.forEach(t => t.call(this));
         }));
     }
-  ]
+  ],
+
+  listeners: [
+    {
+      name: 'updateRender',
+      isMerged: true,
+      mergeDelay: 150,
+      code: function() { this.renderData_ = this.data; }
+    }
+  ],
 });
 
 
@@ -654,6 +669,7 @@ foam.CLASS({
         .start(foam.u2.tag.TextArea, {
           rows: 20,
           cols: 80,
+          onKey: true,
           data$: this.data$,
           placeholder: 'Enter markdown text...'
         }, this.editorElement_$)


### PR DESCRIPTION
Currently, when editing a Markdown block in ReFlow, the content only appears when the markdown editor loses focus. This makes it difficult to gauge how the content will appear while writing it and prevents users from identifying compilation errors as they are writing.

This MR fixes this problem by rendering the editor's content after a valid set of tags has been entered and a 150ms have passed. (The delay is there to avoid re-rendering everything on every keystroke)

[DOS Link](https://payticconnect.atlassian.net/browse/DOS-4904?atlOrigin=eyJpIjoiNDMxOWFmZWI2NzA5NDdmZDkyY2EwMGI3ZTAwMGY4OTUiLCJwIjoiaiJ9)